### PR TITLE
perfect the virtwho_hypervisor.py: esx and kubevirt

### DIFF
--- a/virtwho/base.py
+++ b/virtwho/base.py
@@ -125,6 +125,8 @@ def ssh_connect(ssh):
     ret, output = ssh.runcmd('rpm -qa filesystem')
     if ret == 0 and 'filesystem' in output:
         logger.info(f'Suceeded to ssh connect the host')
+        return True
+    return False
 
 
 def host_ping(host, port=22):


### PR DESCRIPTION
- for kubevirt:  use `ssh_connect` instead of `host_ping` to test the guest, because the guest contains individual port.
- for esx: individually to get the esx_hostname because the hosename got from hypervisor-builder maybe a guest_ip, which depends on the definition in vCenter server.