### PR TITLE
Need to reset the self.cfg after cleaning VirtwhoGlobalConfig

### DIFF
--- a/virtwho/configure.py
+++ b/virtwho/configure.py
@@ -117,6 +117,7 @@ class VirtwhoGlobalConfig:
         """
         os.system(f"echo '' > {self.local_file}")
         self.remote_ssh.put_file(self.local_file, self.remote_file)
+        self.cfg = Configure(self.local_file, self.remote_ssh, self.remote_file)
 
 
 def virtwho_ssh_connect(mode=None):


### PR DESCRIPTION
**Description**
Noted there is an issue:
1.
```
@pytest.mark.usefixtures('globalconf_clean')
def test_interval_in_virtwho_conf(self, virtwho, globalconf):
    globalconf.update('global', 'debug', 'True')
    globalconf.update('global', 'interval', '120')
```
-> result:
```
[root@rhel-8-6-0-20220420-3-esx-55913 ~]# cat /etc/virt-who.conf
[global]
interval=120
debug=True
```
2.
```
@pytest.mark.usefixtures('globalconf_clean')
def test_interval_in_virtwho_conf(self, virtwho, globalconf):
    globalconf.update('global', 'interval', '120')
```
-> result is still:
```
[root@rhel-8-6-0-20220420-3-esx-55913 ~]# cat /etc/virt-who.conf
[global]
interval=120
debug=True
```
Found that after we cleaned the global conf,  the `self.cfg` wasn't be reset, and the `self.config.read(self.local_file)` wasn't be reset to empty, it will still use the contents before we clean the config

