### PR TITLE
Define the virtwho_hypervisor.py for libvirt mode

### DIFF
--- a/virtwho/provision/virtwho_hypervisor.py
+++ b/virtwho/provision/virtwho_hypervisor.py
@@ -1,0 +1,134 @@
+#!/usr/bin/python
+import os
+import sys
+import argparse
+
+curPath = os.path.abspath(os.path.dirname(__file__))
+rootPath = os.path.split(curPath)[0]
+sys.path.append(os.path.split(rootPath)[0])
+
+from virtwho import logger, FailException
+from virtwho.settings import config
+from hypervisor.virt.libvirt.libvirtcli import LibvirtCLI
+from virtwho.ssh import SSHConnect
+from virtwho.base import hostname_get
+from utils.properties_update import virtwho_ini_props_update
+
+
+def libvirt_test(args):
+    """
+    """
+    logger.info(f'+++ Start to test the Libvirt Environment +++')
+    status = 'GOOD'
+    server = config.libvirt.server
+    username = config.libvirt.username
+    password = config.libvirt.password
+    uuid = config.libvirt.uuid
+    hostname = config.libvirt.hostname
+    version = config.libvirt.version
+    cpu = config.libvirt.cpu
+    guest_ip = config.libvirt.guest_ip
+    guest_uuid = config.libvirt.guest_uuid
+    guest_name = config.libvirt.guest_name
+    data = {}
+    libvirt = LibvirtCLI(
+        server=server,
+        ssh_user=username,
+        ssh_passwd=password
+    )
+    ssh_libvirt = SSHConnect(
+        host=server,
+        user=username,
+        pwd=password
+    )
+    try:
+        logger.info(f'>>>Libvirt: Check if the libvirt host is running.')
+        ret = os.system(f'ping -c 2 -w 5 {server}')
+        if ret != 0:
+            status, server, guest_ip, guest_uuid = \
+                'BAD (Server Down)', 'Down', 'None', 'None'
+            raise FailException(
+                f'The libvirt host has broken, please repaire it.'
+            )
+
+        logger.info(f'>>>Libvirt: Check the rhel guest exist or not.')
+        ret = libvirt.guest_exist(guest_name)
+        if not ret:
+            logger.warning(f'Did not find the rhel guest ({guest_name}), '
+                           f'will deploy a new one.')
+            # libvirt.guest_add(args.guest_name)
+
+        logger.info(f'>>>Libvirt: Check the rhel guest status.')
+        guest_status = libvirt.guest_status(guest_name)
+        if guest_status == 'running':
+            logger.info(f'The rhel guest({guest_name}) is running well.')
+        if guest_status == 'paused':
+            logger.info(f'The rhel guest({guest_name}) is paused, '
+                        f'will resume it.')
+            ret = libvirt.guest_resume(guest_name)
+            if ret is False:
+                status, guest_ip, guest_uuid = \
+                    'BAD (Guest Broke)', 'None', 'None'
+                raise FailException(f'Failed to resume the rhel guest'
+                                    f'({guest_name}) from paused status.')
+        if guest_status in ['shut off', 'false']:
+            logger.info(f'The rhel guest({guest_name}) was down, '
+                        f'will start it.')
+            ret = libvirt.guest_start(guest_name)
+            if ret is False:
+                status, guest_ip, guest_uuid = \
+                    'BAD (Guest Broke)', 'None', 'None'
+                raise FailException(f'Failed to start the rhel guest'
+                                    f'({guest_name}) from shut off status.')
+
+        logger.info(f'>>>Libvirt: Get the hypervisor and guest data.')
+        data = libvirt.guest_search(guest_name)
+        logger.info(f'=== Succeeded to get the libvirt data\n{data}\n===')
+
+    finally:
+        logger.info(f'>>>Libvirt: Compare and update the data.')
+        libvirt_dict = {
+            'status': status,
+            'server': server,
+            'guest_ip': guest_ip,
+        }
+        if data:
+            compare_dict = {
+                'uuid': [uuid, data['host_uuid']],
+                'hostname': [hostname, hostname_get(ssh_libvirt)],
+                'version': [version, data['host_version']],
+                'cpu': [cpu, data['host_cpu']],
+                'guest_ip': [guest_ip, data['guest_ip']],
+                'guest_uuid': [guest_uuid, data['guest_uuid']]
+            }
+            for key, value in compare_dict.items():
+                if value[0] != value[1]:
+                    logger.info(f'The libvirt {key} changed.')
+                    libvirt_dict['status'] = 'UPDATED'
+                    libvirt_dict[key] = f'{value[1]} (Updated)'
+        for (args.option, args.value) in libvirt_dict.items():
+            args.section = 'libvirt'
+            virtwho_ini_props_update(args)
+
+
+def arguments_parser():
+    """
+    Parse and convert the arguments from command line to parameters
+    for function using, and generate help and usage messages for
+    each arguments.
+    """
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest='command')
+    # libvirt
+    subparsers.add_parser(
+        'libvirt',
+        help='Test the libvirt environment')
+
+    # esx
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    args = arguments_parser()
+    if args.command == 'libvirt':
+        libvirt_test(args)

--- a/virtwho/provision/virtwho_hypervisor.py
+++ b/virtwho/provision/virtwho_hypervisor.py
@@ -88,7 +88,6 @@ def libvirt_test(args):
     finally:
         logger.info(f'>>>Libvirt: Compare and update the data.')
         libvirt_dict = {
-            'status': status,
             'server': server,
             'guest_ip': guest_ip,
         }
@@ -104,8 +103,12 @@ def libvirt_test(args):
             for key, value in compare_dict.items():
                 if value[0] != value[1]:
                     logger.info(f'The libvirt {key} changed.')
-                    libvirt_dict['status'] = 'UPDATED'
                     libvirt_dict[key] = f'{value[1]} (Updated)'
+                    status = 'UPDATED'
+        args.section, args.option, args.value = (
+            'status', 'libvirt', status
+        )
+        virtwho_ini_props_update(args)
         for (args.option, args.value) in libvirt_dict.items():
             args.section = 'libvirt'
             virtwho_ini_props_update(args)
@@ -125,6 +128,7 @@ def arguments_parser():
         help='Test the libvirt environment')
 
     # esx
+    # pending
     return parser.parse_args()
 
 


### PR DESCRIPTION
**Description**

- This file will used to manage and check all the hypervisor status by command `#virtwho_hypervisor.py {hypervisor mode}`, it will help to get all the test necessary values in virtwho.ini file, including host server, uuid, hostname, version, cpu, guest_ip and guest_uuid.

- If the hypervisor server or guest down, will update the `status = BAD (Server Down)`/`status = BAD (Guest Broke)` and `server=Down`
- If the guest pause, will try to resume it
- If the guest shut off, will try to start it
- If failed to start the guest, will mark `guest_ip=None`
- If any value changed, will give log warning and updated the virtwho.ini file to `guest_ip=10.10.10.10 (Updated)`


**Test Result**
```
# python3 virtwho/provision/virtwho_hypervisor.py libvirt
[2022-08-11 11:07:37] - [virtwho_hypervisor.py] - INFO: +++ Start to test the Libvirt Environment +++
[2022-08-11 11:07:37] - [virtwho_hypervisor.py] - INFO: >>>Libvirt: Check if the libvirt host is running.
PING 10.66.144.3 (10.66.144.3) 56(84) bytes of data.
64 bytes from 10.66.144.3: icmp_seq=1 ttl=58 time=47.3 ms
64 bytes from 10.66.144.3: icmp_seq=2 ttl=58 time=54.7 ms

--- 10.66.144.3 ping statistics ---
2 packets transmitted, 2 received, 0% packet loss, time 1002ms
rtt min/avg/max/mdev = 47.333/51.037/54.741/3.704 ms
[2022-08-11 11:07:38] - [virtwho_hypervisor.py] - INFO: >>>Libvirt: Check the rhel guest exist or not.
[2022-08-11 11:07:38] - [ssh.py] - INFO: >>> virsh  dominfo 9.0_Server_x86_64 | grep '^Name'
[2022-08-11 11:07:39] - [ssh.py] - INFO: <<< stdout
Name:           9.0_Server_x86_64

[2022-08-11 11:07:39] - [libvirtcli.py] - INFO: libvirt(10.66.144.3) guest 9.0_Server_x86_64 is exist
[2022-08-11 11:07:39] - [virtwho_hypervisor.py] - INFO: >>>Libvirt: Check the rhel guest status.
[2022-08-11 11:07:40] - [ssh.py] - INFO: >>> virsh  domstate 9.0_Server_x86_64
[2022-08-11 11:07:40] - [ssh.py] - INFO: <<< stdout
running


[2022-08-11 11:07:40] - [libvirtcli.py] - INFO: libvirt(10.66.144.3) guest status is: running
[2022-08-11 11:07:40] - [virtwho_hypervisor.py] - INFO: The rhel guest(9.0_Server_x86_64) is running well.
[2022-08-11 11:07:40] - [virtwho_hypervisor.py] - INFO: >>>Libvirt: Get the hypervisor and guest data.
[2022-08-11 11:07:41] - [ssh.py] - INFO: >>> ip route | grep 10.66.144.3
[2022-08-11 11:07:41] - [ssh.py] - INFO: <<< stdout
10.66.144.0/22 dev br0 proto kernel scope link src 10.66.144.3 metric 425 

[2022-08-11 11:07:42] - [ssh.py] - INFO: >>> virsh dumpxml 9.0_Server_x86_64 | grep 'mac address'
[2022-08-11 11:07:42] - [ssh.py] - INFO: <<< stdout
      <mac address='52:54:00:56:ea:b9'/>

[2022-08-11 11:07:42] - [libvirtcli.py] - INFO: Succeeded to get libvirt(10.66.144.3) guest mac: 52:54:00:56:ea:b9
[2022-08-11 11:07:43] - [ssh.py] - INFO: >>> nmap -sP -n 10.66.144.0/22 | grep -i -B 2 52:54:00:56:ea:b9 | grep 'Nmap scan report for' | grep -Eo '([0-9]{1,3}[\.]){3}[0-9]{1,3}'| tail -1
[2022-08-11 11:08:07] - [ssh.py] - INFO: <<< stdout
10.66.144.230

[2022-08-11 11:08:07] - [libvirtcli.py] - INFO: Succeeded to get libvirt guest ip (10.66.144.230)
[2022-08-11 11:08:08] - [ssh.py] - INFO: >>> virsh domuuid 9.0_Server_x86_64
[2022-08-11 11:08:08] - [ssh.py] - INFO: <<< stdout
04f63d62-6810-45a7-98f2-12c35ae5848d


[2022-08-11 11:08:08] - [libvirtcli.py] - INFO: Succeeded to get libvirt(10.66.144.3) guest uuid: 04f63d62-6810-45a7-98f2-12c35ae5848d
[2022-08-11 11:08:09] - [ssh.py] - INFO: >>> virsh  domstate 9.0_Server_x86_64
[2022-08-11 11:08:09] - [ssh.py] - INFO: <<< stdout
running


[2022-08-11 11:08:09] - [libvirtcli.py] - INFO: libvirt(10.66.144.3) guest status is: running
[2022-08-11 11:08:10] - [ssh.py] - INFO: >>> virsh capabilities |grep '<uuid>'
[2022-08-11 11:08:10] - [ssh.py] - INFO: <<< stdout
    <uuid>7cc23a00-28ed-11e2-8973-10604b5b2b19</uuid>

[2022-08-11 11:08:10] - [libvirtcli.py] - INFO: Succeeded to get libvirt host(10.66.144.3) uuid is: 7cc23a00-28ed-11e2-8973-10604b5b2b19
[2022-08-11 11:08:11] - [ssh.py] - INFO: >>> virsh version |grep 'Running hypervisor'
[2022-08-11 11:08:11] - [ssh.py] - INFO: <<< stdout
Running hypervisor: QEMU 7.0.0

[2022-08-11 11:08:11] - [libvirtcli.py] - INFO: Succeeded to get libvirt host(10.66.144.3) version is: 7.0.0
[2022-08-11 11:08:12] - [ssh.py] - INFO: >>> virsh nodeinfo  |grep 'CPU socket(s)'
[2022-08-11 11:08:12] - [ssh.py] - INFO: <<< stdout
CPU socket(s):       1

[2022-08-11 11:08:12] - [libvirtcli.py] - INFO: Succeeded to get libvirt host(10.66.144.3) cpu : 1
[2022-08-11 11:08:12] - [virtwho_hypervisor.py] - INFO: === Succeeded to get the libvirt data
{'guest_name': '9.0_Server_x86_64', 'guest_ip': '10.66.144.230', 'guest_uuid': '04f63d62-6810-45a7-98f2-12c35ae5848d', 'guest_state': 'running', 'host_uuid': '7cc23a00-28ed-11e2-8973-10604b5b2b19', 'host_version': '7.0.0', 'host_cpu': '1'}
===
[2022-08-11 11:08:12] - [virtwho_hypervisor.py] - INFO: >>>Libvirt: Compare and update the data.
[2022-08-11 11:08:13] - [ssh.py] - INFO: >>> hostname
[2022-08-11 11:08:13] - [ssh.py] - INFO: <<< stdout
hp-z220-05.qe.lab.eng.nay.redhat.com

[2022-08-11 11:08:13] - [virtwho_hypervisor.py] - INFO: The libvirt uuid changed.
[2022-08-11 11:08:13] - [virtwho_hypervisor.py] - INFO: The libvirt hostname changed.
[2022-08-11 11:08:13] - [virtwho_hypervisor.py] - INFO: The libvirt version changed.
[2022-08-11 11:08:13] - [virtwho_hypervisor.py] - INFO: The libvirt cpu changed.
[2022-08-11 11:08:13] - [virtwho_hypervisor.py] - INFO: The libvirt guest_ip changed.
[2022-08-11 11:08:13] - [virtwho_hypervisor.py] - INFO: The libvirt guest_uuid changed.

```