### PR TITLE
update the test case name due to conflict with the test file name

### DIFF
--- a/tests/hypervisor/test_hypervisors_state.py
+++ b/tests/hypervisor/test_hypervisors_state.py
@@ -10,33 +10,33 @@ from virtwho.provision.virtwho_hypervisor import hypervisor_state
 
 
 class TestHypervisorsState:
-    def test_esx(self):
+    def test_state_esx(self):
         """Test the esx state"""
         hypervisor_state(mode='esx')
         assert config.esx.state == 'GOOD'
 
-    def test_hyperv(self):
+    def test_state_hyperv(self):
         """Test the hyperv state"""
         hypervisor_state(mode='hyperv')
         assert config.hyperv.state == 'GOOD'
 
-    def test_kubevirt(self):
+    def test_state_kubevirt(self):
         """Test the kubevirt state"""
         assert config.kubevirt.state == 'GOOD'
 
-    def test_ahv(self):
+    def test_state_ahv(self):
         """Test the ahv state"""
         assert config.ahv.state == 'GOOD'
 
-    def test_libvirt(self):
+    def test_state_libvirt(self):
         """Test the libvirt state"""
         hypervisor_state(mode='libvirt')
         assert config.libvirt.state == 'GOOD'
 
-    def test_rhevm(self):
+    def test_state_rhevm(self):
         """Test the rhevm state"""
         assert config.rhevm.state == 'GOOD'
 
-    def test_xen(self):
+    def test_state_xen(self):
         """Test the xen state"""
         assert config.xen.state == 'GOOD'


### PR DESCRIPTION
The test file name is `test_hypervisors_state.py`, and there was one test case `test_hyperv()`, so when run `pytest test_hypervisors_state.py -k test_hyperv`, it will still run all the test cases under `test_hypervisors_state.py` because the test file name contains the test case name.
So updated the test case name to fix the issue.