### PR TITLE
Update README file to introduce properties.ini.sample

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,16 @@ virtwho-test
 * Supproted Hypervisors: libvirt, esx, rhevm, hyperv, xen, kubevirt and fake
 * Supported Subscription Servers: rhsm, satellite, sam(deprecated)
 
+`properties.ini.sample`_ is provided as a sample to define attributes
+
+* Change the file name to properties.ini
+* Update the necessary attributes based on test requirements
+* `hypervisor-builder`_ can help to get some datas
+
 .. _virtwho-test: https://github.com/VirtwhoQE/virtwho-test
 .. _Eko: https://github.com/eko999
 .. _Coulson: https://github.com/hkx303
 .. _Yuefen: https://github.com/Junefen
+.. _properties.ini.sample:
+    https://github.com/Junefen/virtwho-test/blob/define_properties/properties.ini.sample
+.. _hypervisor-builder: https://github.com/VirtwhoQE/hypervisor-builder

--- a/README.rst
+++ b/README.rst
@@ -10,13 +10,13 @@ virtwho-test
 `properties.ini.sample`_ is provided as a sample to define attributes
 
 * Change the file name to properties.ini
-* Update the necessary attributes based on test requirements
-* `hypervisor-builder`_ can help to get some datas
+* Update the necessary datas based on test requirements
+* `hypervisor-builder`_ can help to get part of the information
 
 .. _virtwho-test: https://github.com/VirtwhoQE/virtwho-test
 .. _Eko: https://github.com/eko999
 .. _Coulson: https://github.com/hkx303
 .. _Yuefen: https://github.com/Junefen
 .. _properties.ini.sample:
-    https://github.com/Junefen/virtwho-test/blob/define_properties/properties.ini.sample
+    https://github.com/VirtwhoQE/virtwho-test/blob/master/properties.ini.sample
 .. _hypervisor-builder: https://github.com/VirtwhoQE/hypervisor-builder


### PR DESCRIPTION
Added below introduction about properties.ini.sample to README file

```
properties.ini.sample is provided as a sample to define attributes

  - Change the file name to properties.ini
  - Update the necessary datas based on test requirements
  - hypervisor-builder can help to get part of the information

```