### PR TITLE
Fix the hypervisor.version type issue and remove 'raise Fail' from each step.

### DIFF
--- a/virtwho/runner.py
+++ b/virtwho/runner.py
@@ -455,7 +455,7 @@ class VirtwhoRunner:
                     facts = dict()
                     facts['name'] = hypervisor_name
                     facts['type'] = item['facts']['hypervisor.type']
-                    facts['version'] = item['facts']['hypervisor.version']
+                    facts['version'] = str(item['facts']['hypervisor.version'])
                     facts['socket'] = item['facts']['cpu.cpu_socket(s)']
                     facts['dmi'] = item['facts']['dmi.system.uuid']
                     if 'hypervisor.cluster' in item['facts'].keys():


### PR DESCRIPTION
**Description**

- [x] Fix the the hypervisor.version type issue, the version got from mapping is a Integer type, but we need a String to support the assert in test cases because all the values defined in virtwho.ini are string.
- [x] Change the `raise Fail` to `logger error` because the raise fail will make the test stop and failed to get the necessary info to configure the email html. 

**Test Result**
```
# pytest --disable-warnings -v tests/sca/test_sca.py -k test_hypervisor_facts
====================== test session starts ======================
platform linux -- Python 3.9.9, pytest-6.2.5, py-1.10.0, pluggy-1.0.0 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /root/workspace/virtwho-test, configfile: pytest.ini
collected 4 items / 3 deselected / 1 selected                                                                                                    

tests/sca/test_sca.py::TestSCA::test_hypervisor_facts PASSED             [100%]

================= 1 passed, 3 deselected, 1 warning in 65.78s (0:01:05) ==========
```
 