### PR TITLE
Remove refresh satellite manifest

### DIFF
--- a/utils/satellite.py
+++ b/utils/satellite.py
@@ -173,11 +173,11 @@ def satellite_manifest_upload(ssh, url, admin_username, admin_password):
                         f'--file {filename}')
     if ret != 0:
         raise FailException('Failed to upload manifest for satellite')
-    ret, _ = ssh.runcmd(f'hammer -u {admin_username} -p {admin_password} '
-                        f'subscription refresh-manifest '
-                        f'--organization="Default Organization"')
-    if ret != 0:
-        raise FailException('Failed to refresh satellite manifest')
+    # ret, _ = ssh.runcmd(f'hammer -u {admin_username} -p {admin_password} '
+    #                     f'subscription refresh-manifest '
+    #                     f'--organization="Default Organization"')
+    # if ret != 0:
+    #     raise FailException('Failed to refresh satellite manifest')
 
 
 def satellite_arguments_parser():


### PR DESCRIPTION
Recently the step of refresh satellite manifest often fail, which may be caused by network issue or stage issue, but it seems this failure doesn't impact the satellite using.
So comment it now.