### PR TITLE
Update hostrequire of virtwho_satellite because ent2 server has been broken

### DIFF
--- a/virtwho/provision/virtwho_satellite.py
+++ b/virtwho/provision/virtwho_satellite.py
@@ -87,7 +87,7 @@ def beaker_args_define(args):
     if 'RHEL-7' in args.rhel_compose:
         args.variant = 'Server'
     args.job_group = 'virt-who-ci-server-group'
-    args.host = '%ent-02-vm%'
+    args.host = '%hp-dl360g9-08-vm%'
     args.host_type = None
     args.host_require = None
 


### PR DESCRIPTION
Update hostrequire of virtwho_satellite because ent2 server has been broken