### PR TITLE
add server=None param to class Satellite()

### DIFF
--- a/virtwho/provision/virtwho_satellite.py
+++ b/virtwho/provision/virtwho_satellite.py
@@ -61,7 +61,7 @@ def satellite_deploy_for_virtwho(args):
         virtwho_ini_props_update(args)
 
     # Create the organization and activation key as requirement.
-    satellite = Satellite()
+    satellite = Satellite(server=args.server)
     second_org = config.satellite.secondary_org
     if second_org:
         satellite.org_create(name=second_org, label=second_org)

--- a/virtwho/register.py
+++ b/virtwho/register.py
@@ -470,25 +470,28 @@ class RHSM:
 
 class Satellite:
 
-    def __init__(self, org=None, activation_key=None):
+    def __init__(self, server=None, org=None, activation_key=None):
         """
         Using hammer command to set satellite, handle organization and
         activation key, attach/remove subscription for host.
         Using api to check the host-to-guest associations.
+        :param server: satellite server ip/hostname, use the server configured
+            in virtwho.ini as default.
         :param org: organization label, use the default_org configured
             in virtwho.ini as default.
         :param activation_key: activation key name, use the configure
             in virtwho.ini as default.
         """
         register = get_register_handler('satellite')
+        self.server = server or register.server
         self.org = org or register.default_org
         self.activation_key = activation_key or register.activation_key
-        self.ssh = SSHConnect(host=register.server,
+        self.ssh = SSHConnect(host=self.server,
                               user=register.ssh_username,
                               pwd=register.ssh_password)
         self.hammer = 'hammer --output=json'
         self.org_id = self.organization_id()
-        self.api = f'https://{register.server}'
+        self.api = f'https://{self.server}'
         self.auth = (register.username, register.password)
 
     def organization_id(self, org=None):


### PR DESCRIPTION
The satellite `server` is deployed and write to the virthwo.ini file during the job process, so there is conflict to directly call the `config.satellite.server` from the virtwho.ini, which file is read at the beginning by `from virtwho.settings import config`, the server will be null and make trigger failed.
So add a new param `server=` for the Satellite() class to fix this issue.