### PR TITLE
Add the test_fake_mode case for esx hypervisor

### DIFF
--- a/tests/hypervisor/test_esx.py
+++ b/tests/hypervisor/test_esx.py
@@ -9,8 +9,10 @@ import pytest
 from virtwho import REGISTER
 from virtwho import RHEL_COMPOSE
 from virtwho import HYPERVISOR
+from virtwho import PRINT_JSON_FILE
 from virtwho import SECOND_HYPERVISOR_FILE
 from virtwho import SECOND_HYPERVISOR_SECTION
+
 
 from virtwho.base import encrypt_password
 from virtwho.base import get_host_domain_id
@@ -277,14 +279,13 @@ class TestEsxPositive:
             2. Succeed to run the virt-who service, can find the host_uuid and guest_uuid in the
             rhsm.log file
         """
-        print_json_file = "/root/print.json"
         host_uuid = hypervisor_data['hypervisor_uuid']
         guest_uuid = hypervisor_data['guest_uuid']
         virtwho.run_cli(prt=True, oneshot=False)
         function_hypervisor.destroy()
 
         fake_config = hypervisor_create('fake', REGISTER, rhsm=False)
-        fake_config.update('file', print_json_file)
+        fake_config.update('file', PRINT_JSON_FILE)
         fake_config.update('is_hypervisor', 'True')
         result = virtwho.run_service()
         assert (result['error'] == 0

--- a/tests/hypervisor/test_esx.py
+++ b/tests/hypervisor/test_esx.py
@@ -263,6 +263,38 @@ class TestEsxPositive:
                 and result['send'] == 1
                 and result['thread'] == 1)
 
+    def test_fake_type(self, virtwho, function_hypervisor, hypervisor_data):
+        """Test the fake type in /etc/virt-who.d/hypervisor.conf
+
+        :title: virt-who: esx: test fake type
+        :id: 14d3af84-92c3-4335-8bff-8a96cf211c1d
+            1. Generate the json file by virt-who -p -d command
+            2. Create the virt-who config for the fake mode testing
+            3. Check the rhsm.log
+
+        :expectedresults:
+            1. Can find the json data in the specific path
+            2. Succeed to run the virt-who service, can find the host_uuid and guest_uuid in the
+            rhsm.log file
+        """
+        print_json_file = "/root/print.json"
+        host_uuid = hypervisor_data['hypervisor_uuid']
+        guest_uuid = hypervisor_data['guest_uuid']
+        virtwho.run_cli(prt=True, oneshot=False)
+        function_hypervisor.destroy()
+
+        fake_config = hypervisor_create('fake', REGISTER, rhsm=False)
+        fake_config.update('file', print_json_file)
+        fake_config.update('is_hypervisor', 'True')
+        result = virtwho.run_service()
+        assert (result['error'] == 0
+                and result['send'] == 1
+                and result['thread'] == 1
+                and host_uuid in result['log']
+                and guest_uuid in result['log'])
+        # Todo: Need to add the test cases for host-guest association in mapping, web and the test
+        #  cases for the vdc pool's subscription.
+
 
 @pytest.mark.usefixtures('function_virtwho_d_conf_clean')
 @pytest.mark.usefixtures('debug_true')

--- a/virtwho/__init__.py
+++ b/virtwho/__init__.py
@@ -9,6 +9,8 @@ HYPERVISOR = config.job.hypervisor
 
 HYPERVISOR_FILE = f'/etc/virt-who.d/{HYPERVISOR}.conf'
 
+PRINT_JSON_FILE = '/root/print.json'
+
 SECOND_HYPERVISOR_FILE = f'/etc/virt-who.d/{HYPERVISOR}-second.conf'
 
 SECOND_HYPERVISOR_SECTION = f'virtwho-{HYPERVISOR}-second'

--- a/virtwho/configure.py
+++ b/virtwho/configure.py
@@ -202,14 +202,15 @@ def get_hypervisor_handler(mode):
     return hypervisor
 
 
-def hypervisor_create(mode='esx', register_type='rhsm', config_name=None, section=None):
+def hypervisor_create(mode='esx', register_type='rhsm', config_name=None, section=None, rhsm=True):
     """ Create the hypervisor config file
     :param mode: The hypervisor mode.
     :param register_type: The subscription server. (rhsm, satellite)
     :param config_name: the file name for the virt-who config
     :param section: the name for the virt-who config section
+    :param rhsm: True is to add all rhsm related options, False will not
     :return:
     """
     hypervisor = VirtwhoHypervisorConfig(mode, register_type, config_name, section)
-    hypervisor.create()
+    hypervisor.create(rhsm=rhsm)
     return hypervisor

--- a/virtwho/runner.py
+++ b/virtwho/runner.py
@@ -4,7 +4,7 @@ import queue
 import re
 import threading
 import time
-from virtwho import logger, FailException
+from virtwho import logger, FailException, PRINT_JSON_FILE
 from virtwho.configure import virtwho_ssh_connect, get_hypervisor_handler
 
 
@@ -24,7 +24,6 @@ class VirtwhoRunner:
         self.register_type = register_type
         self.config_file = f"/etc/virt-who.d/{self.mode}.conf"
         self.rhsm_log_file = "/var/log/rhsm/rhsm.log"
-        self.print_json_file = "/root/print.json"
         self.ssh = virtwho_ssh_connect(self.mode)
 
     def run_cli(self,
@@ -70,7 +69,7 @@ class VirtwhoRunner:
         if jsn:
             cmd += '-j '
         if prt:
-            cmd = f'{cmd} > {self.print_json_file}'
+            cmd = f'{cmd} > {PRINT_JSON_FILE}'
 
         if status:
             result_data = self.status(cmd)
@@ -268,7 +267,9 @@ class VirtwhoRunner:
         Clean the json file created by print function of virt-who
         """
         _, _ = self.ssh.runcmd("rm -rf /var/log/rhsm/*")
-        # _, _ = self.ssh.runcmd(f"rm -rf {self.print_json_file}")
+
+        # comment this line as we need the print json file for fake mode testing
+        # self.ssh.runcmd(f"rm -rf {PRINT_JSON_FILE}")
 
     def error_warning(self, msg='error'):
         """
@@ -495,7 +496,7 @@ class VirtwhoRunner:
         Get and return the json created by print function.
         :return: json output
         """
-        ret, output = self.ssh.runcmd(f"cat {self.print_json_file}")
+        ret, output = self.ssh.runcmd(f"cat {PRINT_JSON_FILE}")
         if ret == 0 and output != "":
             return output
         else:

--- a/virtwho/runner.py
+++ b/virtwho/runner.py
@@ -268,7 +268,7 @@ class VirtwhoRunner:
         Clean the json file created by print function of virt-who
         """
         _, _ = self.ssh.runcmd("rm -rf /var/log/rhsm/*")
-        _, _ = self.ssh.runcmd(f"rm -rf {self.print_json_file}")
+        # _, _ = self.ssh.runcmd(f"rm -rf {self.print_json_file}")
 
     def error_warning(self, msg='error'):
         """


### PR DESCRIPTION
**Description**
Add the test_fake_mode case for esx hypervisor in test_esx.py

**Test Result**
```
[hkx303@kuhuang virtwho-test]$ pytest tests/hypervisor/test_esx.py -k test_fake_type
==================================== test session starts =====================================
platform linux -- Python 3.7.3, pytest-5.4.3, py-1.8.0, pluggy-0.13.1
rootdir: /home/hkx303/Documents/CI/virtwho-test, inifile: pytest.ini
plugins: services-1.3.1, mock-1.10.4, forked-1.0.2, ibutsu-1.0.34, cov-2.7.1, xdist-1.34.0
collected 13 items / 12 deselected / 1 selected  
======================== 1 passed, 12 deselected in 98.13s (0:01:38) =========================
```

