### PR TITLE
Define test_sca.py with test_hypervisor_facts/host_to_guest_association/guest_entitlement_status

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -145,20 +145,32 @@ def hypervisor_data(ssh_guest):
     data['guest_ip'] = hypervisor_handler.guest_ip
     data['guest_uuid'] = hypervisor_handler.guest_uuid
     data['guest_hostname'] = hostname_get(ssh_guest)
-    data['hypervisor_uuid'] = ''
-    data['hypervisor_hostname'] = ''
     data['hypervisor_hwuuid'] = ''
+    data['cluster'] = ''
     if HYPERVISOR == 'esx':
         data['hypervisor_uuid'] = hypervisor_handler.esx_uuid
         data['hypervisor_hostname'] = hypervisor_handler.esx_hostname
         data['hypervisor_hwuuid'] = hypervisor_handler.esx_hwuuid
+        data['type'] = hypervisor_handler.esx_type
+        data['version'] = hypervisor_handler.esx_version
+        data['cpu'] = hypervisor_handler.esx_cpu
+        data['cluster'] = hypervisor_handler.esx_cluster
     elif HYPERVISOR == 'rhevm':
         data['hypervisor_uuid'] = hypervisor_handler.vdsm_uuid
         data['hypervisor_hostname'] = hypervisor_handler.vdsm_hostname
         data['hypervisor_hwuuid'] = hypervisor_handler.vdsm_hwuuid
+        data['type'] = hypervisor_handler.vdsm_type
+        data['version'] = hypervisor_handler.vdsm_version
+        data['cpu'] = hypervisor_handler.vdsm_cpu
+        data['cluster'] = hypervisor_handler.vdsm_cluster
     else:
         data['hypervisor_uuid'] = hypervisor_handler.uuid
         data['hypervisor_hostname'] = hypervisor_handler.hostname
+        data['type'] = hypervisor_handler.type
+        data['version'] = hypervisor_handler.version
+        data['cpu'] = hypervisor_handler.cpu
+    if HYPERVISOR == 'ahv':
+        data['cluster'] = hypervisor_handler.cluster
     return data
 
 

--- a/tests/sca/test_sca.py
+++ b/tests/sca/test_sca.py
@@ -1,0 +1,145 @@
+"""Test cases Global fields
+
+:casecomponent: virt-who
+:testtype: functional
+:caseautomation: Automated
+"""
+import pytest
+from virtwho.settings import config
+from virtwho import REGISTER, HYPERVISOR
+from virtwho.register import Satellite, RHSM
+
+if REGISTER == 'satellite':
+    register = Satellite(
+        server=config.satellite.server,
+        org=config.satellite.default_org,
+        activation_key=config.satellite.activation_key
+    )
+else:
+    register = RHSM()
+
+
+@pytest.fixture(scope='class')
+def sca_enable():
+    """Enable SCA mode before run test cases"""
+    register.sca(sca='enable')
+
+
+@pytest.fixture(scope='class')
+def sca_disable():
+    """Disable SCA mode after finished all test cases"""
+    yield
+    register.sca(sca='disable')
+
+
+@pytest.mark.usefixtures('globalconf_clean')
+@pytest.mark.usefixtures('hypervisor_create')
+@pytest.mark.usefixtures('debug_true')
+@pytest.mark.usefixtures('sca_enable')
+@pytest.mark.usefixtures('sca_disable')
+class TestSCA:
+    def test_hypervisor_facts(self, virtwho, hypervisor, hypervisor_data,
+                              register_data):
+        """Test the hypervisor facts in mapping
+
+        :title: virt-who: sca: test hypervisor facts
+        :id: d0ca112a-6965-4334-8b41-410bb4c74e0c
+        :caseimportance: High
+        :tags: tier1
+        :customerscenario: false
+        :upstream: no
+        :steps:
+            1. Run virt-who to get the mapping
+            2. Check the hypervisor facts
+        :expectedresults:
+            1. virt-who can get and send maping successfully
+            2. the hypervisor facts of type, version, socket, dmi and cluster
+                are expected.
+        """
+        register_org = register_data['default_org']
+        hypervisor_hostname = hypervisor_data['hypervisor_hostname']
+        result = virtwho.run_cli()
+        assert (result['send'] == 1
+                and result['error'] == 0)
+
+        facts = result['mappings'][register_org][hypervisor_hostname]
+        assert (facts['type'] == hypervisor_data['type']
+                and facts['version'] == hypervisor_data['version']
+                and facts['socket'] == hypervisor_data['cpu']
+                and facts['dmi'] == hypervisor_data['hypervisor_uuid'])
+        if HYPERVISOR in ['esx', 'rhevm', 'ahv']:
+            assert facts['cluster'] == hypervisor_data['cluster']
+
+    def test_host_to_guest_association(self, virtwho, sm_guest, ssh_guest,
+                                       register_data, hypervisor_data,
+                                       register_guest):
+        """Test the host-to-guest association in mapping log and register server
+        Web UI.
+
+        :title: virt-who: sca: test host-to-guest association
+        :id: 044a7c1b-92cb-43a0-a790-f81279e09a8b
+        :caseimportance: High
+        :tags: tier1
+        :customerscenario: false
+        :upstream: no
+        :steps:
+            1. run virt-who against Satellite/RHSM
+            2. assert the association in mapping
+            3. assert the association in Satellite/RHSM WebUI
+        :expectedresults:
+            1. the host and guest are associated in the both mapping
+            and register server WebUI
+        """
+        guest_uuid = hypervisor_data['guest_uuid']
+        guest_hostname = hypervisor_data['guest_hostname']
+        hypervisor_hostname = hypervisor_data['hypervisor_hostname']
+        default_org = register_data['default_org']
+        # assert the association in mapping
+        result = virtwho.run_cli()
+        mappings = result['mappings']
+        associated_hypervisor_in_mapping = mappings[default_org][guest_uuid][
+            'guest_hypervisor']
+        assert (result['send'] == 1
+                and result['error'] == 0
+                and associated_hypervisor_in_mapping == hypervisor_hostname)
+        # assert the association in Satellite web
+        if REGISTER == 'satellite':
+            assert register.associate(hypervisor_hostname,
+                                      guest_hostname) is not False
+        else:
+            assert register.associate(hypervisor_hostname,
+                                      guest_uuid) is not False
+
+    def test_guest_entitlement_status(self, ssh_guest, register_guest):
+        """Test the guest entitlement status.
+
+        :title: virt-who: sca: test guest entitlement status
+        :id: 7192ed31-a6fc-4cef-a7f3-7d19bdc2581f
+        :caseimportance: High
+        :tags: tier1
+        :customerscenario: false
+        :upstream: no
+        :steps:
+            1. register guest and check the #subscription-manager status
+        :expectedresults:
+            get the output with 'Content Access Mode is set to Simple Content
+            Access'
+        """
+        ret, output = ssh_guest.runcmd('subscription-manager status')
+        assert ('Content Access Mode is set to Simple Content Access' in output)
+
+    def test_hypervisor_status(self, virtwho):
+        """Test the hypervisor status in register server.
+
+        :title: virt-who: sca: test hypervisor status
+        :id: 15a23e94-934f-462e-b190-2942b33d6418
+        :caseimportance: High
+        :tags: tier1
+        :customerscenario: false
+        :upstream: no
+        :steps:
+            1.
+        :expectedresults:
+            1.
+        """
+        pass

--- a/tests/sca/test_sca.py
+++ b/tests/sca/test_sca.py
@@ -104,11 +104,9 @@ class TestSCA:
                 and associated_hypervisor_in_mapping == hypervisor_hostname)
         # assert the association in Satellite web
         if REGISTER == 'satellite':
-            assert register.associate(hypervisor_hostname,
-                                      guest_hostname) is not False
+            assert register.associate(hypervisor_hostname, guest_hostname)
         else:
-            assert register.associate(hypervisor_hostname,
-                                      guest_uuid) is not False
+            assert register.associate(hypervisor_hostname, guest_uuid)
 
     def test_guest_entitlement_status(self, ssh_guest, register_guest,
                                       hypervisor_data):

--- a/tests/sca/test_sca.py
+++ b/tests/sca/test_sca.py
@@ -110,7 +110,8 @@ class TestSCA:
             assert register.associate(hypervisor_hostname,
                                       guest_uuid) is not False
 
-    def test_guest_entitlement_status(self, ssh_guest, register_guest):
+    def test_guest_entitlement_status(self, ssh_guest, register_guest,
+                                      hypervisor_data):
         """Test the guest entitlement status.
 
         :title: virt-who: sca: test guest entitlement status
@@ -120,26 +121,50 @@ class TestSCA:
         :customerscenario: false
         :upstream: no
         :steps:
-            1. register guest and check the #subscription-manager status
+            1. register guest
+            2. check the #subscription-manager status
+            3. try to auto-attach subscription for guest
         :expectedresults:
-            get the output with 'Content Access Mode is set to Simple Content
-            Access'
+            1. get the output with 'Content Access Mode is set to Simple Content
+                Access' by #subscription-manager status
+            2. get the 'This host's organization is in Simple Content Access
+                mode. Auto-attach is disabled'
         """
         ret, output = ssh_guest.runcmd('subscription-manager status')
         assert ('Content Access Mode is set to Simple Content Access' in output)
 
-    def test_hypervisor_status(self, virtwho):
-        """Test the hypervisor status in register server.
+        guest_hostname = hypervisor_data['guest_hostname']
+        if 'satellite' in REGISTER:
+            msg = "This host's organization is in Simple Content Access mode." \
+                  " Auto-attach is disabled"
+            result = register.attach(host=guest_hostname)
+            assert msg in result
+        else:
+            # pending on bz2108415
+            pass
 
-        :title: virt-who: sca: test hypervisor status
+    def test_hypervisor_entitlement_status(self, virtwho, hypervisor_data):
+        """Test the hypervisor entitlement status.
+
+        :title: virt-who: sca: test hypervisor entilement status
         :id: 15a23e94-934f-462e-b190-2942b33d6418
         :caseimportance: High
         :tags: tier1
         :customerscenario: false
         :upstream: no
         :steps:
-            1.
+            1. run virt-who to report mappings
+            2. try to auto-attach subscription for hypervisor
         :expectedresults:
-            1.
+            get the 'This host's organization is in Simple Content Access
+                mode. Auto-attach is disabled'
         """
-        pass
+        hypervisor_hostname = hypervisor_data['hypervisor_hostname']
+        if 'satellite' in REGISTER:
+            msg = "This host's organization is in Simple Content Access mode." \
+                  " Auto-attach is disabled"
+            result = register.attach(host=hypervisor_hostname)
+            assert msg in result
+        else:
+            # pending on bz2108415
+            pass

--- a/virtwho/register.py
+++ b/virtwho/register.py
@@ -661,7 +661,7 @@ class Satellite:
         :param host: host name/uuid/hwuuid
         :param pool: pool id, run auto attach when pool=None.
         :param quantity: the subscription quantity to attach.
-        :return: True or raise Fail.
+        :return: True, output or raise Fail.
         """
         host_id = self.host_id(host)
         cmd = f'hammer host subscription auto-attach --host-id {host_id}'
@@ -677,6 +677,11 @@ class Satellite:
         if ret == 0 and msg in output:
             logger.info(f'Succeeded to attach subscription for {host}')
             return True
+        elif (ret != 0 and "This host's organization is in Simple Content "
+                           "Access mode" in output):
+            logger.info(f'The organizaiton is in SCA mode, no need to '
+                        f'attach subscription')
+            return output
         raise FailException(f'Failed to attach subscription for {host}')
 
     def unattach(self, host, pool, quantity=1):

--- a/virtwho/register.py
+++ b/virtwho/register.py
@@ -838,6 +838,7 @@ class Satellite:
             if guest.lower() in str(output):
                 logger.info(
                     'Succeeded to find the associated guest in hypervisor page')
+
             else:
                 logger.warning(
                     'Failed to find the associated guest in hypervisor page')
@@ -852,6 +853,7 @@ class Satellite:
                 logger.warning(
                     'Failed to find the associated hypervisor in guest page')
                 return False
+            return True
 
     def sca(self, sca='disable'):
         """

--- a/virtwho/register.py
+++ b/virtwho/register.py
@@ -868,20 +868,52 @@ class Satellite:
 
 
 def request_get(url, auth, verify=False):
+    """Sends a GET request.
+    :param url: API URL
+    :param auth: authentication with format (username, password)
+    :param verify: a boolean to control whether we verify the server's
+        TLS certificate
+    :return: response status code and json output.
+    """
     res = requests.get(url=url, auth=auth, verify=verify)
     return res.status_code, res.json()
 
 
 def request_post(url, auth, params, verify=False):
+    """Sends a POST request.
+    :param url: API URL
+    :param auth: authentication with format (username, password)
+    :param params: Dictionary, list of tuples or bytes to send
+        in the query string
+    :param verify: a boolean to control whether we verify the server's
+        TLS certificate
+    :return: response status code
+    """
     res = requests.post(url=url, auth=auth, params=params, verify=verify)
     return res.status_code
 
 
 def request_put(url, auth, headers, json_data, verify=False):
+    """Sends a PUT request.
+    :param url: API URL
+    :param auth: authentication with format (username, password)
+    :param headers: dictionary of HTTP Headers
+    :param json_data: json data to send in the body
+    :param verify: a boolean to control whether we verify the server's
+        TLS certificate
+    :return: response status code
+    """
     res = requests.put(url=url, auth=auth, headers=headers, json=json_data, verify=verify)
     return res.status_code
 
 
 def request_delete(url, auth, verify=False):
+    """Sends a DELETE request.
+    :param url: API URL
+    :param auth: authentication with format (username, password)
+    :param verify: a boolean to control whether we verify the server's
+        TLS certificate
+    :return: response status code
+    """
     res = requests.delete(url=url, auth=auth, verify=verify)
     return res.status_code

--- a/virtwho/register.py
+++ b/virtwho/register.py
@@ -318,12 +318,6 @@ class RHSM:
         self.org = config.rhsm.default_org
         self.api = f'https://{config.rhsm.server}/subscription'
         self.auth = (config.rhsm.username, config.rhsm.password)
-        # self.headers = '-H "accept: application/json" ' \
-        #                '-H "Content-Type: application/json"'
-        # self.headers = {
-        #     'accept': 'application/json',
-        #     'Content-Type': 'application/json',
-        # }
 
     def consumers(self, host_name=None):
         """


### PR DESCRIPTION
**Description**
- [x] test_hypervisor_facts
- [x] test_host_to_guest_association
- [x] test_guest_entitlement_status
- [x] test_hypervisor_entitlement_status


**Test Result**
```
# pytest --disable-warnings -v tests/sca/test_sca.py
================== test session starts ========================
platform linux -- Python 3.9.9, pytest-6.2.5, py-1.10.0, pluggy-1.0.0 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /root/workspace/virtwho-test, configfile: pytest.ini
collected 4 items                                                                                                                                

tests/sca/test_sca.py::TestSCA::test_hypervisor_facts PASSED                            [ 25%]
tests/sca/test_sca.py::TestSCA::test_host_to_guest_association PASSED            [ 50%]
tests/sca/test_sca.py::TestSCA::test_guest_entitlement_status PASSED              [ 75%]
tests/sca/test_sca.py::TestSCA::test_hypervisor_entitlement_status PASSED                         [100%]

================ 4 passed, 1 warning in 172.69s (0:02:52) ======================
```