### PR TITLE
Define the test_gating.py

### DIFF
--- a/tests/gating/test_gating.py
+++ b/tests/gating/test_gating.py
@@ -1,0 +1,186 @@
+"""Test cases Global fields
+
+:casecomponent: virt-who
+:testtype: functional
+:caseautomation: Automated
+"""
+import pytest
+from virtwho import logger
+
+
+@pytest.mark.usefixtures('globalconf_clean')
+@pytest.mark.usefixtures('hypervisor_create')
+class TestGating:
+    def test_debug(self, virtwho):
+        """Test the '-d' option in virt-who command line
+
+        :title: virt-who: gating: test debug function
+        :id: 4ba50cb9-c431-4283-bb8c-1d4a8ff0a036
+        :caseimportance: High
+        :tags: gating
+        :customerscenario: false
+        :upstream: no
+        :steps:
+
+            1. clean all virt-who global configurations
+            2. run "#virt-who -c" without "-d"
+            3. run "#virt-who -d -c"
+
+        :expectedresults:
+
+            1. no [DEBUG] log printed without "-d" option
+            2. [DEBUG] logs are printed with "-d" option
+        """
+        result = virtwho.run_cli(debug=False)
+        assert (result['send'] == 1
+                and result['error'] == 0
+                and result['debug'] is False)
+
+        result = virtwho.run_cli(debug=True)
+        assert (result['send'] == 1
+                and result['error'] == 0
+                and result['debug'] is True)
+
+    def test_oneshot(self, virtwho):
+        """Test the '-o' option in virt-who command line
+
+        :title: virt-who: gating: test oneshot function
+        :id: 2ec0f2c4-9633-48cd-8d61-7872d0e23117
+        :caseimportance: High
+        :tags: gating
+        :customerscenario: false
+        :upstream: no
+        :steps:
+
+            1. clean all virt-who global configurations
+            2. run "#virt-who -c" without "-o"
+            3. run "#virt-who -o -c"
+
+        :expectedresults:
+
+            1. virt-who thread is not terminated automatically without "-o"
+            2. virt-who thread is terminated after reporting once with "-o"
+        """
+        result = virtwho.run_cli(oneshot=False)
+        assert (result['send'] == 1
+                and result['error'] == 0
+                and result['thread'] == 1
+                and result['terminate'] == 0
+                and result['oneshot'] is False)
+
+        result = virtwho.run_cli(oneshot=True)
+        assert (result['send'] == 1
+                and result['error'] == 0
+                and result['thread'] == 0
+                and result['terminate'] == 1
+                and result['oneshot'] is True)
+
+    def test_interval(self, virtwho, globalconf, global_debug_true):
+        """Test the interval option in /etc/virt-who.conf
+
+        :title: virt-who: gating: test interval function
+        :id: e226ed41-454d-4855-8c1d-5ab2ba5293e4
+        :caseimportance: High
+        :tags: gating
+        :customerscenario:
+        :upstream: no
+        :steps:
+
+            1. clean all virt-who global configurations
+            2. run virt-who without #interval=
+            3. run virt-who with interval=10
+            4. run virt-who with interval=60
+
+        :expectedresults:
+
+            1. the default interval=3600 when do not set interval=
+            2. the interval=3600 when run with interval < 60
+            3. the interval uses the setting value when run with interval >= 60
+        """
+        result = virtwho.run_service()
+        assert (result['send'] == 1
+                and result['interval'] == 3600)
+
+        globalconf.update('global', 'interval', '10')
+        result = virtwho.run_service()
+        assert (result['send'] == 1
+                and result['interval'] == 3600)
+
+        globalconf.update('global', 'interval', '60')
+        result = virtwho.run_service(wait=60)
+        assert (result['send'] == 1
+                and result['interval'] == 60
+                and result['loop'] == 60)
+
+    def test_hypervisor_id(self, virtwho, hypervisor, hypervisor_data, hypervisor_handler):
+        """Test the hypervisor_id= option in /etc/virt-who.d/hypervisor.conf
+
+        :title: virt-who: gating: test hypervisor_id function
+        :id: 03b79c0b-8b1f-4f32-8285-370773b7124b
+        :caseimportance: High
+        :tags: gating
+        :customerscenario: false
+        :upstream: no
+        :steps:
+
+            1. clean all virt-who global configurations
+            2. run virt-who with hypervisor_id=uuid
+            3. run virt-who with hypervisor_id=hostname
+            4. run virt-who with hypervisor_id=hwuuid (Only for esx and rhevm)
+
+        :expectedresults:
+
+            hypervisor id shows uuid/hostname/hwuuid in mapping as the setting.
+        """
+        hypervisor.update('hypervisor_id', 'uuid')
+        result = virtwho.run_cli()
+        id_1 = result['hypervisor_id']
+        id_2 = hypervisor_data['hypervisor_uuid']
+        assert (result['send'] == 1
+                and
+                result['hypervisor_id'] == hypervisor_data['hypervisor_uuid'])
+
+        hypervisor.update('hypervisor_id', 'hostname')
+        result = virtwho.run_cli()
+        assert (result['send'] == 1
+                and
+                result['hypervisor_id'] == hypervisor_data['hypervisor_hostname'])
+
+        if hypervisor_handler in ['esx', 'rhevm']:
+            hypervisor.update('hypervisor_id', 'hwuuid')
+            result = virtwho.run_cli()
+            assert (result['send'] == 1
+                    and
+                    result['hypervisor_id'] == hypervisor_data['hypervisor_hwuuid'])
+
+    # def host_guest_association_in_mapping(self):
+    #     pass
+
+    # def test_vdc_bonus_pool(self, virtwho, sm_guest, register):
+    #     """Test the vdc subscription can be derive bonus pool for guest using
+    #
+    #     :title: virt-who: gating: test the derived vdc virtual bonus pool
+    #     :id: 03b79c0b-8b1f-4f32-8285-370773b7124b
+    #     :caseimportance: High
+    #     :tags: gating
+    #     :customerscenario: false
+    #     :upstream: no
+    #     :steps:
+    #
+    #         1. Register guest to entitlement server
+    #         2. Run virt-who to report mappings to entitlement server
+    #         3. Attach physical vdc for hypervisor
+    #         4. Check and attach virtual bonus pool for guest
+    #
+    #     :expectedresults:
+    #
+    #         1. Attach vdc physical pool for hypervisor successfully
+    #         2. Virtual bonus vdc pool is created
+    #         3. Guest can subscribe the bonus vdc pool
+    #     """
+    #     sm_guest.register()
+    #
+    #     result = virtwho.run_cli()
+    #     assert (result['send'] == 1)
+    #
+    #     register.attach()

--- a/virtwho/provision/virtwho_host.py
+++ b/virtwho/provision/virtwho_host.py
@@ -24,6 +24,9 @@ def provision_virtwho_host(args):
         args.virtwho_pkg_url = msg['pkg_url']
         if not args.rhel_compose:
             args.rhel_compose = msg['latest_rhel_compose']
+        config.update('gating', 'package_nvr', msg['pkg_nvr'])
+        config.update('gating', 'build_id', msg['build_id'])
+        config.update('gating', 'task_id', msg['task_id'])
 
     if not args.server:
         beaker_args_define(args)

--- a/virtwho/runner.py
+++ b/virtwho/runner.py
@@ -4,7 +4,7 @@ import re
 import threading
 import time
 from virtwho import logger, FailException
-from virtwho.configure import virtwho_ssh_connect
+from virtwho.configure import virtwho_ssh_connect, get_hypervisor_handler
 
 
 class VirtwhoRunner:
@@ -110,6 +110,7 @@ class VirtwhoRunner:
         data['interval'] = self.interval_time(rhsm_log)
         data['loop'], data['loop_num'] = self.loop_info()
         data['mappings'] = self.mappings(rhsm_log)
+        data['hypervisor_id'] = self.hypervisor_id(data['mappings'])
         data['print_json'] = self.print_json()
         data['error'], data['error_msg'] = self.error_warning('error')
         data['warning'], data['warning_msg'] = self.error_warning('warning')
@@ -431,6 +432,19 @@ class VirtwhoRunner:
                     org_data[hypervisorId] = facts
                 data[org] = org_data
         return data
+
+    def hypervisor_id(self, mapping):
+        """
+        Get the hypervisor id by mapping
+        :param mapping: the host-to-guest mapping
+        """
+        if mapping:
+            guest_uuid = get_hypervisor_handler(self.mode).guest_uuid
+            for org in mapping['orgs']:
+                org_dict = mapping[org]
+                if guest_uuid in org_dict.keys():
+                    return mapping[org][guest_uuid]['guest_hypervisor']
+        return ''
 
     def print_json(self):
         """


### PR DESCRIPTION
Define the test_gating.py, including

- test_debug
- test_interval
- test_oneshot
- test_hypervisor_id

Will add test_vdc_sku and test_host_guest_associates later

**Test Results**
#pytest tests/gating/test_gating.py
======================== test session starts ========================
platform linux -- Python 3.9.9, pytest-6.2.5, py-1.10.0, pluggy-1.0.0
rootdir: /root/workspace/virtwho-test, configfile: pytest.ini
collected 4 items                                                                                                                                

tests/gating/test_gating.py ....                                                                                                           [100%]
========================== 4 passed in 441.27s (0:07:21) ===========