### PR TITLE
Fix issue of the virtwho.ini update conflict in virtwho_host.py and virtwho_satellite.py

### DIFF
--- a/utils/properties_update.py
+++ b/utils/properties_update.py
@@ -6,15 +6,16 @@ import argparse
 
 curPath = os.path.abspath(os.path.dirname(__file__))
 rootPath = os.path.split(curPath)[0]
-sys.path.append(os.path.split(rootPath)[0])
+sys.path.append(rootPath)
 
-from virtwho.settings import config
+from virtwho.settings import Configure, TEST_DATA
 
 
 def virtwho_ini_props_update(args):
     """
-    Update the properties of virtwho.ini for testing
+    Update the property of virtwho.ini for testing/using
     """
+    config = Configure(TEST_DATA)
     if args.section and args.option:
         config.update(args.section, args.option, args.value)
 

--- a/virtwho/provision/virtwho_host.py
+++ b/virtwho/provision/virtwho_host.py
@@ -8,7 +8,7 @@ rootPath = os.path.split(curPath)[0]
 sys.path.append(os.path.split(rootPath)[0])
 
 from virtwho import logger, FailException
-from virtwho.settings import config
+from virtwho.settings import config, Configure, TEST_DATA
 from virtwho.ssh import SSHConnect
 from virtwho import base
 from utils.beaker import install_rhel_by_beaker
@@ -26,9 +26,10 @@ def provision_virtwho_host(args):
         args.virtwho_pkg_url = msg['pkg_url']
         if not args.rhel_compose:
             args.rhel_compose = msg['latest_rhel_compose']
-        config.update('gating', 'package_nvr', msg['pkg_nvr'])
-        config.update('gating', 'build_id', msg['build_id'])
-        config.update('gating', 'task_id', msg['task_id'])
+        virtwho_ini = Configure(TEST_DATA)
+        virtwho_ini.update('gating', 'package_nvr', msg['pkg_nvr'])
+        virtwho_ini.update('gating', 'build_id', msg['build_id'])
+        virtwho_ini.update('gating', 'task_id', msg['task_id'])
     # Will deploy a new host by beaker if no server provided
     if not args.server:
         beaker_args_define(args)
@@ -47,11 +48,12 @@ def provision_virtwho_host(args):
     base.system_init(ssh_host, 'virtwho')
     virtwho_pkg = virtwho_install(ssh_host, args.virtwho_pkg_url)
     # Update the test properties in virtwho.ini
-    config.update('job', 'rhel_compose', args.rhel_compose)
-    config.update('virtwho', 'server', args.server)
-    config.update('virtwho', 'username', args.username)
-    config.update('virtwho', 'password', args.password)
-    config.update('virtwho', 'package', virtwho_pkg)
+    virtwho_ini = Configure(TEST_DATA)
+    virtwho_ini.update('job', 'rhel_compose', args.rhel_compose)
+    virtwho_ini.update('virtwho', 'server', args.server)
+    virtwho_ini.update('virtwho', 'username', args.username)
+    virtwho_ini.update('virtwho', 'password', args.password)
+    virtwho_ini.update('virtwho', 'package', virtwho_pkg)
     # Configure the virt-who host as mode requirements
     if (config.job.hypervisor == 'libvirt'
             or 'libvirt' in config.job.multi_hypervisors):
@@ -63,9 +65,10 @@ def provision_virtwho_host(args):
 
     if (config.job.hypervisor == 'local'
             or 'local' in config.job.multi_hypervisors):
-        config.update('local', 'server', args.server)
-        config.update('server', 'username', args.username)
-        config.update('server', 'password', args.password)
+        virtwho_ini = Configure(TEST_DATA)
+        virtwho_ini.update('local', 'server', args.server)
+        virtwho_ini.update('local', 'username', args.username)
+        virtwho_ini.update('local', 'password', args.password)
 
     logger.info(f"+++ Suceeded to deploy the virt-who host "
                 f"{args.rhel_compose}/{args.server} +++")

--- a/virtwho/provision/virtwho_satellite.py
+++ b/virtwho/provision/virtwho_satellite.py
@@ -11,7 +11,7 @@ sys.path.append(os.path.split(rootPath)[0])
 from virtwho import FailException, logger
 from virtwho.register import Satellite
 from virtwho.ssh import SSHConnect
-from virtwho.settings import config
+from virtwho.settings import config, Configure, TEST_DATA
 from utils.beaker import install_rhel_by_beaker
 from utils.satellite import satellite_deploy
 
@@ -49,11 +49,12 @@ def satellite_deploy_for_virtwho(args):
     satellite_settings(ssh_satellite, 'unregister_delete_host', 'true')
 
     # Update the [satellite] section of virtwho.ini
-    config.update('satellite', 'server', args.server)
-    config.update('satellite', 'username', args.admin_username)
-    config.update('satellite', 'password', args.admin_password)
-    config.update('satellite', 'ssh_username', args.ssh_username)
-    config.update('satellite', 'ssh_password', args.ssh_password)
+    virtwho_ini = Configure(TEST_DATA)
+    virtwho_ini.update('satellite', 'server', args.server)
+    virtwho_ini.update('satellite', 'username', args.admin_username)
+    virtwho_ini.update('satellite', 'password', args.admin_password)
+    virtwho_ini.update('satellite', 'ssh_username', args.ssh_username)
+    virtwho_ini.update('satellite', 'ssh_password', args.ssh_password)
 
     # Create the organization and activation key as requirement.
     satellite = Satellite()


### PR DESCRIPTION
In the Jenkins jobs, the virtwho_host.py and virtwho_satellite.py are run meanwhile to parallel deploy virt-who host and satellite, but there is conflict when update the virtwho.ini, only the last update take effect because it covers the previous one.
So change to use the `utils/properties_update.py` to read and save the current file for each update action.