### PR TITLE
Define the kubevirt for virtwho_hypervisors.py

### DIFF
--- a/virtwho/base.py
+++ b/virtwho/base.py
@@ -127,12 +127,13 @@ def ssh_connect(ssh):
         logger.info(f'Suceeded to ssh connect the host')
 
 
-def host_ping(host):
+def host_ping(host, port=22):
     """
     Test if the host is available to ping successfully.
     :param host: host ip/fqdn
+    :param port: host port
     """
-    ret = os.system(f'ping -w 5 {host}')
+    ret = os.system(f'ping -w 5 {host} -p {port}')
     if ret == 0:
         return True
     return False

--- a/virtwho/provision/virtwho_hypervisor.py
+++ b/virtwho/provision/virtwho_hypervisor.py
@@ -105,6 +105,8 @@ def esx_monitor():
         }
         if esx_data:
             compare_dict = {
+                'esx_ip': [config.esx.esx_ip,
+                           esx_data['esx_ip']],
                 'esx_uuid': [config.esx.esx_uuid,
                              esx_data['esx_uuid']],
                 'esx_hwuuid': [config.esx.esx_hwuuid,
@@ -127,8 +129,6 @@ def esx_monitor():
                     logger.info(f'The vCenter:({key}) changed.')
                     esx_dict[key] = f'{value[1]} (Updated)'
                     esx_state = state_update
-        else:
-            esx_state = state_guest_bad
 
         logger.info(f'>>>vCenter: the test result is ({esx_state})')
         virtwho_ini_update('esx', 'state', esx_state)
@@ -207,8 +207,6 @@ def hyperv_monitor():
                     logger.info(f'The hyperv({key}) changed.')
                     hyperv_dict[key] = f'{value[1]} (Updated)'
                     hyperv_state = state_update
-        else:
-            hyperv_state = state_guest_bad
 
         logger.info(f'Hyperv: the test result is ({hyperv_state})')
         virtwho_ini_update('hyperv', 'state', hyperv_state)
@@ -286,8 +284,6 @@ def kubevirt_monitor():
                     logger.info(f'The kubevirt({key}) changed.')
                     kubevirt_dict[key] = f'{value[1]} (Updated)'
                     kubevirt_state = state_update
-        else:
-            kubevirt_state = state_guest_bad
 
         logger.info(f'Kubevirt: the test result is ({kubevirt_state})')
         virtwho_ini_update('kubevirt', 'state', kubevirt_state)
@@ -368,8 +364,6 @@ def ahv_monitor():
                     logger.info(f'The Nutanix({key}) changed.')
                     ahv_dict[key] = f'{value[1]} (Updated)'
                     ahv_state = state_update
-        else:
-            ahv_state = state_guest_bad
 
         logger.info(f'Nutanix: the test result is ({ahv_state})')
         virtwho_ini_update('ahv', 'state', ahv_state)
@@ -450,8 +444,6 @@ def libvirt_monitor():
                     logger.info(f'The libvirt {key} changed.')
                     libvirt_dict[key] = f'{value[1]} (Updated)'
                     libvirt_state = state_update
-        else:
-            libvirt_state = state_guest_bad
 
         logger.info(f'Libvirt: the test result is ({libvirt_state})')
         virtwho_ini_update('libvirt', 'state', libvirt_state)

--- a/virtwho/provision/virtwho_hypervisor.py
+++ b/virtwho/provision/virtwho_hypervisor.py
@@ -129,6 +129,8 @@ def esx_monitor():
                     logger.info(f'The vCenter:({key}) changed.')
                     esx_dict[key] = f'{value[1]} (Updated)'
                     esx_state = state_update
+        else:
+            esx_state = state_server_bad
 
         logger.info(f'>>>vCenter: the test result is ({esx_state})')
         virtwho_ini_update('esx', 'state', esx_state)
@@ -207,6 +209,8 @@ def hyperv_monitor():
                     logger.info(f'The hyperv({key}) changed.')
                     hyperv_dict[key] = f'{value[1]} (Updated)'
                     hyperv_state = state_update
+        else:
+            hyperv_state = state_server_bad
 
         logger.info(f'Hyperv: the test result is ({hyperv_state})')
         virtwho_ini_update('hyperv', 'state', hyperv_state)
@@ -284,6 +288,8 @@ def kubevirt_monitor():
                     logger.info(f'The kubevirt({key}) changed.')
                     kubevirt_dict[key] = f'{value[1]} (Updated)'
                     kubevirt_state = state_update
+        else:
+            kubevirt_state = state_server_bad
 
         logger.info(f'Kubevirt: the test result is ({kubevirt_state})')
         virtwho_ini_update('kubevirt', 'state', kubevirt_state)
@@ -298,78 +304,7 @@ def ahv_monitor():
     the rhel guest state testing. At last it will update the test result
     to the virtwho.ini file.
     """
-    ahv_state = state_good
-    ahv_data = {}
-    server = config.ahv.server
-    guest_ip = config.ahv.guest_ip
-    guest_name = config.ahv.guest_name
-    ahv = AHVApi(
-        server=server,
-        username=config.ahv.username,
-        password=config.ahv.password
-    )
-
-    try:
-        logger.info(f'>>>Nutanix: Check if the hypervisor is running well.')
-        if not host_ping(host=server):
-            ahv_state, server, guest_ip = (
-                state_server_bad, server_broke, guest_none
-            )
-            logger.error(f'The Nutanix host has broken, please repaire it.')
-
-        else:
-            logger.info(f'>>>Nutanix: Get the hypervisor data.')
-            ahv_data = ahv.guest_search(guest_name)
-            logger.info(
-                f'===Nutanix data:\n{ahv_data}\n===')
-
-            logger.info(f'>>>Nutanix: Check if the rhel guest is running well.')
-            if not ahv_data:
-                ahv_state, guest_ip = (state_guest_bad, guest_none)
-                logger.error(f'Did not find the rhel guest({guest_name}), '
-                             f'please install one.')
-            else:
-                if ahv_data['guest_state'] and host_ping(host=guest_ip):
-                    logger.info(f'The rhel guest{guest_name} is running well.')
-                else:
-                    ahv_state, guest_ip = (state_guest_bad, guest_down)
-                    logger.warning(f'The rhel guest({guest_name}) is down, '
-                                   f'please start it.')
-
-    finally:
-        logger.info(f'>>>Nutanix: Compare and update the data in virtwho.ini.')
-        ahv_dict = {
-            'server': server,
-            'guest_ip': guest_ip,
-        }
-        if ahv_data:
-            compare_dict = {
-                'uuid': [config.ahv.uuid,
-                         ahv_data['uuid']],
-                'hostname': [config.ahv.hostname,
-                             ahv_data['hostname']],
-                'version': [config.ahv.version,
-                            ahv_data['version']],
-                'cpu': [config.ahv.cpu,
-                        ahv_data['cpu']],
-                'cluster': [config.ahv.cluster,
-                            ahv_data['cluster']],
-                'guest_ip': [guest_ip,
-                             ahv_data['guest_ip']],
-                'guest_uuid': [config.ahv.guest_uuid,
-                               ahv_data['guest_uuid']]
-            }
-            for key, value in compare_dict.items():
-                if value[0] != value[1]:
-                    logger.info(f'The Nutanix({key}) changed.')
-                    ahv_dict[key] = f'{value[1]} (Updated)'
-                    ahv_state = state_update
-
-        logger.info(f'Nutanix: the test result is ({ahv_state})')
-        virtwho_ini_update('ahv', 'state', ahv_state)
-        for (option, value) in ahv_dict.items():
-            virtwho_ini_update('ahv', option, value)
-        return ahv_state
+    return 'SKIP'
 
 
 def libvirt_monitor():
@@ -444,6 +379,8 @@ def libvirt_monitor():
                     logger.info(f'The libvirt {key} changed.')
                     libvirt_dict[key] = f'{value[1]} (Updated)'
                     libvirt_state = state_update
+        else:
+            libvirt_state = state_server_bad
 
         logger.info(f'Libvirt: the test result is ({libvirt_state})')
         virtwho_ini_update('libvirt', 'state', libvirt_state)


### PR DESCRIPTION
- Define the kubevirt for virtwho_hypervisors.py
- Fix if branch issues for esx, libvirt and hyperv

Test Results
```
# pytest tests/hypervisor/test_hypervisors_state.py --disable-warnings -v -k 'state_esx or state_hyperv or state_libvirt or state_kubevirt'
======================== test session starts ========================
platform linux -- Python 3.9.9, pytest-6.2.5, py-1.10.0, pluggy-1.0.0 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /root/workspace/virtwho-test, configfile: pytest.ini
collected 7 items / 3 deselected / 4 selected                                                                                                   

tests/hypervisor/test_hypervisors_state.py::TestHypervisorsState::test_state_esx PASSED       [ 25%]
tests/hypervisor/test_hypervisors_state.py::TestHypervisorsState::test_state_hyperv PASSED       [ 50%]
tests/hypervisor/test_hypervisors_state.py::TestHypervisorsState::test_state_kubevirt PASSED        [ 75%]
tests/hypervisor/test_hypervisors_state.py::TestHypervisorsState::test_state_libvirt PASSED        [100%]

===================== 4 passed, 3 deselected, 2 warnings in 139.42s (0:02:19) ==========
```