### PR TITLE
Add test case around simplified_vim option for esx hypervisor

### DIFF
--- a/tests/hypervisor/test_esx.py
+++ b/tests/hypervisor/test_esx.py
@@ -157,6 +157,36 @@ class TestEsxPositive:
                     and result['thread'] == 1
                     and hypervisor_id_data not in str(result['mappings']))
 
+    @pytest.mark.tier1
+    def test_simplified_vim(self, virtwho, function_hypervisor, hypervisor_data):
+        """Test the simplified_vim option in /etc/virt-who.d/hypervisor.conf
+
+        :title: virt-who: esx: test simplified_vim option
+        :id: 4e0a0ab3-8426-4121-8bbd-2e39794043d8
+        :caseimportance: High
+        :tags: tier1
+        :customerscenario: false
+        :upstream: no
+        :steps:
+            1. run virt-who with simplified_vim=true
+            2. run virt-who with simplified_vim=false
+
+        :expectedresults:
+            1. Succeed to run the virt-who
+            2. Succeed to run the virt-who
+        """
+        function_hypervisor.update('simplified_vim', 'true')
+        result = virtwho.run_service()
+        assert (result['error'] == 0
+                and result['send'] == 1
+                and result['thread'] == 1)
+
+        function_hypervisor.update('simplified_vim', 'false')
+        result = virtwho.run_service()
+        assert (result['error'] == 0
+                and result['send'] == 1
+                and result['thread'] == 1)
+
 
 @pytest.mark.usefixtures('function_virtwho_d_conf_clean')
 @pytest.mark.usefixtures('debug_true')


### PR DESCRIPTION
**Description**
Add test case around simplified_vim option for esx hypervisor

**Test Result**
```
[hkx303@kuhuang virtwho-test]$ pytest tests/hypervisor/test_esx.py -k test_simplified_vim -s
==================================== test session starts =====================================
platform linux -- Python 3.7.3, pytest-5.4.3, py-1.8.0, pluggy-0.13.1
rootdir: /home/hkx303/Documents/CI/virtwho-test, inifile: pytest.ini
plugins: services-1.3.1, mock-1.10.4, forked-1.0.2, ibutsu-1.0.34, cov-2.7.1, xdist-1.34.0
collected 14 items / 13 deselected / 1 selected   

======================== 1 passed, 13 deselected in 93.44s (0:01:33) =========================
```
