### PR TITLE
Update option name in virtwho.ini

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,7 @@ from virtwho.register import Satellite
 import pytest
 
 
-mode = config.job.mode
+mode = config.job.hypervisor
 register_type = config.job.register
 
 

--- a/virtwho.ini.sample
+++ b/virtwho.ini.sample
@@ -1,8 +1,8 @@
 ; The section of [job] is used to define the testing hypervisor and subscription server
-; mode is an optional setting from esx/xen/hyperv/libvirt/rhevm/kubevirt/ahv/local, the default is 'esx'.
+; hypervisor is an optional setting from esx/xen/hyperv/libvirt/rhevm/kubevirt/ahv/local, the default is 'esx'.
 ; register is an optional setting from rhsm/satellite, the default is 'rhsm'
 [job]
-mode=
+hypervisor=
 register=
 
 ; The section of [virtwho] is used to define the host information where virt-who package is installed and running


### PR DESCRIPTION
Update the `mode=` to `hypervisor=` in virtwho.ini, which is more clear