### PR TITLE
Define test cases of test_cli.py

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -4,5 +4,10 @@ markers =
     tier2: Tier 2 cases for virt-who extra functions
     tier3: Tier 2 cases for virt-who extra functions
 
-    satelliteOnly: cases for satellite
-    rhsmOnly: cases for candlepin
+    satellite: cases for satellite
+    rhsm: cases for candlepin
+
+    rhel8: cases only for rhel 8
+    rhel9: cases only for rhel 9
+
+    notLocal: cases not for local libvirt mode

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,31 +5,18 @@ from virtwho.configure import VirtwhoGlobalConfig
 from virtwho.configure import get_hypervisor_handler, virtwho_ssh_connect
 from virtwho.configure import get_register_handler
 from virtwho.register import SubscriptionManager
+from virtwho import HYPERVISOR, REGISTER
 import pytest
-
-
-mode = config.job.hypervisor
-register_type = config.job.register
-
-
-@pytest.fixture(name='rhel_compose', scope='session')
-def virtwho_test_rhel_compose():
-    return config.job.rhel_compose
-
-
-@pytest.fixture(name='mode_file', scope='session')
-def virtwho_test_hypervisor_configure_file():
-    return f'/etc/virt-who.d/{mode}.conf'
 
 
 @pytest.fixture(name='hypervisor_handler', scope='session')
 def virtwho_hypervisor_handler():
-    return get_hypervisor_handler(mode)
+    return get_hypervisor_handler(HYPERVISOR)
 
 
 @pytest.fixture(name='hypervisor', scope='session')
 def virtwho_hypervisor_config():
-    return VirtwhoHypervisorConfig(mode, register_type)
+    return VirtwhoHypervisorConfig(HYPERVISOR, REGISTER)
 
 
 @pytest.fixture(name='hypervisor_create', scope='class')
@@ -39,12 +26,12 @@ def virtwho_hypervisor_config_file_create(hypervisor):
 
 @pytest.fixture(name='register_handler', scope='session')
 def virtwho_register_handler():
-    return get_register_handler(register_type)
+    return get_register_handler(REGISTER)
 
 
 @pytest.fixture(name='globalconf', scope='session')
 def virtwho_global_config():
-    return VirtwhoGlobalConfig(mode)
+    return VirtwhoGlobalConfig(HYPERVISOR)
 
 
 @pytest.fixture(name='globalconf_clean', scope='function')
@@ -59,12 +46,12 @@ def virtwho_global_config_debug_true(globalconf):
 
 @pytest.fixture(name='virtwho', scope='class')
 def virtwho_runner():
-    return VirtwhoRunner(mode, register_type)
+    return VirtwhoRunner(HYPERVISOR, REGISTER)
 
 
 @pytest.fixture(name='ssh_host', scope='session')
 def virtwho_host_ssh_connect():
-    return virtwho_ssh_connect(mode)
+    return virtwho_ssh_connect(HYPERVISOR)
 
 
 @pytest.fixture(name='sm_host', scope='session')
@@ -73,7 +60,7 @@ def subscription_manager_virtwho_host_with_default_org(register_handler):
     vw_username = config.virtwho.username
     vw_password = config.virtwho.password
     vw_port = config.virtwho.port or 22
-    if mode == 'local':
+    if HYPERVISOR == 'local':
         vw_server = config.local.server
         vw_username = config.local.username
         vw_password = config.local.password
@@ -82,7 +69,7 @@ def subscription_manager_virtwho_host_with_default_org(register_handler):
                                username=vw_username,
                                password=vw_password,
                                port=vw_port,
-                               register_type=register_type,
+                               register_type=REGISTER,
                                org=register_handler.default_org)
 
 
@@ -92,7 +79,7 @@ def subscription_manager_guest_host_with_default_org(hypervisor_handler, registe
                                username=hypervisor_handler.guest_username,
                                password=hypervisor_handler.guest_password,
                                port=22,
-                               register_type=register_type,
+                               register_type=REGISTER,
                                org=register_handler.default_org)
 
 
@@ -103,11 +90,11 @@ def hypervisor_common_data_get_from_virtwho_ini(hypervisor_handler):
     data['hypervisor_uuid'] = ''
     data['hypervisor_hostname'] = ''
     data['hypervisor_hwuuid'] = ''
-    if mode == 'esx':
+    if HYPERVISOR == 'esx':
         data['hypervisor_uuid'] = hypervisor_handler.esx_uuid
         data['hypervisor_hostname'] = hypervisor_handler.esx_hostname
         data['hypervisor_hwuuid'] = hypervisor_handler.esx_hwuuid
-    elif mode == 'rhevm':
+    elif HYPERVISOR == 'rhevm':
         data['hypervisor_uuid'] = hypervisor_handler.vdsm_uuid
         data['hypervisor_hostname'] = hypervisor_handler.vdsm_hostname
         data['hypervisor_hwuuid'] = hypervisor_handler.vdsm_hwuuid

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,15 +2,24 @@ from virtwho.settings import config
 from virtwho.runner import VirtwhoRunner
 from virtwho.configure import VirtwhoHypervisorConfig
 from virtwho.configure import VirtwhoGlobalConfig
-from virtwho.configure import get_hypervisor_handler
+from virtwho.configure import get_hypervisor_handler, virtwho_ssh_connect
 from virtwho.configure import get_register_handler
 from virtwho.register import SubscriptionManager
-from virtwho import logger
 import pytest
 
 
 mode = config.job.hypervisor
 register_type = config.job.register
+
+
+@pytest.fixture(name='rhel_compose', scope='session')
+def virtwho_test_rhel_compose():
+    return config.job.rhel_compose
+
+
+@pytest.fixture(name='mode_file', scope='session')
+def virtwho_test_hypervisor_configure_file():
+    return f'/etc/virt-who.d/{mode}.conf'
 
 
 @pytest.fixture(name='hypervisor_handler', scope='session')
@@ -51,6 +60,11 @@ def virtwho_global_config_debug_true(globalconf):
 @pytest.fixture(name='virtwho', scope='class')
 def virtwho_runner():
     return VirtwhoRunner(mode, register_type)
+
+
+@pytest.fixture(name='ssh_host', scope='session')
+def virtwho_host_ssh_connect():
+    return virtwho_ssh_connect(mode)
 
 
 @pytest.fixture(name='sm_host', scope='session')

--- a/tests/function/test_cli.py
+++ b/tests/function/test_cli.py
@@ -5,7 +5,6 @@
 :caseautomation: Automated
 """
 import pytest
-from virtwho import logger
 
 
 @pytest.mark.usefixtures('globalconf_clean')
@@ -32,119 +31,148 @@ class TestCli:
             1. no [DEBUG] log printed without "-d" option
             2. [DEBUG] logs are printed with "-d" option
         """
-        # result = virtwho.run_cli(debug=False)
-        # assert (result['send'] == 1
-        #         and result['error'] == 0
-        #         and result['debug'] is False)
-        #
-        # result = virtwho.run_cli(debug=True)
-        # assert (result['send'] == 1
-        #         and result['error'] == 0
-        #         and result['debug'] is True)
-        logger.info("Succeeded to run the 'test_debug_by_cli'")
+        result = virtwho.run_cli(debug=False)
+        assert (result['send'] == 1
+                and result['error'] == 0
+                and result['debug'] is False)
 
-    # @pytest.mark.tier1
-    # def test_oneshot(self, virtwho):
-    #     """Test the '-o' option in virt-who command line
-    #
-    #     :title: virt-who: cli: test option -o
-    #     :id: 6902b844-8b71-490c-abf1-fa6087987666
-    #     :caseimportance: High
-    #     :tags: tier1
-    #     :customerscenario: false
-    #     :upstream: no
-    #     :steps:
-    #
-    #         1. clean all virt-who global configurations
-    #         2. run "#virt-who -c" without "-o"
-    #         3. run "#virt-who -o -c"
-    #
-    #     :expectedresults:
-    #
-    #         1. virt-who thread is not terminated automatically without "-o"
-    #         2. virt-who thread is terminated after reporting once with "-o"
-    #     """
-    #     result = virtwho.run_cli(oneshot=False)
-    #     assert (result['send'] == 1
-    #             and result['error'] == 0
-    #             and result['thread'] == 1
-    #             and result['terminate'] == 0
-    #             and result['oneshot'] is False)
-    #
-    #     result = virtwho.run_cli(oneshot=True)
-    #     assert (result['send'] == 1
-    #             and result['error'] == 0
-    #             and result['thread'] == 0
-    #             and result['terminate'] == 1
-    #             and result['oneshot'] is True)
+        result = virtwho.run_cli(debug=True)
+        assert (result['send'] == 1
+                and result['error'] == 0
+                and result['debug'] is True)
 
-    # @pytest.mark.tier1
-    # def test_interval(self, virtwho):
-    #     """Test the '-i' option in virt-who command line
-    #
-    #     :title: virt-who: cli: test option -i
-    #     :id: e43d9fd0-0f1b-4b25-98f6-c421046e1c47
-    #     :caseimportance: High
-    #     :tags: tier1
-    #     :customerscenario:
-    #     :upstream: no
-    #     :steps:
-    #
-    #         1. clean all virt-who global configurations
-    #         2. run "#virt-who" without "-i"
-    #         3. run "#virtwho -i 10 -c"
-    #         4. run "#virtwho -i 60 -c"
-    #
-    #     :expectedresults:
-    #
-    #         1. the default interval=3600 when run without "-i"
-    #         2. the interval=3600 when run with "-i" < 60
-    #         3. the interval uses the setting value when run with "-i" >= 60
-    #     """
-    #     result = virtwho.run_cli(oneshot=False, interval=None)
-    #     assert (result['send'] == 1
-    #             and result['interval'] == 3600)
-    #
-    #     result = virtwho.run_cli(oneshot=False, interval=10)
-    #     assert (result['send'] == 1
-    #             and result['interval'] == 3600)
-    #
-    #     result = virtwho.run_cli(oneshot=False, interval=60, wait=60)
-    #     assert (result['send'] == 1
-    #             and result['interval'] == 60
-    #             and result['loop'] == 60)
-    #
-    # @pytest.mark.tier1
-    # def test_print(self, virtwho, hypervisor_handler):
-    #     """Test the '-p' option in virt-who command line
-    #
-    #     :title: virt-who: cli: test option -p
-    #     :id: 16c01269-f4ab-4fe5-a29e-a3d5dc69a32a
-    #     :caseimportance: High
-    #     :tags: tier1
-    #     :customerscenario: false
-    #     :upstream: no
-    #     :steps:
-    #
-    #         1. clean all virt-who global configurations
-    #         2. run "#virt-who -p -c"
-    #         3. run "#virt-who -p -d -c"
-    #
-    #     :expectedresults:
-    #
-    #         1. virt-who service is terminated after run with -p
-    #         2. mappings is not reported when run with -p
-    #         3. mappings can be printed out
-    #     """
-    #     guest_id = hypervisor_handler.guest_uuid
-    #     result = virtwho.run_cli(oneshot=False, debug=False, prt=True)
-    #     assert (result['thread'] == 0
-    #             and result['send'] == 0
-    #             and result['debug'] is False
-    #             and guest_id in result['print_json'])
-    #
-    #     result = virtwho.run_cli(oneshot=False, debug=True, prt=True)
-    #     assert (result['thread'] == 0
-    #             and result['send'] == 0
-    #             and result['debug'] is True
-    #             and guest_id in result['print_json'])
+    @pytest.mark.tier1
+    def test_oneshot(self, virtwho):
+        """Test the '-o' option in virt-who command line
+
+        :title: virt-who: cli: test option -o
+        :id: 6902b844-8b71-490c-abf1-fa6087987666
+        :caseimportance: High
+        :tags: tier1
+        :customerscenario: false
+        :upstream: no
+        :steps:
+
+            1. clean all virt-who global configurations
+            2. run "#virt-who -c" without "-o"
+            3. run "#virt-who -o -c"
+
+        :expectedresults:
+
+            1. virt-who thread is not terminated automatically without "-o"
+            2. virt-who thread is terminated after reporting once with "-o"
+        """
+        result = virtwho.run_cli(oneshot=False)
+        assert (result['send'] == 1
+                and result['error'] == 0
+                and result['thread'] == 1
+                and result['terminate'] == 0
+                and result['oneshot'] is False)
+
+        result = virtwho.run_cli(oneshot=True)
+        assert (result['send'] == 1
+                and result['error'] == 0
+                and result['thread'] == 0
+                and result['terminate'] == 1
+                and result['oneshot'] is True)
+
+    @pytest.mark.tier1
+    def test_interval(self, virtwho):
+        """Test the '-i' option in virt-who command line
+
+        :title: virt-who: cli: test option -i
+        :id: e43d9fd0-0f1b-4b25-98f6-c421046e1c47
+        :caseimportance: High
+        :tags: tier1
+        :customerscenario: false
+        :upstream: no
+        :steps:
+
+            1. clean all virt-who global configurations
+            2. run "#virt-who" without "-i"
+            3. run "#virtwho -i 10 -c"
+            4. run "#virtwho -i 60 -c"
+
+        :expectedresults:
+
+            1. the default interval=3600 when run without "-i"
+            2. the interval=3600 when run with "-i" < 60
+            3. the interval uses the setting value when run with "-i" >= 60
+        """
+        result = virtwho.run_cli(oneshot=False, interval=None)
+        assert (result['send'] == 1
+                and result['interval'] == 3600)
+
+        result = virtwho.run_cli(oneshot=False, interval=10)
+        assert (result['send'] == 1
+                and result['interval'] == 3600)
+
+        result = virtwho.run_cli(oneshot=False, interval=60, wait=60)
+        assert (result['send'] == 1
+                and result['interval'] == 60
+                and result['loop'] == 60)
+
+    @pytest.mark.tier1
+    def test_print(self, virtwho, hypervisor_handler):
+        """Test the '-p' option in virt-who command line
+
+        :title: virt-who: cli: test option -p
+        :id: 16c01269-f4ab-4fe5-a29e-a3d5dc69a32a
+        :caseimportance: High
+        :tags: tier1
+        :customerscenario: false
+        :upstream: no
+        :steps:
+
+            1. clean all virt-who global configurations
+            2. run "#virt-who -p -c"
+            3. run "#virt-who -p -d -c"
+
+        :expectedresults:
+
+            1. virt-who service is terminated after run with -p
+            2. mappings is not reported when run with -p
+            3. mappings can be printed out
+        """
+        guest_id = hypervisor_handler.guest_uuid
+        result = virtwho.run_cli(oneshot=False, debug=False, prt=True)
+        assert (result['thread'] == 0
+                and result['send'] == 0
+                and result['debug'] is False
+                and guest_id in result['print_json'])
+
+        result = virtwho.run_cli(oneshot=False, debug=True, prt=True)
+        assert (result['thread'] == 0
+                and result['send'] == 0
+                and result['debug'] is True
+                and guest_id in result['print_json'])
+
+    @pytest.mark.tier1
+    @pytest.mark.notLocal
+    def test_config(self, virtwho, ssh_host, mode_file):
+        """Test the '-c' option in virt-who command line
+
+        :title: virt-who: cli: test option -c
+        :id: 851a41fd-4fdc-4f8a-ac1b-e185079452fa
+        :caseimportance: High
+        :tags: tier1
+        :customerscenario: false
+        :upstream: no
+        :steps:
+
+            1. clean all virt-who global configurations
+            2. configure the both /etc/virt-who.d/x.conf and /root/x.conf
+            3. run "#virt-who -c /root/x.conf"
+
+        :expectedresults:
+
+            1. virt-who only reports the /root/x.conf
+            2. virt-who ignores the files in /etc/virt-who.d/
+        """
+        msg = "ignoring configuration files in '/etc/virt-who.d/'"
+        config_file = '/root/test_cli_config.conf'
+        ssh_host.runcmd(f'cp {mode_file} {config_file}')
+        result = virtwho.run_cli(config=config_file)
+        assert (result['send'] == 1
+                and result['error'] == 0
+                and msg in result['log'])

--- a/tests/function/test_cli.py
+++ b/tests/function/test_cli.py
@@ -5,6 +5,7 @@
 :caseautomation: Automated
 """
 import pytest
+from virtwho import HYPERVISOR_FILE
 
 
 @pytest.mark.usefixtures('globalconf_clean')
@@ -149,7 +150,7 @@ class TestCli:
 
     @pytest.mark.tier1
     @pytest.mark.notLocal
-    def test_config(self, virtwho, ssh_host, mode_file):
+    def test_config(self, virtwho, ssh_host):
         """Test the '-c' option in virt-who command line
 
         :title: virt-who: cli: test option -c
@@ -171,7 +172,7 @@ class TestCli:
         """
         msg = "ignoring configuration files in '/etc/virt-who.d/'"
         config_file = '/root/test_cli_config.conf'
-        ssh_host.runcmd(f'cp {mode_file} {config_file}')
+        ssh_host.runcmd(f'\\cp -f {HYPERVISOR_FILE} {config_file}')
         result = virtwho.run_cli(config=config_file)
         assert (result['send'] == 1
                 and result['error'] == 0

--- a/virtwho/__init__.py
+++ b/virtwho/__init__.py
@@ -1,6 +1,15 @@
 from virtwho.logger import getLogger
+from virtwho.settings import config
 
 logger = getLogger(__name__)
+
+RHEL_COMPOSE = config.job.register
+
+HYPERVISOR = config.job.hypervisor
+
+HYPERVISOR_FILE = f'/etc/virt-who.d/{HYPERVISOR}.conf'
+
+REGISTER = config.job.register
 
 
 class FailException(BaseException):

--- a/virtwho/runner.py
+++ b/virtwho/runner.py
@@ -114,9 +114,7 @@ class VirtwhoRunner:
         data['print_json'] = self.print_json()
         data['error'], data['error_msg'] = self.error_warning('error')
         data['warning'], data['warning_msg'] = self.error_warning('warning')
-        logger.info(f"Completed the analyzer after run virt-who, "
-                    f"the result is:\n"
-                    f"{data}")
+        data['log'] = rhsm_log
         return data
 
     def run_start(self, cli=None, wait=None):


### PR DESCRIPTION
**Description**
- [x] test_debug: -d
- [x] test_interval: -i
- [x] test_oneshot: -o
- [x] test_print: -p
- [x] test_config: -c

BTW: 

- Will define cases about option `-h` and `--version` in the `test_info.py`, which should only be run once at beginning.
- Will test the `-s` `-j` in each hypervisor test file, which should be tested for each file, not only for esx.

**Test Result**
```
# pytest tests/function/test_cli.py --disable-warnings -v
==================== test session starts ======================
platform linux -- Python 3.9.9, pytest-6.2.5, py-1.10.0, pluggy-1.0.0 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /root/workspace/virtwho-test, configfile: pytest.ini
collected 5 items                                                                                                                                

tests/function/test_cli.py::TestCli::test_debug PASSED               [ 20%]
tests/function/test_cli.py::TestCli::test_oneshot PASSED            [ 40%]
tests/function/test_cli.py::TestCli::test_interval PASSED              [ 60%]
tests/function/test_cli.py::TestCli::test_print PASSED                    [ 80%]
tests/function/test_cli.py::TestCli::test_config PASSED                [100%]

=========================== 5 passed in 386.19s (0:06:26) ==================
```