### PR TITLE
add the test_encrypted_password case for the esx hypervisor

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -198,6 +198,8 @@ def hypervisor_data(ssh_guest):
         data['cpu'] = hypervisor_handler.cpu
     if HYPERVISOR == 'ahv':
         data['cluster'] = hypervisor_handler.cluster
+    if HYPERVISOR is not 'kubevirt':
+        data['hypervisor_password'] = hypervisor_handler.password
     return data
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,10 +3,10 @@ import pytest
 from virtwho.settings import config
 from virtwho.runner import VirtwhoRunner
 from virtwho.configure import VirtwhoSysConfig
-from virtwho.configure import VirtwhoHypervisorConfig
 from virtwho.configure import VirtwhoGlobalConfig
 from virtwho.configure import get_hypervisor_handler, virtwho_ssh_connect
 from virtwho.configure import get_register_handler
+from virtwho.configure import hypervisor_create
 from virtwho.ssh import SSHConnect
 from virtwho.register import SubscriptionManager, Satellite, RHSM
 from virtwho import HYPERVISOR, REGISTER, RHEL_COMPOSE, FailException, logger
@@ -19,15 +19,13 @@ register_handler = get_register_handler(REGISTER)
 @pytest.fixture(scope='class')
 def hypervisor():
     """Instantication of class VirtwhoHypervisorConfig()"""
-    VirtwhoHypervisorConfig(HYPERVISOR, REGISTER).create(rhsm=True)
-    return VirtwhoHypervisorConfig(HYPERVISOR, REGISTER)
+    return hypervisor_create(HYPERVISOR, REGISTER)
 
 
 @pytest.fixture(scope='function')
-def function_hypervisor(config_name=None):
+def function_hypervisor():
     """Create virt-who hypervisor test file with all rhsm options"""
-    VirtwhoHypervisorConfig(HYPERVISOR, REGISTER, config_name).create()
-    return VirtwhoHypervisorConfig(HYPERVISOR, REGISTER, config_name)
+    return hypervisor_create(HYPERVISOR, REGISTER)
 
 
 @pytest.fixture(scope='session')

--- a/tests/hypervisor/conftest.py
+++ b/tests/hypervisor/conftest.py
@@ -1,5 +1,9 @@
 import pytest
 
+from virtwho import HYPERVISOR, FailException, logger
+
+from virtwho.configure import virtwho_ssh_connect
+
 
 @pytest.fixture(scope='session')
 def esx_assertion():
@@ -48,8 +52,30 @@ def esx_assertion():
             'disable': 'Required option: "password" not set',
             'disable_multi_configs': 'Required option: "password" not set',
             'null_multi_configs': login_error,
+        },
+        'encrypted_password': {
+            'invalid': {
+                'xxx': 'Option "encrypted_password" cannot be decrypted',
+                '': 'Option "encrypted_password" cannot be decrypted',
+            },
+            'valid_multi_configs': 'Option "encrypted_password" cannot be decrypted'
         }
 
     }
 
     return data
+
+
+def encrypted_password(password):
+    cmd = f'virt-who-password -p {password} > /tmp/vw.log'
+    ret, output = virtwho_ssh_connect(HYPERVISOR).runcmd(cmd)
+    if ret == 0:
+        ret, output = virtwho_ssh_connect(HYPERVISOR).runcmd("cat /tmp/vw.log")
+        if output is not None and output != '':
+            encrypted_value = output.strip()
+            logger.info(f'Succeeded to get encrypted_password : {encrypted_value}')
+            return encrypted_value
+        else:
+            raise FailException("Failed to run virt-who-password")
+    else:
+        raise FailException("Failed to run virt-who-password")

--- a/tests/hypervisor/conftest.py
+++ b/tests/hypervisor/conftest.py
@@ -1,9 +1,5 @@
 import pytest
 
-from virtwho import HYPERVISOR, FailException, logger
-
-from virtwho.configure import virtwho_ssh_connect
-
 
 @pytest.fixture(scope='session')
 def esx_assertion():
@@ -64,18 +60,3 @@ def esx_assertion():
     }
 
     return data
-
-
-def encrypted_password(password):
-    cmd = f'virt-who-password -p {password} > /tmp/vw.log'
-    ret, output = virtwho_ssh_connect(HYPERVISOR).runcmd(cmd)
-    if ret == 0:
-        ret, output = virtwho_ssh_connect(HYPERVISOR).runcmd("cat /tmp/vw.log")
-        if output is not None and output != '':
-            encrypted_value = output.strip()
-            logger.info(f'Succeeded to get encrypted_password : {encrypted_value}')
-            return encrypted_value
-        else:
-            raise FailException("Failed to run virt-who-password")
-    else:
-        raise FailException("Failed to run virt-who-password")

--- a/tests/hypervisor/test_esx.py
+++ b/tests/hypervisor/test_esx.py
@@ -9,8 +9,8 @@ import pytest
 from virtwho import REGISTER
 from virtwho import RHEL_COMPOSE
 from virtwho import HYPERVISOR
-from virtwho import DEFAULT_HYPERVISOR_FILE
-from virtwho import SECTION_NAME
+from virtwho import SECOND_HYPERVISOR_FILE
+from virtwho import SECOND_HYPERVISOR_SECTION
 
 from virtwho.base import encrypt_password
 from virtwho.configure import hypervisor_create
@@ -143,7 +143,7 @@ class TestEsxNegative:
                 and assertion['disable'] in result['error_msg'])
 
         # type option is disable but another config is ok
-        hypervisor_create(HYPERVISOR, REGISTER, DEFAULT_HYPERVISOR_FILE, SECTION_NAME)
+        hypervisor_create(HYPERVISOR, REGISTER, SECOND_HYPERVISOR_FILE, SECOND_HYPERVISOR_SECTION)
         result = virtwho.run_service()
         assert (result['error'] is not 0
                 and result['send'] == 1
@@ -202,7 +202,7 @@ class TestEsxNegative:
                 and assertion['disable'] in result['error_msg'])
 
         # server option is disable but another config is ok
-        hypervisor_create(HYPERVISOR, REGISTER, DEFAULT_HYPERVISOR_FILE, SECTION_NAME)
+        hypervisor_create(HYPERVISOR, REGISTER, SECOND_HYPERVISOR_FILE, SECOND_HYPERVISOR_SECTION)
         result = virtwho.run_service()
         assert (result['error'] is not 0
                 and result['send'] == 1
@@ -260,7 +260,7 @@ class TestEsxNegative:
                 and assertion['disable'] in result['error_msg'])
 
         # username option is disable but another config is ok
-        hypervisor_create(HYPERVISOR, REGISTER, DEFAULT_HYPERVISOR_FILE, SECTION_NAME)
+        hypervisor_create(HYPERVISOR, REGISTER, SECOND_HYPERVISOR_FILE, SECOND_HYPERVISOR_SECTION)
         result = virtwho.run_service()
         assert (result['error'] is not 0
                 and result['send'] == 1
@@ -318,7 +318,7 @@ class TestEsxNegative:
                 and assertion['disable'] in result['error_msg'])
 
         # password option is disable but another config is ok
-        hypervisor_create(HYPERVISOR, REGISTER, DEFAULT_HYPERVISOR_FILE, SECTION_NAME)
+        hypervisor_create(HYPERVISOR, REGISTER, SECOND_HYPERVISOR_FILE, SECOND_HYPERVISOR_SECTION)
         result = virtwho.run_service()
         assert (result['error'] is not 0
                 and result['send'] == 1
@@ -366,7 +366,7 @@ class TestEsxNegative:
                     and assertion['invalid'][f'{value}'] in result['warning_msg'])
 
         # encrypted_password option is valid but another config is ok
-        hypervisor_create(HYPERVISOR, REGISTER, DEFAULT_HYPERVISOR_FILE, SECTION_NAME)
+        hypervisor_create(HYPERVISOR, REGISTER, SECOND_HYPERVISOR_FILE, SECOND_HYPERVISOR_SECTION)
         result = virtwho.run_service()
         assert (result['error'] is not 0
                 and result['send'] == 1

--- a/tests/hypervisor/test_esx.py
+++ b/tests/hypervisor/test_esx.py
@@ -9,6 +9,8 @@ import pytest
 from virtwho import REGISTER
 from virtwho import RHEL_COMPOSE
 from virtwho import HYPERVISOR
+from virtwho import DEFAULT_HYPERVISOR_FILE
+from virtwho import SECTION_NAME
 
 from virtwho.base import encrypt_password
 from virtwho.configure import hypervisor_create
@@ -17,7 +19,85 @@ from virtwho.configure import hypervisor_create
 @pytest.mark.usefixtures('function_virtwho_d_conf_clean')
 @pytest.mark.usefixtures('debug_true')
 @pytest.mark.usefixtures('globalconf_clean')
-class TestEsx:
+class TestEsxPositive:
+    @pytest.mark.tier1
+    def test_encrypted_password(self, virtwho, function_hypervisor,
+                                hypervisor_data, ssh_host):
+        """Test the encrypted_password= option in /etc/virt-who.d/test_esx.conf
+
+        :title: virt-who: esx: test encrypted_password option
+        :id: f07205a4-8f18-4c6b-8a2c-285664b59ed3
+        :caseimportance: High
+        :tags: tier2
+        :customerscenario: false
+        :upstream: no
+        :steps:
+            1. Delete the password option, encrypted password for the hypervisor.
+            2. Configure encrypted_password option with valid value, run the virt-who service.
+
+        :expectedresults:
+            2. Succeeded to run the virt-who, no error messages in the log info
+        """
+        # encrypted_password option is valid value
+        function_hypervisor.delete('password')
+        encrypted_pwd = encrypt_password(ssh_host, hypervisor_data['hypervisor_password'])
+        function_hypervisor.update('encrypted_password', encrypted_pwd)
+        result = virtwho.run_service()
+        assert (result['error'] == 0
+                and result['send'] == 1
+                and result['thread'] == 1)
+
+    @pytest.mark.tier1
+    def test_hypervisor_id(self, virtwho, function_hypervisor, hypervisor_data, globalconf, rhsm, satellite):
+        """Test the hypervisor_id= option in /etc/virt-who.d/hypervisor.conf
+
+        :title: virt-who: esx: test hypervisor_id function
+        :id: be5877d9-3a59-46aa-bd9a-6c1e3ed5f5ee
+        :caseimportance: High
+        :tags: tier1
+        :customerscenario: false
+        :upstream: no
+        :steps:
+
+            1. clean all virt-who global configurations
+            2. run virt-who with hypervisor_id=uuid
+            3. run virt-who with hypervisor_id=hostname
+            4. run virt-who with hypervisor_id=hwuuid
+
+        :expectedresults:
+
+            hypervisor id shows uuid/hostname/hwuuid in mapping as the setting.
+        """
+        hypervisor_ids = ['hostname', 'uuid', 'hwuuid']
+        for hypervisor_id in hypervisor_ids:
+            function_hypervisor.update('hypervisor_id', hypervisor_id)
+            result = virtwho.run_service()
+            assert (result['error'] == 0
+                    and result['send'] == 1
+                    and result['thread'] == 1
+                    and result['hypervisor_id'] == hypervisor_data[f'hypervisor_{hypervisor_id}'])
+            if REGISTER == 'rhsm':
+                assert rhsm.consumers(hypervisor_data['hypervisor_hostname'])
+                rhsm.delete(hypervisor_data['hypervisor_hostname'])
+            else:
+                if hypervisor_id == 'hostname':
+                    assert satellite.host_id(hypervisor_data['hypervisor_hostname'])
+                    assert not satellite.host_id(hypervisor_data['hypervisor_uuid'])
+                    assert not satellite.host_id(hypervisor_data['hypervisor_hwuuid'])
+                elif hypervisor_id == 'uuid':
+                    assert satellite.host_id(hypervisor_data['hypervisor_uuid'])
+                    assert not satellite.host_id(hypervisor_data['hypervisor_hostname'])
+                    assert not satellite.host_id(hypervisor_data['hypervisor_hwuuid'])
+                else:
+                    assert satellite.host_id(hypervisor_data['hypervisor_hwuuid'])
+                    assert not satellite.host_id(hypervisor_data['hypervisor_hostname'])
+                    assert not satellite.host_id(hypervisor_data['hypervisor_uuid'])
+
+
+@pytest.mark.usefixtures('function_virtwho_d_conf_clean')
+@pytest.mark.usefixtures('debug_true')
+@pytest.mark.usefixtures('globalconf_clean')
+class TestEsxNegative:
     @pytest.mark.tier2
     def test_type(self, virtwho, function_hypervisor, esx_assertion):
         """Test the type= option in /etc/virt-who.d/test_esx.conf
@@ -63,9 +143,7 @@ class TestEsx:
                 and assertion['disable'] in result['error_msg'])
 
         # type option is disable but another config is ok
-        new_file = '/etc/virt-who.d/new_config.conf'
-        section_name = 'virtwho-config'
-        hypervisor_create(HYPERVISOR, REGISTER, new_file, section_name)
+        hypervisor_create(HYPERVISOR, REGISTER, DEFAULT_HYPERVISOR_FILE, SECTION_NAME)
         result = virtwho.run_service()
         assert (result['error'] is not 0
                 and result['send'] == 1
@@ -124,9 +202,7 @@ class TestEsx:
                 and assertion['disable'] in result['error_msg'])
 
         # server option is disable but another config is ok
-        new_file = '/etc/virt-who.d/new_config.conf'
-        section_name = 'virtwho-config'
-        hypervisor_create(HYPERVISOR, REGISTER, new_file, section_name)
+        hypervisor_create(HYPERVISOR, REGISTER, DEFAULT_HYPERVISOR_FILE, SECTION_NAME)
         result = virtwho.run_service()
         assert (result['error'] is not 0
                 and result['send'] == 1
@@ -184,9 +260,7 @@ class TestEsx:
                 and assertion['disable'] in result['error_msg'])
 
         # username option is disable but another config is ok
-        new_file = '/etc/virt-who.d/new_config.conf'
-        section_name = 'virtwho-config'
-        hypervisor_create(HYPERVISOR, REGISTER, new_file, section_name)
+        hypervisor_create(HYPERVISOR, REGISTER, DEFAULT_HYPERVISOR_FILE, SECTION_NAME)
         result = virtwho.run_service()
         assert (result['error'] is not 0
                 and result['send'] == 1
@@ -244,9 +318,7 @@ class TestEsx:
                 and assertion['disable'] in result['error_msg'])
 
         # password option is disable but another config is ok
-        new_file = '/etc/virt-who.d/new_config.conf'
-        section_name = 'virtwho-config'
-        hypervisor_create(HYPERVISOR, REGISTER, new_file, section_name)
+        hypervisor_create(HYPERVISOR, REGISTER, DEFAULT_HYPERVISOR_FILE, SECTION_NAME)
         result = virtwho.run_service()
         assert (result['error'] is not 0
                 and result['send'] == 1
@@ -267,33 +339,22 @@ class TestEsx:
         """Test the encrypted_password= option in /etc/virt-who.d/test_esx.conf
 
         :title: virt-who: esx: test encrypted_password option
-        :id: f07205a4-8f18-4c6b-8a2c-285664b59ed3
+        :id: 5014c314-8d57-44ce-820b-6de88810044e
         :caseimportance: High
         :tags: tier2
         :customerscenario: false
         :upstream: no
         :steps:
-            1. Delete the password option, encrypted password for the hypervisor.
-            2. Configure encrypted_password option with valid value, run the virt-who service.
-            3. Configure password option with invalid value.
-            4. Create another valid config file, run the virt-who service
+            1. Configure password option with invalid value.
+            2. Create another valid config file, run the virt-who service
 
         :expectedresults:
-            2. Succeeded to run the virt-who, no error messages in the log info
-            3. Failed to run the virt-who service, find warning message:
+            1. Failed to run the virt-who service, find warning message:
             'Option "encrypted_password" cannot be decrypted'
-            4. Find warning message: 'Option "encrypted_password" cannot be decrypted'
+            2. Find warning message: 'Option "encrypted_password" cannot be decrypted'
         """
-        # encrypted_password option is valid value
-        function_hypervisor.delete('password')
-        encrypted_pwd = encrypt_password(ssh_host, hypervisor_data['hypervisor_password'])
-        function_hypervisor.update('encrypted_password', encrypted_pwd)
-        result = virtwho.run_service()
-        assert (result['error'] == 0
-                and result['send'] == 1
-                and result['thread'] == 1)
-
         # encrypted_password option is invalid value
+        function_hypervisor.delete('password')
         assertion = esx_assertion['encrypted_password']
         assertion_invalid_list = list(assertion['invalid'].keys())
         for value in assertion_invalid_list:
@@ -305,57 +366,9 @@ class TestEsx:
                     and assertion['invalid'][f'{value}'] in result['warning_msg'])
 
         # encrypted_password option is valid but another config is ok
-        new_file = '/etc/virt-who.d/new_config.conf'
-        section_name = 'virtwho-config'
-        hypervisor_create(HYPERVISOR, REGISTER, new_file, section_name)
+        hypervisor_create(HYPERVISOR, REGISTER, DEFAULT_HYPERVISOR_FILE, SECTION_NAME)
         result = virtwho.run_service()
         assert (result['error'] is not 0
                 and result['send'] == 1
                 and result['thread'] == 1
                 and assertion['valid_multi_configs'] in result['warning_msg'])
-
-    @pytest.mark.tier1
-    def test_hypervisor_id(self, virtwho, function_hypervisor, hypervisor_data, globalconf, rhsm, satellite):
-        """Test the hypervisor_id= option in /etc/virt-who.d/hypervisor.conf
-
-        :title: virt-who: esx: test hypervisor_id function
-        :id: be5877d9-3a59-46aa-bd9a-6c1e3ed5f5ee
-        :caseimportance: High
-        :tags: tier1
-        :customerscenario: false
-        :upstream: no
-        :steps:
-
-            1. clean all virt-who global configurations
-            2. run virt-who with hypervisor_id=uuid
-            3. run virt-who with hypervisor_id=hostname
-            4. run virt-who with hypervisor_id=hwuuid
-
-        :expectedresults:
-
-            hypervisor id shows uuid/hostname/hwuuid in mapping as the setting.
-        """
-        hypervisor_ids = ['hostname', 'uuid', 'hwuuid']
-        for hypervisor_id in hypervisor_ids:
-            function_hypervisor.update('hypervisor_id', hypervisor_id)
-            result = virtwho.run_service()
-            assert (result['error'] == 0
-                    and result['send'] == 1
-                    and result['thread'] == 1
-                    and result['hypervisor_id'] == hypervisor_data[f'hypervisor_{hypervisor_id}'])
-            if REGISTER == 'rhsm':
-                assert rhsm.consumers(hypervisor_data['hypervisor_hostname'])
-                rhsm.delete(hypervisor_data['hypervisor_hostname'])
-            else:
-                if hypervisor_id == 'hostname':
-                    assert satellite.host_id(hypervisor_data['hypervisor_hostname'])
-                    assert not satellite.host_id(hypervisor_data['hypervisor_uuid'])
-                    assert not satellite.host_id(hypervisor_data['hypervisor_hwuuid'])
-                elif hypervisor_id == 'uuid':
-                    assert satellite.host_id(hypervisor_data['hypervisor_uuid'])
-                    assert not satellite.host_id(hypervisor_data['hypervisor_hostname'])
-                    assert not satellite.host_id(hypervisor_data['hypervisor_hwuuid'])
-                else:
-                    assert satellite.host_id(hypervisor_data['hypervisor_hwuuid'])
-                    assert not satellite.host_id(hypervisor_data['hypervisor_hostname'])
-                    assert not satellite.host_id(hypervisor_data['hypervisor_uuid'])

--- a/tests/hypervisor/test_esx.py
+++ b/tests/hypervisor/test_esx.py
@@ -10,8 +10,8 @@ from virtwho import REGISTER
 from virtwho import RHEL_COMPOSE
 from virtwho import HYPERVISOR
 
-from virtwho.base import encrypted_password
-from virtwho.configure import VirtwhoHypervisorConfig
+from virtwho.base import encrypt_password
+from virtwho.configure import hypervisor_create
 
 
 @pytest.mark.usefixtures('function_virtwho_d_conf_clean')
@@ -65,8 +65,7 @@ class TestEsx:
         # type option is disable but another config is ok
         new_file = '/etc/virt-who.d/new_config.conf'
         section_name = 'virtwho-config'
-        new_hypervisor = VirtwhoHypervisorConfig(HYPERVISOR, REGISTER, new_file, section_name)
-        new_hypervisor.create()
+        hypervisor_create(HYPERVISOR, REGISTER, new_file, section_name)
         result = virtwho.run_service()
         assert (result['error'] is not 0
                 and result['send'] == 1
@@ -127,8 +126,7 @@ class TestEsx:
         # server option is disable but another config is ok
         new_file = '/etc/virt-who.d/new_config.conf'
         section_name = 'virtwho-config'
-        new_hypervisor = VirtwhoHypervisorConfig(HYPERVISOR, REGISTER, new_file, section_name)
-        new_hypervisor.create()
+        hypervisor_create(HYPERVISOR, REGISTER, new_file, section_name)
         result = virtwho.run_service()
         assert (result['error'] is not 0
                 and result['send'] == 1
@@ -188,8 +186,7 @@ class TestEsx:
         # username option is disable but another config is ok
         new_file = '/etc/virt-who.d/new_config.conf'
         section_name = 'virtwho-config'
-        new_hypervisor = VirtwhoHypervisorConfig(HYPERVISOR, REGISTER, new_file, section_name)
-        new_hypervisor.create()
+        hypervisor_create(HYPERVISOR, REGISTER, new_file, section_name)
         result = virtwho.run_service()
         assert (result['error'] is not 0
                 and result['send'] == 1
@@ -249,8 +246,7 @@ class TestEsx:
         # password option is disable but another config is ok
         new_file = '/etc/virt-who.d/new_config.conf'
         section_name = 'virtwho-config'
-        new_hypervisor = VirtwhoHypervisorConfig(HYPERVISOR, REGISTER, new_file, section_name)
-        new_hypervisor.create()
+        hypervisor_create(HYPERVISOR, REGISTER, new_file, section_name)
         result = virtwho.run_service()
         assert (result['error'] is not 0
                 and result['send'] == 1
@@ -290,7 +286,7 @@ class TestEsx:
         """
         # encrypted_password option is valid value
         function_hypervisor.delete('password')
-        encrypted_pwd = encrypted_password(ssh_host, hypervisor_data['hypervisor_password'])
+        encrypted_pwd = encrypt_password(ssh_host, hypervisor_data['hypervisor_password'])
         function_hypervisor.update('encrypted_password', encrypted_pwd)
         result = virtwho.run_service()
         assert (result['error'] == 0
@@ -311,8 +307,7 @@ class TestEsx:
         # encrypted_password option is valid but another config is ok
         new_file = '/etc/virt-who.d/new_config.conf'
         section_name = 'virtwho-config'
-        new_hypervisor = VirtwhoHypervisorConfig(HYPERVISOR, REGISTER, new_file, section_name)
-        new_hypervisor.create()
+        hypervisor_create(HYPERVISOR, REGISTER, new_file, section_name)
         result = virtwho.run_service()
         assert (result['error'] is not 0
                 and result['send'] == 1

--- a/virtwho/__init__.py
+++ b/virtwho/__init__.py
@@ -9,9 +9,9 @@ HYPERVISOR = config.job.hypervisor
 
 HYPERVISOR_FILE = f'/etc/virt-who.d/{HYPERVISOR}.conf'
 
-DEFAULT_HYPERVISOR_FILE = '/etc/virt-who.d/virtwho-config.conf'
+SECOND_HYPERVISOR_FILE = f'/etc/virt-who.d/{HYPERVISOR}-second.conf'
 
-SECTION_NAME = 'virtwho-config'
+SECOND_HYPERVISOR_SECTION = f'virtwho-{HYPERVISOR}-second'
 
 REGISTER = config.job.register
 

--- a/virtwho/__init__.py
+++ b/virtwho/__init__.py
@@ -9,6 +9,10 @@ HYPERVISOR = config.job.hypervisor
 
 HYPERVISOR_FILE = f'/etc/virt-who.d/{HYPERVISOR}.conf'
 
+DEFAULT_HYPERVISOR_FILE = '/etc/virt-who.d/virtwho-config.conf'
+
+SECTION_NAME = 'virtwho-config'
+
 REGISTER = config.job.register
 
 VIRTWHO_PKG = config.virtwho.package

--- a/virtwho/base.py
+++ b/virtwho/base.py
@@ -441,6 +441,12 @@ def random_string(num=8):
 
 
 def encrypted_password(ssh, password):
+    """
+    Encrypt password by virt-who-password command
+    :param ssh: ssh access of testing host
+    :param password: the password would like to Encrypt
+    :return: the Encrypted password
+    """
     cmd = f'virt-who-password -p {password} > /tmp/vw.log'
     ret, output = ssh.runcmd(cmd)
     if ret == 0:

--- a/virtwho/base.py
+++ b/virtwho/base.py
@@ -440,12 +440,12 @@ def random_string(num=8):
     return random_str
 
 
-def encrypted_password(ssh, password):
+def encrypt_password(ssh, password):
     """
     Encrypt password by virt-who-password command
     :param ssh: ssh access of testing host
     :param password: the password would like to Encrypt
-    :return: the Encrypted password
+    :return: the encrypted password
     """
     cmd = f'virt-who-password -p {password} > /tmp/vw.log'
     ret, output = ssh.runcmd(cmd)

--- a/virtwho/base.py
+++ b/virtwho/base.py
@@ -438,3 +438,18 @@ def random_string(num=8):
         random.sample(string.ascii_letters + string.digits, num)
     )
     return random_str
+
+
+def encrypted_password(ssh, password):
+    cmd = f'virt-who-password -p {password} > /tmp/vw.log'
+    ret, output = ssh.runcmd(cmd)
+    if ret == 0:
+        ret, output = ssh.runcmd("cat /tmp/vw.log")
+        if output is not None and output != '':
+            encrypted_value = output.strip()
+            logger.info(f'Succeeded to get encrypted_password : {encrypted_value}')
+            return encrypted_value
+        else:
+            raise FailException("Failed to run virt-who-password")
+    else:
+        raise FailException("Failed to run virt-who-password")

--- a/virtwho/configure.py
+++ b/virtwho/configure.py
@@ -200,3 +200,16 @@ def get_hypervisor_handler(mode):
     if mode in ['xen', 'hyperv', 'rhevm', 'libvirt', 'kubevirt', 'ahv', 'local']:
         hypervisor = getattr(config, mode)
     return hypervisor
+
+
+def hypervisor_create(mode='esx', register_type='rhsm', config_name=None, section=None):
+    """ Create the hypervisor config file
+    :param mode: The hypervisor mode.
+    :param register_type: The subscription server. (rhsm, satellite)
+    :param config_name: the file name for the virt-who config
+    :param section: the name for the virt-who config section
+    :return:
+    """
+    hypervisor = VirtwhoHypervisorConfig(mode, register_type, config_name, section)
+    hypervisor.create()
+    return hypervisor


### PR DESCRIPTION
**Description**
- [X] Created `encrypt_password` function
- [X] Add the test_encrypted_password case for the ESX mode
- [X] Created `hypervisor_create` function

**Test Result**
```
[hkx303@kuhuang virtwho-test]$ pytest tests/hypervisor/test_esx.py  -k test_encrypted_password -s
==================================== test session starts =====================================
platform linux -- Python 3.7.3, pytest-5.4.3, py-1.8.0, pluggy-0.13.1
rootdir: /home/hkx303/Documents/CI/virtwho-test, inifile: pytest.ini
plugins: services-1.3.1, mock-1.10.4, forked-1.0.2, ibutsu-1.0.34, cov-2.7.1, xdist-1.34.0
collected 6 items / 5 deselected / 1 selected                                                

======================== 1 passed, 5 deselected in 184.50s (0:03:04) =========================
```
