### PR TITLE
Add log options related 2 cases in test_config.py

### DIFF
--- a/tests/function/test_config.py
+++ b/tests/function/test_config.py
@@ -112,7 +112,7 @@ class TestConfiguration:
                 and result['terminate'] == 0
                 and result['oneshot'] is False)
 
-    def test_print_in_virtwho_conf(self, virtwho, globalconf, hypervisor_handler):
+    def test_print_in_virtwho_conf(self, virtwho, globalconf, hypervisor_data):
         """Test the print_ option in /etc/virtwho.conf
 
         :title: virt-who: config: test print_ option
@@ -137,7 +137,7 @@ class TestConfiguration:
                 and result['send'] == 1
                 and result['thread'] == 1)
 
-        guest_id = hypervisor_handler.guest_uuid
+        guest_id = hypervisor_data['guest_uuid']
         globalconf.update('global', 'print_', 'True')
         globalconf.update('global', 'debug', 'True')
         result = virtwho.run_service()
@@ -156,8 +156,7 @@ class TestConfiguration:
                 and result['debug'] is False
                 and guest_id not in result['log'])
 
-    @pytest.mark.usefixtures('hypervisor_data')
-    def test_reporter_id_in_virtwho_conf(self, virtwho, globalconf, ssh_host):
+    def test_reporter_id_in_virtwho_conf(self, virtwho, globalconf, ssh_host, hypervisor_data):
         """Test the reporter_id option in /etc/virtwho.conf
 
         :title: virt-who: config: test reporter_id option
@@ -191,7 +190,7 @@ class TestConfiguration:
                 and result['thread'] == 1
                 and result['reporter_id'] == reporter_id)
 
-    def test_log_per_config_in_virtwho_conf(self, virtwho, globalconf, hypervisor_handler, ssh_host):
+    def test_log_per_config_in_virtwho_conf(self, virtwho, globalconf, hypervisor_data, ssh_host):
         """Test the log_per_config option in /etc/virtwho.conf
 
         :title: virt-who: config: test log_per_config option
@@ -211,7 +210,7 @@ class TestConfiguration:
             2. Succeeded to find virtwho.destination_-*.log, virtwho.main.log, virtwho.main.log and
             virtwho.rhsm_log.log file in /var/log/rhsm/
         """
-        guest_uuid = hypervisor_handler.guest_uuid
+        guest_uuid = hypervisor_data['guest_uuid']
         globalconf.update('global', 'debug', 'True')
 
         globalconf.update('global', 'log_per_config', 'False')
@@ -256,7 +255,7 @@ class TestConfiguration:
                         and 'virtwho.destination' not in file_content
                         and 'virtwho.main' not in file_content)
 
-    def test_log_dir_and_log_file_in_virtwho_conf(self, virtwho, globalconf, hypervisor_handler, ssh_host):
+    def test_log_dir_and_log_file_in_virtwho_conf(self, virtwho, globalconf, hypervisor_data, ssh_host):
         """Test the log_dir and log_file option in /etc/virtwho.conf
 
         :title: virt-who: config: test log_dir and log_file option
@@ -278,7 +277,7 @@ class TestConfiguration:
         log_dir = '/var/log/rhsm/virtwho/'
         default_log_file = '/var/log/rhsm/virtwho/rhsm.log'
         specific_log_file = '/var/log/rhsm/virtwho/virtwho.log'
-        guest_uuid = hypervisor_handler.guest_uuid
+        guest_uuid = hypervisor_data['guest_uuid']
         globalconf.update('global', 'debug', 'True')
 
         globalconf.update('global', 'log_dir', log_dir)

--- a/tests/function/test_config.py
+++ b/tests/function/test_config.py
@@ -190,3 +190,126 @@ class TestConfiguration:
                 and result['send'] == 1
                 and result['thread'] == 1
                 and result['reporter_id'] == reporter_id)
+
+    def test_log_per_config_in_virtwho_conf(self, virtwho, globalconf, hypervisor_handler, ssh_host):
+        """Test the log_per_config option in /etc/virtwho.conf
+
+        :title: virt-who: config: test log_per_config option
+        :id: 85accd49-54dc-4899-a9cf-c6fb07b2fe3c
+        :caseimportance: High
+        :tags: tier1
+        :customerscenario: false
+        :upstream: no
+        :steps:
+
+            1. Run virt-who with log-per-config=False in /etc/virt-who.conf
+            2. Run virt-who with log-per-config=True in /etc/virt-who.conf
+
+        :expectedresults:
+
+            1. unexpected /var/log/rhsm/virtwho* files not exist
+            2. Succeeded to find virtwho.destination_-*.log, virtwho.main.log, virtwho.main.log and
+            virtwho.rhsm_log.log file in /var/log/rhsm/
+        """
+        guest_uuid = hypervisor_handler.guest_uuid
+        globalconf.update('global', 'debug', 'True')
+
+        globalconf.update('global', 'log_per_config', 'False')
+        result = virtwho.run_service()
+        assert (result['error'] == 0
+                and result['send'] == 1
+                and result['thread'] == 1)
+        ret, output = ssh_host.runcmd('ls /var/log/rhsm/virtwho*')
+        assert ret is not 0
+
+        globalconf.update('global', 'log_per_config', 'True')
+        result = virtwho.run_service()
+        assert (result['error'] == 0
+                and result['send'] == 1
+                and result['thread'] == 1)
+        ret, files = ssh_host.runcmd('ls /var/log/rhsm/virtwho*')
+        assert (ret == 0
+                and 'virtwho.destination' in files
+                and 'virtwho.main.log' in files
+                and 'virtwho.rhsm_log.log' in files
+                and 'virtwho.virt.log' in files)
+
+        # assert the contents for the log files
+        for file in files.strip().split('\n'):
+            _, file_content = ssh_host.runcmd(f"cat {file.strip()}")
+            if "virtwho.destination" in file:
+                assert (guest_uuid in file_content
+                        and "ERROR" not in file_content)
+            if file == 'virtwho.main.log':
+                assert ("Report for config" in file_content
+                        and "ERROR" not in file_content)
+            if file == 'virtwho.rhsm_log.log':
+                assert ("Using reporter_id=" in file_content
+                        and "ERROR" not in file_content)
+
+    def test_log_dir_in_virtwho_conf(self, virtwho, globalconf, hypervisor_handler, ssh_host):
+        """Test the log_dir option in /etc/virtwho.conf
+
+        :title: virt-who: config: test log_dir option
+        :id: b20c8bf6-25f1-485a-a659-2f4194ee7fcc
+        :caseimportance: High
+        :tags: tier1
+        :customerscenario: false
+        :upstream: no
+        :steps:
+
+            1. Run virt-who with log_dir setting in /etc/virt-who.conf
+
+        :expectedresults:
+
+            1. Succeeded to find the rhsm.log file in specific log dir
+        """
+        log_dir = "/var/log/rhsm/virtwho/"
+        log_file = "/var/log/rhsm/virtwho/rhsm.log"
+        guest_uuid = hypervisor_handler.guest_uuid
+        globalconf.update('global', 'debug', 'True')
+
+        globalconf.update('global', 'log_dir', log_dir)
+        result = virtwho.run_service()
+        assert (result['error'] == 0
+                and result['send'] == 1
+                and result['thread'] == 1)
+        result, _ = ssh_host.runcmd(f"ls {log_file}")
+        assert result == 0
+        _, content = ssh_host.runcmd(f'cat {log_file}')
+        assert (guest_uuid in content
+                and "ERROR" not in content)
+
+    def test_log_file_in_virtwho_conf(self, virtwho, globalconf, hypervisor_handler, ssh_host):
+        """Test the log_file option in /etc/virtwho.conf
+
+        :title: virt-who: config: test log_file option
+        :id: 3bfa53f7-2564-4978-8189-099860f80c26
+        :caseimportance: High
+        :tags: tier1
+        :customerscenario: false
+        :upstream: no
+        :steps:
+
+            1. Run virt-who with log_dir and log_file setting in /etc/virt-who.conf
+
+        :expectedresults:
+
+            1. Succeeded to find the specific log file in specific log dir
+        """
+        log_dir = "/var/log/rhsm/virtwho/"
+        log_file = "/var/log/rhsm/virtwho/rhsm.log"
+        guest_uuid = hypervisor_handler.guest_uuid
+        globalconf.update('global', 'debug', 'True')
+
+        globalconf.update('global', 'log_dir', log_dir)
+        globalconf.update('global', 'log_file', log_file)
+        result = virtwho.run_service()
+        assert (result['error'] == 0
+                and result['send'] == 1
+                and result['thread'] == 1)
+        result, _ = ssh_host.runcmd(f"ls {log_file}")
+        assert result == 0
+        result, contents = ssh_host.runcmd(f"cat {log_file}")
+        assert (guest_uuid in contents
+                and "ERROR" not in contents)


### PR DESCRIPTION
**Description**
Add log_per_config log_dir and log_file 3 cases in test_config.py
- [X] test_log_per_config_in_virtwho_conf
- [X] test_log_dir_and_log_file_in_virtwho_conf

**Test Result**
```
(env) [hkx303@kuhuang function]$  pytest test_config.py -k test_log_ 
==================================== test session starts =====================================
platform linux -- Python 3.7.3, pytest-5.4.3, py-1.11.0, pluggy-0.13.1
rootdir: /home/hkx303/Documents/CI/virtwho-test, inifile: pytest.ini
plugins: services-1.3.1, xdist-1.34.0, mock-1.10.4, forked-1.4.0
collected 7 items / 5 deselected / 2 selected                                                

test_config.py ..                                                                      [100%]

======================== 2 passed, 5 deselected in 172.92s (0:02:52) =========================
```