### PR TITLE
Define new functions in conftest

### DIFF
--- a/tests/function/test_cli.py
+++ b/tests/function/test_cli.py
@@ -114,7 +114,7 @@ class TestCli:
                 and result['loop'] == 60)
 
     @pytest.mark.tier1
-    def test_print(self, virtwho, hypervisor_handler):
+    def test_print(self, virtwho, hypervisor_data):
         """Test the '-p' option in virt-who command line
 
         :title: virt-who: cli: test option -p
@@ -135,7 +135,7 @@ class TestCli:
             2. mappings is not reported when run with -p
             3. mappings can be printed out
         """
-        guest_id = hypervisor_handler.guest_uuid
+        guest_id = hypervisor_data['guest_uuid']
         result = virtwho.run_cli(oneshot=False, debug=False, prt=True)
         assert (result['thread'] == 0
                 and result['send'] == 0


### PR DESCRIPTION
- Removed the `name='register_handler'` fixture, which could be replaced by `name='register_data'`, which should be more smart because there are different options for the `satellite` and `rhsm`, we don't need to separate them in cases any more.
- Removed the `name='hypervisor_handler'` fixture, which could be replaced by `name='hypervisor_data'`, there are different options for different hypervisors, we don't need to separate them in cases any more.
- New add `name='ssh_guest'`
- Updated the previous case in `test_cli`, replaced the `hypervisor_handler` by `hypervisor_data`.