### PR TITLE
define test_smoke.py with test_hypervisor_id, test_vdc_sku and test_temporary_sku

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,7 +39,7 @@ def globalconf_clean(globalconf):
     globalconf.clean()
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope='class')
 def debug_true(globalconf):
     """Set the debug=True in /etc/virt-who.conf"""
     globalconf.update('global', 'debug', 'true')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -98,10 +98,13 @@ def sm_guest():
     Instantication of class SubscriptionManager() for hypervisor guest
     with default org
     """
+    port = 22
+    if HYPERVISOR == 'kubevirt':
+        port = hypervisor_handler.guest_port
     return SubscriptionManager(host=hypervisor_handler.guest_ip,
                                username=hypervisor_handler.guest_username,
                                password=hypervisor_handler.guest_password,
-                               port=22,
+                               port=port,
                                register_type=REGISTER,
                                org=register_handler.default_org)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,14 +8,14 @@ from virtwho.configure import get_hypervisor_handler, virtwho_ssh_connect
 from virtwho.configure import get_register_handler
 from virtwho.ssh import SSHConnect
 from virtwho.register import SubscriptionManager, Satellite, RHSM
-from virtwho import HYPERVISOR, REGISTER
+from virtwho import HYPERVISOR, REGISTER, FailException, logger
 from virtwho.base import hostname_get
 
 hypervisor_handler = get_hypervisor_handler(HYPERVISOR)
 register_handler = get_register_handler(REGISTER)
 
 
-@pytest.fixture(scope='class')
+@pytest.fixture(scope='session')
 def hypervisor():
     """Instantication of class VirtwhoHypervisorConfig()"""
     return VirtwhoHypervisorConfig(HYPERVISOR, REGISTER)
@@ -27,7 +27,7 @@ def hypervisor_create(hypervisor):
     hypervisor.create(rhsm=True)
 
 
-@pytest.fixture(scope='class')
+@pytest.fixture(scope='session')
 def globalconf():
     """Instantication of class VirtwhoGlobalConfig()"""
     return VirtwhoGlobalConfig(HYPERVISOR)
@@ -45,7 +45,7 @@ def debug_true(globalconf):
     globalconf.update('global', 'debug', 'true')
 
 
-@pytest.fixture(scope='class')
+@pytest.fixture(scope='session')
 def virtwho():
     """Instantication of class VirtwhoRunner()"""
     return VirtwhoRunner(HYPERVISOR, REGISTER)
@@ -104,6 +104,18 @@ def sm_guest():
                                port=22,
                                register_type=REGISTER,
                                org=register_handler.default_org)
+
+
+@pytest.fixture(scope='function')
+def register_host(sm_host):
+    """register the virt-who host"""
+    sm_host.register()
+
+
+@pytest.fixture(scope='function')
+def register_guest(sm_guest):
+    """register the guest"""
+    sm_guest.register()
 
 
 @pytest.fixture(scope='session')
@@ -188,4 +200,28 @@ def proxy_data():
                       'Connection timed out',
                       'Unable to connect']
     return proxy
+
+
+@pytest.fixture(scope='session')
+def sku_data():
+    """SKU data for testing from virtwho.ini file"""
+    data = dict()
+    data['vdc_physical'] = config.sku.vdc
+    data['vdc_virtual'] = config.sku.vdc_virtual
+    return data
+
+
+@pytest.fixture(scope='session')
+def vdc_pool_physical(sm_guest, sku_data):
+    """Get the vdc physical sku pool id"""
+    sku = sku_data['vdc_physical']
+    sm_guest.register()
+    sku_data = sm_guest.available(sku, 'Physical')
+    if sku_data is not None:
+        sku_pool = sku_data['pool_id']
+        logger.info(f'Succeeded to get the vdc physical sku pool id: '
+                    f'{sku_pool}')
+        return sku_pool
+    raise FailException('Failed to get the vdc physical sku pool id')
+
 

--- a/tests/smoke/test_smoke.py
+++ b/tests/smoke/test_smoke.py
@@ -10,6 +10,7 @@ from virtwho import logger
 
 @pytest.mark.usefixtures('globalconf_clean')
 @pytest.mark.usefixtures('hypervisor_create')
+@pytest.mark.usefixtures('debug_true')
 class TestSmoke:
     def test_host_guest_association(self, virtwho, satellite, hypervisor_data,
                                     register_data, sm_guest, ssh_guest):
@@ -46,7 +47,7 @@ class TestSmoke:
         sm_guest.register()
         assert satellite.associate(hypervisor_hostname, guest_hostname) is not False
 
-    def test_rhsm_options(self, virtwho, hypervisor, sm_host, debug_true):
+    def test_rhsm_options(self, virtwho, hypervisor, sm_host):
         """Test the rhsm_hostname/username/password/prefix/port
 
         :title: virt-who: satellite smoke: test rhsm options
@@ -137,8 +138,7 @@ class TestSmoke:
         hypervisor.delete('rhsm_proxy_port')
         hypervisor.delete('rhsm_proxy_hostname')
 
-    def test_hypervisor_id(self, virtwho, debug_true,
-                           hypervisor, hypervisor_data):
+    def test_hypervisor_id(self, virtwho, hypervisor, hypervisor_data):
         """Test hypervisor_id option in /etc/virt-who.d/hypervisor.conf
 
         :title: virt-who: satellite smoke: test hypervisor_id

--- a/tests/smoke/test_smoke.py
+++ b/tests/smoke/test_smoke.py
@@ -11,7 +11,6 @@ from virtwho import logger
 @pytest.mark.usefixtures('globalconf_clean')
 @pytest.mark.usefixtures('hypervisor_create')
 class TestSmoke:
-    @pytest.mark.notLocal
     def test_host_guest_association(self, virtwho, satellite, hypervisor_data,
                                     register_data, sm_guest, ssh_guest):
         """Test the host-to-guest association in mapping log and Satellite
@@ -90,7 +89,6 @@ class TestSmoke:
             assert (result['send'] == 1
                     and result['error'] == 0)
 
-    @pytest.mark.notLocal
     def test_rhsm_proxy(self, virtwho, hypervisor, proxy_data, register_data):
         """Test the rhsm_proxy in /etc/virt-who.d/hypervisor.conf
 
@@ -139,7 +137,6 @@ class TestSmoke:
         hypervisor.delete('rhsm_proxy_port')
         hypervisor.delete('rhsm_proxy_hostname')
 
-    @pytest.mark.notLocal
     def test_hypervisor_id(self, virtwho, debug_true,
                            hypervisor, hypervisor_data):
         """Test hypervisor_id option in /etc/virt-who.d/hypervisor.conf

--- a/tests/smoke/test_smoke.py
+++ b/tests/smoke/test_smoke.py
@@ -5,7 +5,7 @@
 :caseautomation: Automated
 """
 import pytest
-from virtwho import logger, REGISTER
+from virtwho import logger
 
 
 @pytest.mark.usefixtures('globalconf_clean')


### PR DESCRIPTION
- [x] test_hypervisor_id, will update this case again after the related functions ready.
- [x] test_vdc_sku
- [x] test_temporary_sku

**Test Result**
```
# pytest --disable-warnings -v tests/smoke/test_smoke.py
================== test session starts ===================================
platform linux -- Python 3.9.9, pytest-6.2.5, py-1.10.0, pluggy-1.0.0 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /root/workspace/virtwho-test, configfile: pytest.ini
collected 6 items                                                                                                                                

tests/smoke/test_smoke.py::TestSmoke::test_host_guest_association PASSED                                                                   [ 16%]
tests/smoke/test_smoke.py::TestSmoke::test_rhsm_options PASSED                                                                             [ 33%]
tests/smoke/test_smoke.py::TestSmoke::test_rhsm_proxy PASSED                                                                               [ 50%]
tests/smoke/test_smoke.py::TestSmoke::test_hypervisor_id PASSED                                                                            [ 66%]
tests/smoke/test_smoke.py::TestSmoke::test_vdc_sku PASSED                                                                                  [ 83%]
tests/smoke/test_smoke.py::TestSmoke::test_temporary_sku PASSED                                                                            [100%]

```