### PR TITLE
Define the provision/virtwho_satellite.py

### DIFF
--- a/virtwho/provision/virtwho_satellite.py
+++ b/virtwho/provision/virtwho_satellite.py
@@ -23,6 +23,11 @@ def satellite_deploy_for_virtwho(args):
     And will configure the satellite as virt-who testing requirements.
     Please refer to the README for usage.
     """
+    satellite = args.satellite.split('-')
+    args.version = satellite[0]
+    args.repo = satellite[1]
+    args.rhel_compose = rhel_compose_for_satellite(satellite[2])
+    args.manifest = config.satellite.manifest
 
     # Install a new system by beaker when no server provided.
     if not args.server:
@@ -37,11 +42,6 @@ def satellite_deploy_for_virtwho(args):
     )
 
     # Start to deploy and configure the satellite server
-    satellite = args.satellite.split('-')
-    args.version = satellite[0]
-    args.repo = satellite[1]
-    args.rhel_compose = rhel_compose_for_satellite(satellite[2])
-    args.manifest = config.satellite.manifest
     satellite_deploy(args)
     satellite_settings(ssh_satellite, 'failed_login_attempts_limit', '0')
     satellite_settings(ssh_satellite, 'unregister_delete_host', 'true')

--- a/virtwho/provision/virtwho_satellite.py
+++ b/virtwho/provision/virtwho_satellite.py
@@ -19,14 +19,10 @@ from utils.satellite import satellite_deploy
 def satellite_deploy_for_virtwho(args):
     """
     Deploy satellite by cdn or dogfood with required arguments.
-    If no server provided, will install new system by beaker.
-    Configure the satellite as virt-who testing requirements.
+    If no server provided, will firstly install a new system by beaker.
+    And will configure the satellite as virt-who testing requirements.
     Please refer to the README for usage.
     """
-    satellite = args.satellite.split('-')
-    args.version = satellite[0]
-    args.repo = satellite[1]
-    args.rhel_compose = rhel_compose_for_satellite(satellite[2])
 
     # Install a new system by beaker when no server provided.
     if not args.server:
@@ -41,6 +37,11 @@ def satellite_deploy_for_virtwho(args):
     )
 
     # Start to deploy and configure the satellite server
+    satellite = args.satellite.split('-')
+    args.version = satellite[0]
+    args.repo = satellite[1]
+    args.rhel_compose = rhel_compose_for_satellite(satellite[2])
+    args.manifest = config.satellite.manifest
     satellite_deploy(args)
     satellite_settings(ssh_satellite, 'failed_login_attempts_limit', '0')
     satellite_settings(ssh_satellite, 'unregister_delete_host', 'true')
@@ -148,12 +149,6 @@ def virtwho_satellite_arguments_parser():
         required=False,
         help='Account password for the satellite administrator, '
              'default to the [satellite]:password in virtwho.ini')
-    parser.add_argument(
-        '--manifest',
-        default=config.satellite.manifest,
-        required=False,
-        help='Manifest url to upload after complete deploying satellite, '
-             'default to the [satellite]:manifest in virtwho.ini')
     return parser.parse_args()
 
 

--- a/virtwho/provision/virtwho_satellite.py
+++ b/virtwho/provision/virtwho_satellite.py
@@ -1,0 +1,147 @@
+#!/usr/bin/python
+
+import os
+import sys
+import argparse
+
+curPath = os.path.abspath(os.path.dirname(__file__))
+rootPath = os.path.split(curPath)[0]
+sys.path.append(os.path.split(rootPath)[0])
+
+from virtwho import logger, FailException
+from utils.beaker import install_rhel_by_beaker
+from utils.satellite import satellite_deploy
+from virtwho.ssh import SSHConnect
+from virtwho.settings import config
+
+
+def satellite_deploy_for_virtwho(args):
+    """
+    Deploy satellite by cdn or dogfood with required arguments to.
+    Please refer to the README for usage.
+    :param args: version, repo, os and server are required options.
+        version: satellite version, such as 6.8, 6.9
+        repo: repo resources, cdn or dogfood
+        os: rhel host, such as RHEL-7.9-20200917.0
+        server: server FQDN or IP
+    """
+    satellite = args.satellite.split('-')
+    args.rhel_compose = rhel_compose_for_satellite(satellite[2])
+    args.version = satellite[0]
+    args.repo = satellite[1]
+
+    if not args.server:
+        beaker_args_define(args)
+        args.server = install_rhel_by_beaker(args)
+        args.ssh_username = config.beaker.default_username
+        args.ssh_password = config.beaker.default_password
+    ssh_host = SSHConnect(
+        host=args.server,
+        user=args.ssh_username,
+        pwd=args.ssh_password
+    )
+
+    satellite_deploy(args)
+    satellite_settings(ssh_host, 'failed_login_attempts_limit', '0')
+    satellite_settings(ssh_host, 'unregister_delete_host', 'true')
+    config.update('satellite', 'server', args.server)
+    config.update('satellite', 'username', args.admin_username)
+    config.update('satellite', 'password', args.admin_password)
+    config.update('satellite', 'ssh_username', args.ssh_username)
+    config.update('satellite', 'ssh_password', args.ssh_password)
+
+
+def rhel_compose_for_satellite(rhel_version):
+    compose = ''
+    if 'rhel7' in rhel_version:
+        compose = 'RHEL-7.9-20200917.0'
+    if 'rhel8' in rhel_version:
+        compose = 'RHEL-8.5.0-20211013.2'
+    return compose
+
+
+def beaker_args_define(args):
+    """
+    Define the necessary args to call the utils/beaker.by
+    :param args: arguments to define
+    """
+    args.arch = 'x86_64'
+    args.variant = 'BaseOS'
+    if 'RHEL-7' in args.rhel_compose:
+        args.variant = 'Server'
+    args.job_group = 'virt-who-ci-server-group'
+    args.host = '%ent-02-vm%'
+    args.host_type = None
+    args.host_require = None
+
+
+def satellite_settings(ssh, name, value):
+    """
+    Update the settings by hammer command.
+    :param ssh: ssh access to satellite host.
+    :param name: such as unregister_delete_host.
+    :param value: the value.
+    :return: True or raise Fail.
+    """
+    ret, output = ssh.runcmd(f'hammer settings set '
+                             f'--name={name} '
+                             f'--value={value}')
+    if ret == 0 and f'Setting [{name}] updated to' in output:
+        logger.info(f'Succeeded to set {name}:{value} for satellite')
+        return True
+    raise FailException(f'Failed to set {name}:{value} for satellite')
+
+
+def virtwho_satellite_arguments_parser():
+    """
+    Parse and convert the arguments from command line to parameters
+    for function using, and generate help and usage messages for
+    each arguments.
+    """
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '--satellite',
+        required=True,
+        help='Such as: 6.10-cdn-rhel7, 6.9-dogfood-rhel7')
+    parser.add_argument(
+        '--server',
+        default=config.satellite.server,
+        required=False,
+        help='ip/fqdn, default to the [satellite]:server in virtwho.ini, '
+             'will install a new system if no server provide.')
+    parser.add_argument(
+        '--ssh-username',
+        default=config.satellite.ssh_username,
+        required=False,
+        help='Username to access the server, '
+             'default to the [satellite]:ssh_username in virtwho.ini')
+    parser.add_argument(
+        '--ssh-password',
+        default=config.satellite.ssh_password,
+        required=False,
+        help='Password to access the server, '
+             'default to the [satellite]:ssh_password in virtwho.ini')
+    parser.add_argument(
+        '--admin-username',
+        default=config.satellite.username,
+        required=False,
+        help='Account name for the satellite administrator, '
+             'default to the [satellite]:username in virtwho.ini')
+    parser.add_argument(
+        '--admin-password',
+        default=config.satellite.password,
+        required=False,
+        help='Account password for the satellite administrator, '
+             'default to the [satellite]:password in virtwho.ini')
+    parser.add_argument(
+        '--manifest',
+        default=config.satellite.manifest,
+        required=False,
+        help='Manifest url to upload after complete deploying satellite, '
+             'default to the [satellite]:manifest in virtwho.ini')
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    args = virtwho_satellite_arguments_parser()
+    satellite_deploy_for_virtwho(args)

--- a/virtwho/provision/virtwho_satellite.py
+++ b/virtwho/provision/virtwho_satellite.py
@@ -29,7 +29,7 @@ def satellite_deploy_for_virtwho(args):
     args.rhel_compose = rhel_compose_for_satellite(satellite[2])
     args.version = satellite[0]
     args.repo = satellite[1]
-
+    # If not provide the server ip/fqdn, will install a new system by beaker.
     if not args.server:
         beaker_args_define(args)
         args.server = install_rhel_by_beaker(args)
@@ -40,7 +40,7 @@ def satellite_deploy_for_virtwho(args):
         user=args.ssh_username,
         pwd=args.ssh_password
     )
-
+    # start to deploy and set satellite
     satellite_deploy(args)
     satellite_settings(ssh_host, 'failed_login_attempts_limit', '0')
     satellite_settings(ssh_host, 'unregister_delete_host', 'true')


### PR DESCRIPTION
`virtwho_satellite.py`_ is used to deploy and configure satellite for virt-who testing.

It helps to install and initiate a host by beaker, install satellite pkg, deploy satellite server,
load manifest and set for virt-who testing.

* If need to install system by beaker, we should firstly set the [beaker] section in virtwho.ini.

    * [beaker]
    * client=
    * client_username=
    * client_password=
    * default_username=
    * default_password=
    * keytab=
    * principal=

* Define the register and repo information before deploying.

    * cnd,  define the [rhsm] section in virtwho.ini
    * dogfood, define the [satellite]:dogfood= in virtwho.ini


* We can optionally configure the [satellite] in virtwho.ini to replace some arguments.

    * [satellite]
    * server=
    * username=
    * password=
    * ssh_username=
    * ssh_passowrd=

* Below are examples to run the file with required arguments.

    * ```# python3 satellite.py --version=6.9 --repo=cdn --rhel-compose=RHEL-7.9-20200917.0```
    * ```# python3 satellite.py --version=6.10 --repo=dogfood --rhel-compose=RHEL-7.9-20200917.0 --server=ent-02-vm-x.lab.eng.nay.redhat.com --ssh-username=root --ssh-password=redhat --admin-username=admin --admin-password=password --manifest=[url]```