### PR TITLE
Remove to define the default beaker-host to hp-z220

### DIFF
--- a/virtwho/provision/virtwho_host.py
+++ b/virtwho/provision/virtwho_host.py
@@ -187,7 +187,7 @@ def virtwho_arguments_parser():
     parser.add_argument(
         '--beaker-host',
         required=False,
-        default='%hp-z220%',
+        default=None,
         help='Define/filter system as hostrequire. '
              'Such as: %ent-02-vm%, ent-02-vm-20.lab.eng.nay.redhat.com')
     parser.add_argument(


### PR DESCRIPTION
Remove to define the default beaker-host to hp-z220, will define it in pipeline job. If no local mode involve in testing, will install a host from anywhere in beaker.