### PR TITLE
Create the test_rhesm.py cloning the test_esx.py

### DIFF
--- a/tests/hypervisor/conftest.py
+++ b/tests/hypervisor/conftest.py
@@ -68,7 +68,7 @@ def rhevm_assertion():
     Collect all the assertion info for rhevm to this fixture
     :return:
     """
-    login_error = 'Unable to login to ESX'
+    login_error = 'Unable to connect to RHEV-M server: 401 Client Error'
     data = {
         'type': {
             'invalid': {
@@ -83,7 +83,7 @@ def rhevm_assertion():
         'server': {
             'invalid': {
                 'xxx': 'Name or service not known',
-                '红帽€467aa': 'Option server needs to be ASCII characters only',
+                '红帽€467aa': 'Unable to connect to RHEV-M server',
                 '': 'Option server needs to be set in config',
             },
             'disable': "virt-who can't be started",

--- a/tests/hypervisor/conftest.py
+++ b/tests/hypervisor/conftest.py
@@ -60,3 +60,64 @@ def esx_assertion():
     }
 
     return data
+
+
+@pytest.fixture(scope='session')
+def rhevm_assertion():
+    """
+    Collect all the assertion info for rhevm to this fixture
+    :return:
+    """
+    login_error = 'Unable to login to ESX'
+    data = {
+        'type': {
+            'invalid': {
+                'xxx': "Unsupported virtual type 'xxx' is set",
+                '红帽€467aa': "Unsupported virtual type '红帽€467aa' is set",
+                '': "Unsupported virtual type '' is set",
+            },
+            'non_rhel9': "virt-who can't be started",
+            'disable': "Cannot read CA certificate '/etc/pki/CA/cacert.pem'",
+            'disable_multi_configs': "Cannot read CA certificate '/etc/pki/CA/cacert.pem'"
+        },
+        'server': {
+            'invalid': {
+                'xxx': 'Name or service not known',
+                '红帽€467aa': 'Option server needs to be ASCII characters only',
+                '': 'Option server needs to be set in config',
+            },
+            'disable': "virt-who can't be started",
+            'disable_multi_configs': 'Required option: "server" not set',
+            'null_multi_configs': 'Option server needs to be set in config',
+        },
+        'username': {
+            'invalid': {
+                'xxx': login_error,
+                '红帽€467aa': login_error,
+                '': login_error,
+            },
+            'disable': 'Required option: "username" not set',
+            'disable_multi_configs': 'Required option: "username" not set',
+            'null_multi_configs': login_error,
+        },
+        'password': {
+            'invalid': {
+                'xxx': login_error,
+                '红帽€467aa': login_error,
+                '': login_error,
+            },
+            'disable': 'Required option: "password" not set',
+            'disable_multi_configs': 'Required option: "password" not set',
+            'null_multi_configs': login_error,
+        },
+        'encrypted_password': {
+            'invalid': {
+                'xxx': 'Option "encrypted_password" cannot be decrypted',
+                '': 'Option "encrypted_password" cannot be decrypted',
+            },
+            'valid_multi_configs': 'Option "encrypted_password" cannot be decrypted'
+        }
+
+    }
+
+    return data

--- a/tests/hypervisor/test_rhevm.py
+++ b/tests/hypervisor/test_rhevm.py
@@ -5,40 +5,645 @@
 :caseautomation: Automated
 """
 import pytest
-from virtwho import logger
+
+from virtwho import REGISTER
+from virtwho import RHEL_COMPOSE
+from virtwho import HYPERVISOR
+from virtwho import PRINT_JSON_FILE
+from virtwho import SECOND_HYPERVISOR_FILE
+from virtwho import SECOND_HYPERVISOR_SECTION
 
 
-class TestRhevm:
+from virtwho.base import encrypt_password
+from virtwho.configure import hypervisor_create
+
+
+@pytest.mark.usefixtures('function_virtwho_d_conf_clean')
+@pytest.mark.usefixtures('debug_true')
+@pytest.mark.usefixtures('globalconf_clean')
+class TestRHEVMPositive:
     @pytest.mark.tier1
-    def test_hostname_option(self):
-        """Just a demo
+    def test_encrypted_password(self, virtwho, function_hypervisor,
+                                hypervisor_data, ssh_host):
+        """Test the encrypted_password= option in /etc/virt-who.d/test_rhevm.conf
 
-        :title: virt-who: rhevm: test hostname option
-        :id: 3faa0d5a-77e9-4931-9793-8f0eb352e83c
+        :title: virt-who: rhevm: test encrypted_password option
+        :id: 1a113c7e-d54d-46a1-941d-16d94a62ef0f
         :caseimportance: High
         :tags: tier1
         :customerscenario: false
         :upstream: no
         :steps:
-            1.
+            1. Delete the password option, encrypted password for the hypervisor.
+            2. Configure encrypted_password option with valid value, run the virt-who service.
+
         :expectedresults:
-            1.
+            2. Succeeded to run the virt-who, no error messages in the log info
         """
-        logger.info("Succeeded to run the 'test_hostname_option'")
+        # encrypted_password option is valid value
+        function_hypervisor.delete('password')
+        encrypted_pwd = encrypt_password(ssh_host, hypervisor_data['hypervisor_password'])
+        function_hypervisor.update('encrypted_password', encrypted_pwd)
+        result = virtwho.run_service()
+        assert (result['error'] == 0
+                and result['send'] == 1
+                and result['thread'] == 1)
 
+    @pytest.mark.tier1
+    def test_hypervisor_id(self, virtwho, function_hypervisor, hypervisor_data, globalconf, rhsm, satellite):
+        """Test the hypervisor_id= option in /etc/virt-who.d/hypervisor.conf
+
+        :title: virt-who: rhevm: test hypervisor_id function
+        :id: a69aff68-beff-4666-b9a0-03be32b6fdff
+        :caseimportance: High
+        :tags: tier1
+        :customerscenario: false
+        :upstream: no
+        :steps:
+
+            1. clean all virt-who global configurations
+            2. run virt-who with hypervisor_id=uuid
+            3. run virt-who with hypervisor_id=hostname
+            4. run virt-who with hypervisor_id=hwuuid
+
+        :expectedresults:
+
+            hypervisor id shows uuid/hostname/hwuuid in mapping as the setting.
+        """
+        hypervisor_ids = ['hostname', 'uuid', 'hwuuid']
+        for hypervisor_id in hypervisor_ids:
+            function_hypervisor.update('hypervisor_id', hypervisor_id)
+            result = virtwho.run_service()
+            assert (result['error'] == 0
+                    and result['send'] == 1
+                    and result['thread'] == 1
+                    and result['hypervisor_id'] == hypervisor_data[f'hypervisor_{hypervisor_id}'])
+            if REGISTER == 'rhsm':
+                assert rhsm.consumers(hypervisor_data['hypervisor_hostname'])
+                rhsm.delete(hypervisor_data['hypervisor_hostname'])
+            else:
+                if hypervisor_id == 'hostname':
+                    assert satellite.host_id(hypervisor_data['hypervisor_hostname'])
+                    assert not satellite.host_id(hypervisor_data['hypervisor_uuid'])
+                    assert not satellite.host_id(hypervisor_data['hypervisor_hwuuid'])
+                elif hypervisor_id == 'uuid':
+                    assert satellite.host_id(hypervisor_data['hypervisor_uuid'])
+                    assert not satellite.host_id(hypervisor_data['hypervisor_hostname'])
+                    assert not satellite.host_id(hypervisor_data['hypervisor_hwuuid'])
+                else:
+                    assert satellite.host_id(hypervisor_data['hypervisor_hwuuid'])
+                    assert not satellite.host_id(hypervisor_data['hypervisor_hostname'])
+                    assert not satellite.host_id(hypervisor_data['hypervisor_uuid'])
+
+    @pytest.mark.tier1
+    def test_filter_hosts(self, virtwho, function_hypervisor, hypervisor_data):
+        """Test the filter_hosts= option in /etc/virt-who.d/hypervisor.conf
+
+        :title: virt-who: rhevm: test filter_hosts option
+        :id: 16970ea6-8148-42ff-bd6d-4946e64077d4
+        :caseimportance: High
+        :tags: tier1
+        :customerscenario: false
+        :upstream: no
+        :steps:
+            1. Set hypervisor_id=hostname.
+            2. Configure filter_hosts={hostname}, run the virt-who service.
+            3. Configure filter_hosts={host_uuid}, run the virt-who service.
+            4. Configure filter_hosts={host_hwuuid}, run the virt-who service.
+        :expectedresults:
+            2. Succeeded to run the virt-who, can find hostname in the log message
+            3. Succeeded to run the virt-who, can find host_uuid in the log message
+            4. Succeeded to run the virt-who, can find host_hwuuid in the log message
+        """
+        hypervisor_ids = ['hostname', 'uuid', 'hwuuid']
+        for hypervisor_id in hypervisor_ids:
+            function_hypervisor.update('hypervisor_id', hypervisor_id)
+            hypervisor_id_data = hypervisor_data[f'hypervisor_{hypervisor_id}']
+
+            function_hypervisor.update('filter_hosts', hypervisor_id_data)
+            result = virtwho.run_service()
+            assert (result['error'] == 0
+                    and result['send'] == 1
+                    and result['thread'] == 1
+                    and hypervisor_id_data in str(result['mappings']))
+
+    @pytest.mark.tier1
+    def test_exclude_hosts(self, virtwho, function_hypervisor, hypervisor_data):
+        """Test the exclude_hosts= option in /etc/virt-who.d/hypervisor.conf
+
+        :title: virt-who: rhevm: test exclude_hosts option
+        :id: 557ead54-9c01-4bf3-8cd3-192d5bd70ba8
+        :caseimportance: High
+        :tags: tier1
+        :customerscenario: false
+        :upstream: no
+        :steps:
+            1. Set hypervisor_id=hostname.
+            2. Configure exclude_hosts={hostname}, run the virt-who service.
+            3. Configure exclude_hosts={host_uuid}, run the virt-who service.
+            4. Configure exclude_hosts={host_hwuuid}, run the virt-who service.
+        :expectedresults:
+            2. Succeeded to run the virt-who, cannot find hostname in the log message
+            3. Succeeded to run the virt-who, cannot find host_uuid in the log message
+            4. Succeeded to run the virt-who, cannot find host_hwuuid in the log message
+        """
+        hypervisor_ids = ['hostname', 'uuid', 'hwuuid']
+        for hypervisor_id in hypervisor_ids:
+            function_hypervisor.update('hypervisor_id', hypervisor_id)
+            hypervisor_id_data = hypervisor_data[f'hypervisor_{hypervisor_id}']
+
+            function_hypervisor.update('exclude_hosts', hypervisor_id_data)
+            result = virtwho.run_service()
+            assert (result['error'] == 0
+                    and result['send'] == 1
+                    and result['thread'] == 1
+                    and hypervisor_id_data not in str(result['mappings']))
+
+    def test_fake_type(self, virtwho, function_hypervisor, hypervisor_data):
+        """Test the fake type in /etc/virt-who.d/hypervisor.conf
+
+        :title: virt-who: rhevm: test fake type
+        :id: 59cf1330-3127-467d-bf1c-3b0cbe2fdd84
+            1. Generate the json file by virt-who -p -d command
+            2. Create the virt-who config for the fake mode testing
+            3. Check the rhsm.log
+
+        :expectedresults:
+            1. Can find the json data in the specific path
+            2. Succeed to run the virt-who service, can find the host_uuid and guest_uuid in the
+            rhsm.log file
+        """
+        host_uuid = hypervisor_data['hypervisor_uuid']
+        guest_uuid = hypervisor_data['guest_uuid']
+        virtwho.run_cli(prt=True, oneshot=False)
+        function_hypervisor.destroy()
+
+        fake_config = hypervisor_create('fake', REGISTER, rhsm=False)
+        fake_config.update('file', PRINT_JSON_FILE)
+        fake_config.update('is_hypervisor', 'True')
+        result = virtwho.run_service()
+        assert (result['error'] == 0
+                and result['send'] == 1
+                and result['thread'] == 1
+                and host_uuid in result['log']
+                and guest_uuid in result['log'])
+        # Todo: Need to add the test cases for host-guest association in mapping, web and the test
+        #  cases for the vdc pool's subscription.
+
+
+@pytest.mark.usefixtures('function_virtwho_d_conf_clean')
+@pytest.mark.usefixtures('debug_true')
+@pytest.mark.usefixtures('globalconf_clean')
+class TestRHEVMNegative:
     @pytest.mark.tier2
-    def test_http_option(self):
-        """Just a demo
+    def test_type(self, virtwho, function_hypervisor, esx_assertion):
+        """Test the type= option in /etc/virt-who.d/test_rhevm.conf
 
-        :title: virt-who: rhevm: test http option
-        :id: e56e6f64-63aa-4ffa-af2d-245552d120e8
+        :title: virt-who: rhevm: test type option
+        :id: f2533fe1-5536-4bd5-830b-b2141f0896d7
         :caseimportance: High
         :tags: tier2
         :customerscenario: false
         :upstream: no
         :steps:
-            1.
+            1. Configure type option with invalid value.
+            2. Disable the type option in the config file.
+            3. Create another valid config file
+            4. Update the type option with null value
+
         :expectedresults:
-            1.
+            1. Failed to run the virt-who service, find error messages
+            2. Find error message: Error in libvirt backend
+            3. Find error message, the good config works fine
+            4. The good config works fine
         """
-        logger.info("Succeeded to run the 'test_http_option'")
+        # type option is invalid value
+        assertion = esx_assertion['type']
+        assertion_invalid_list = list(assertion['invalid'].keys())
+        for value in assertion_invalid_list:
+            function_hypervisor.update('type', value)
+            result = virtwho.run_service()
+            assert (result['error'] is not 0
+                    and result['send'] == 0
+                    and result['thread'] == 0)
+            if 'RHEL-9' in RHEL_COMPOSE:
+                assert assertion['invalid'][f'{value}'] in result['error_msg']
+            else:
+                assert assertion['non_rhel9'] in result['error_msg']
+
+        # type option is disable
+        function_hypervisor.delete('type')
+        result = virtwho.run_service()
+        assert (result['error'] is not 0
+                and result['send'] == 0
+                and result['thread'] == 1
+                and assertion['disable'] in result['error_msg'])
+
+        # type option is disable but another config is ok
+        hypervisor_create(HYPERVISOR, REGISTER, SECOND_HYPERVISOR_FILE, SECOND_HYPERVISOR_SECTION)
+        result = virtwho.run_service()
+        assert (result['error'] is not 0
+                and result['send'] == 1
+                and result['thread'] == 1
+                and assertion['disable_multi_configs'] in result['error_msg'])
+
+        # type option is null but another config is ok
+        function_hypervisor.update('type', '')
+        result = virtwho.run_service()
+        assert (result['send'] == 1
+                and result['thread'] == 1)
+        if 'RHEL-9' in RHEL_COMPOSE:
+            assert result['error'] == 1
+        else:
+            assert result['error'] == 0
+
+    @pytest.mark.tier2
+    def test_server(self, virtwho, function_hypervisor, esx_assertion):
+        """Test the server= option in /etc/virt-who.d/test_rhevm.conf
+
+        :title: virt-who: rhevm: test server option
+        :id: 70eec0cb-317b-4ee9-933c-88ff3310137e
+        :caseimportance: High
+        :tags: tier2
+        :customerscenario: false
+        :upstream: no
+        :steps:
+            1. Configure server option with invalid value.
+            2. Disable the server option in the config file.
+            3. Create another valid config file
+            4. Update the server option with null value
+
+        :expectedresults:
+            1. Failed to run the virt-who service, find error messages
+            2. Find error message: virt-who can't be started
+            3. Find error message: 'Required option: "server" not set', the good config works fine
+            4. Find error message: 'Option server needs to be set in config', the good config
+            works fine
+        """
+        # server option is invalid value
+        assertion = esx_assertion['server']
+        assertion_invalid_list = list(assertion['invalid'].keys())
+        for value in assertion_invalid_list:
+            function_hypervisor.update('server', value)
+            result = virtwho.run_service()
+            assert (result['error'] is not 0
+                    and result['send'] == 0
+                    and assertion['invalid'][f'{value}'] in result['error_msg'])
+
+        # server option is disable
+        function_hypervisor.delete('server')
+        result = virtwho.run_service()
+        assert (result['error'] is not 0
+                and result['send'] == 0
+                and result['thread'] == 0
+                and assertion['disable'] in result['error_msg'])
+
+        # server option is disable but another config is ok
+        hypervisor_create(HYPERVISOR, REGISTER, SECOND_HYPERVISOR_FILE, SECOND_HYPERVISOR_SECTION)
+        result = virtwho.run_service()
+        assert (result['error'] is not 0
+                and result['send'] == 1
+                and result['thread'] == 1
+                and assertion['disable_multi_configs'] in result['error_msg'])
+
+        # server option is null but another config is ok
+        function_hypervisor.update('server', '')
+        result = virtwho.run_service()
+        assert (result['error'] is not 0
+                and result['send'] == 1
+                and result['thread'] == 1
+                and assertion['null_multi_configs'] in result['error_msg'])
+
+    @pytest.mark.tier2
+    def test_username(self, function_hypervisor, virtwho, esx_assertion):
+        """Test the username= option in /etc/virt-who.d/test_rhevm.conf
+
+        :title: virt-who: rhevm: test username option
+        :id: 19f8643b-0aa9-4380-b91c-afe6384dbb75
+        :caseimportance: High
+        :tags: tier2
+        :customerscenario: false
+        :upstream: no
+        :steps:
+            1. Configure username option with invalid value.
+            2. Disable the username option in the config file.
+            3. Create another valid config file
+            4. Update the username option with null value
+
+        :expectedresults:
+            1. Failed to run the virt-who service, find error message: 'Unable to login to ESX'
+            2. Find error message: 'Required option: "username" not set'
+            3. Find error message: 'Required option: "username" not set', the good config
+            works fine
+            4. Find error message: 'Unable to login to ESX', the good config works fine
+        """
+        # username option is invalid value
+        assertion = esx_assertion['username']
+        assertion_invalid_list = list(assertion['invalid'].keys())
+        for value in assertion_invalid_list:
+            function_hypervisor.update('username', value)
+            result = virtwho.run_service()
+            assert (result['error'] is not 0
+                    and result['send'] == 0
+                    and result['thread'] == 1
+                    and assertion['invalid'][f'{value}'] in result['error_msg'])
+
+        # username option is disable
+        function_hypervisor.delete('username')
+        result = virtwho.run_service()
+        assert (result['error'] is not 0
+                and result['send'] == 0
+                and result['thread'] == 0
+                and assertion['disable'] in result['error_msg'])
+
+        # username option is disable but another config is ok
+        hypervisor_create(HYPERVISOR, REGISTER, SECOND_HYPERVISOR_FILE, SECOND_HYPERVISOR_SECTION)
+        result = virtwho.run_service()
+        assert (result['error'] is not 0
+                and result['send'] == 1
+                and result['thread'] == 1
+                and assertion['disable_multi_configs'] in result['error_msg'])
+
+        # username option is null but another config is ok
+        function_hypervisor.update('username', '')
+        result = virtwho.run_service()
+        assert (result['error'] is not 0
+                and result['send'] == 1
+                and result['thread'] == 1
+                and assertion['null_multi_configs'] in result['error_msg'])
+
+    @pytest.mark.tier2
+    def test_password(self, virtwho, function_hypervisor, esx_assertion):
+        """Test the password= option in /etc/virt-who.d/test_rhevm.conf
+
+        :title: virt-who: rhevm: test password option
+        :id: 10127e23-95df-4906-a77f-943cf2a271b9
+        :caseimportance: High
+        :tags: tier2
+        :customerscenario: false
+        :upstream: no
+        :steps:
+            1. Configure password option with invalid value.
+            2. Disable the password option in the config file.
+            3. Create another valid config file
+            4. Update the password option with null value
+
+        :expectedresults:
+            1. Failed to run the virt-who service, find error message: 'Unable to login to ESX'
+            2. Find error message: 'Required option: "password" not set'
+            3. Find error message: 'Required option: "password" not set', the good config
+            works fine
+            4. Find error message: 'Unable to login to ESX', the good config works fine
+        """
+        # password option is invalid value
+        assertion = esx_assertion['password']
+        assertion_invalid_list = list(assertion['invalid'].keys())
+        for value in assertion_invalid_list:
+            function_hypervisor.update('password', value)
+            result = virtwho.run_service()
+            assert (result['error'] is not 0
+                    and result['send'] == 0
+                    and result['thread'] == 1
+                    and assertion['invalid'][f'{value}'] in result['error_msg'])
+
+        # password option is disable
+        function_hypervisor.delete('password')
+        result = virtwho.run_service()
+        assert (result['error'] is not 0
+                and result['send'] == 0
+                and result['thread'] == 0
+                and assertion['disable'] in result['error_msg'])
+
+        # password option is disable but another config is ok
+        hypervisor_create(HYPERVISOR, REGISTER, SECOND_HYPERVISOR_FILE, SECOND_HYPERVISOR_SECTION)
+        result = virtwho.run_service()
+        assert (result['error'] is not 0
+                and result['send'] == 1
+                and result['thread'] == 1
+                and assertion['disable_multi_configs'] in result['error_msg'])
+
+        # password option is null but another config is ok
+        function_hypervisor.update('password', '')
+        result = virtwho.run_service()
+        assert (result['error'] is not 0
+                and result['send'] == 1
+                and result['thread'] == 1
+                and assertion['null_multi_configs'] in result['error_msg'])
+
+    @pytest.mark.tier2
+    def test_encrypted_password(self, virtwho, function_hypervisor, esx_assertion,
+                                hypervisor_data, ssh_host):
+        """Test the encrypted_password= option in /etc/virt-who.d/test_rhevm.conf
+
+        :title: virt-who: rhevm: test encrypted_password option
+        :id: 0e2197fe-c806-4f8c-b6ca-e93fb69b07a1
+        :caseimportance: High
+        :tags: tier2
+        :customerscenario: false
+        :upstream: no
+        :steps:
+            1. Configure password option with invalid value.
+            2. Create another valid config file, run the virt-who service
+
+        :expectedresults:
+            1. Failed to run the virt-who service, find warning message:
+            'Option "encrypted_password" cannot be decrypted'
+            2. Find warning message: 'Option "encrypted_password" cannot be decrypted'
+        """
+        # encrypted_password option is invalid value
+        function_hypervisor.delete('password')
+        assertion = esx_assertion['encrypted_password']
+        assertion_invalid_list = list(assertion['invalid'].keys())
+        for value in assertion_invalid_list:
+            function_hypervisor.update('encrypted_password', value)
+            result = virtwho.run_service()
+            assert (result['error'] is not 0
+                    and result['send'] == 0
+                    and result['thread'] == 0
+                    and assertion['invalid'][f'{value}'] in result['warning_msg'])
+
+        # encrypted_password option is valid but another config is ok
+        hypervisor_create(HYPERVISOR, REGISTER, SECOND_HYPERVISOR_FILE, SECOND_HYPERVISOR_SECTION)
+        result = virtwho.run_service()
+        assert (result['error'] is not 0
+                and result['send'] == 1
+                and result['thread'] == 1
+                and assertion['valid_multi_configs'] in result['warning_msg'])
+
+    @pytest.mark.tier2
+    def test_filter_hosts(self, virtwho, function_hypervisor, hypervisor_data):
+        """Test the filter_hosts= option in /etc/virt-who.d/hypervisor.conf
+
+        :title: virt-who: rhevm: test filter_hosts negative option
+        :id: f8f4dae1-7c00-4224-a685-fe86762d795c
+        :caseimportance: High
+        :tags: tier2
+        :customerscenario: false
+        :upstream: no
+        :steps:
+            1. Set hypervisor_id=hostname.
+            2. Configure filter_hosts='*', run the virt-who service.
+            3. Configure filter_hosts=wildcard, run the virt-who service.
+            4. Configure filter_hosts=, run the virt-who service.
+            5. Configure filter_hosts='', run the virt-who service.
+            6. Configure filter_hosts="", run the virt-who service.
+            7. Configure filter_hosts='{hostname}', run the virt-who service.
+            8. Configure filter_hosts="{hostname}, run the virt-who service.
+        :expectedresults:
+            2. Succeeded to run the virt-who, can find hostname in the log message
+            3. Succeeded to run the virt-who, can find hostname in the log message
+            4. Succeeded to run the virt-who, cannot find hostname in the log message
+            5. Succeeded to run the virt-who, cannot find hostname in the log message
+            6. Succeeded to run the virt-who, cannot find hostname in the log message
+            7. Succeeded to run the virt-who, can find hostname in the log message
+            8. Succeeded to run the virt-who, can find hostname in the log message
+        """
+        hypervisor_ids = ['hostname', 'uuid', 'hwuuid']
+        for hypervisor_id in hypervisor_ids:
+            function_hypervisor.update('hypervisor_id', hypervisor_id)
+            hypervisor_id_data = hypervisor_data[f'hypervisor_{hypervisor_id}']
+            wildcard = hypervisor_id_data[:3] + '*' + hypervisor_id_data[4:]
+
+            for filter_hosts in ['*', wildcard]:
+                function_hypervisor.update('filter_hosts', filter_hosts)
+                result = virtwho.run_service()
+                assert (result['error'] == 0
+                        and result['send'] == 1
+                        and result['thread'] == 1
+                        and hypervisor_id_data in str(result['mappings']))
+
+            function_hypervisor.delete('hypervisor_id')
+
+        hostname = hypervisor_data['hypervisor_hostname']
+        function_hypervisor.update('hypervisor_id', 'hostname')
+
+        # config filter_hosts with null option
+        for filter_hosts in ['', "''", '""']:
+            function_hypervisor.update('filter_hosts', filter_hosts)
+            result = virtwho.run_service()
+            assert (result['error'] == 0
+                    and result['send'] == 1
+                    and result['thread'] == 1
+                    and hostname not in str(result['mappings']))
+
+        # config filter_hosts with 'hostname' and "hostname"
+        for filter_hosts in [f"'{hostname}'", f'"{hostname}"']:
+            function_hypervisor.update('filter_hosts', filter_hosts)
+            result = virtwho.run_service()
+            assert (result['error'] == 0
+                    and result['send'] == 1
+                    and result['thread'] == 1
+                    and hostname in str(result['mappings']))
+
+    @pytest.mark.tier2
+    def test_exclude_host(self, virtwho, function_hypervisor, hypervisor_data):
+        """Test the exclude_hosts= option in /etc/virt-who.d/hypervisor.conf
+
+        :title: virt-who: rhevm: test exclude_hosts negative option
+        :id: d779d83c-a5a9-44c2-a331-315c00a78f0c
+        :caseimportance: High
+        :tags: tier2
+        :customerscenario: false
+        :upstream: no
+        :steps:
+            1. Set hypervisor_id=hostname.
+            2. Configure exclude_hosts='*', run the virt-who service.
+            3. Configure exclude_hosts=wildcard, run the virt-who service.
+            4. Configure exclude_hosts=, run the virt-who service.
+            5. Configure exclude_hosts='', run the virt-who service.
+            6. Configure exclude_hosts="", run the virt-who service.
+            7. Configure exclude_hosts='{hostname}', run the virt-who service.
+            8. Configure exclude_hosts="{hostname}, run the virt-who service.
+        :expectedresults:
+            2. Succeeded to run the virt-who, cannot find hostname in the log message
+            3. Succeeded to run the virt-who, cannot find hostname in the log message
+            4. Succeeded to run the virt-who, can find hostname in the log message
+            5. Succeeded to run the virt-who, can find hostname in the log message
+            6. Succeeded to run the virt-who, can find hostname in the log message
+            7. Succeeded to run the virt-who, cannot find hostname in the log message
+            8. Succeeded to run the virt-who, cannot find hostname in the log message
+        """
+        hypervisor_ids = ['hostname', 'uuid', 'hwuuid']
+        for hypervisor_id in hypervisor_ids:
+            function_hypervisor.update('hypervisor_id', hypervisor_id)
+            hypervisor_id_data = hypervisor_data[f'hypervisor_{hypervisor_id}']
+            wildcard = hypervisor_id_data[:3] + '*' + hypervisor_id_data[4:]
+
+            for exclude_hosts in ['*', wildcard]:
+                function_hypervisor.update('exclude_hosts', exclude_hosts)
+                result = virtwho.run_service()
+                assert (result['error'] == 0
+                        and result['send'] == 1
+                        and result['thread'] == 1
+                        and hypervisor_id_data not in str(result['mappings']))
+
+        hostname = hypervisor_data['hypervisor_hostname']
+        function_hypervisor.update('hypervisor_id', 'hostname')
+
+        for exclude_hosts in ['', "''", '""']:
+            function_hypervisor.update('exclude_hosts', exclude_hosts)
+            result = virtwho.run_service()
+            assert (result['error'] == 0
+                    and result['send'] == 1
+                    and result['thread'] == 1
+                    and hostname in str(result['mappings']))
+
+        for exclude_hosts in [f"'{hostname}'", f'"{hostname}"']:
+            function_hypervisor.update('exclude_hosts', exclude_hosts)
+            result = virtwho.run_service()
+            assert (result['error'] == 0
+                    and result['send'] == 1
+                    and result['thread'] == 1
+                    and hostname not in str(result['mappings']))
+
+    @pytest.mark.tier2
+    def test_filter_exclude_mix(self, virtwho, function_hypervisor, hypervisor_data):
+        """Test the filter_hosts= and exclude_hosts= mix option in /etc/virt-who.d/hypervisor.conf
+
+        :title: virt-who: rhevm: test filter_hosts and exclude_hosts related mix function
+        :id: 0d8ed2d8-b646-40b0-accb-2780b9961d2c
+        :caseimportance: High
+        :tags: tier1
+        :customerscenario: false
+        :upstream: no
+        :steps:
+            1. Set hypervisor_id=host_uuid.
+            2. run virt-who with filter_hosts=[host_uuid] and exclude_hosts=[host_uuid]
+            3. run virt-who with filter_hosts=* and exclude_hosts=[host_uuid]
+            4. run virt-who with exclude_hosts= and filter_hosts=[host_uuid]
+
+        :expectedresults:
+            2. Succeeded to run the virt-who, cannot find the log message "hypervisorId": "{host_uuid}"
+            3. Succeeded to run the virt-who, cannot find the log message "hypervisorId": "{host_uuid}"
+            4. Succeeded to run the virt-who, can find the log message "hypervisorId": "{host_uuid}"
+
+        """
+        function_hypervisor.update('hypervisor_id', 'uuid')
+        hypervisor_uuid = hypervisor_data['hypervisor_uuid']
+
+        # run virt-who with filter_hosts=[host_uuid] and exclude_hosts=[host_uuid]
+        function_hypervisor.update('filter_hosts', hypervisor_uuid)
+        function_hypervisor.update('exclude_hosts', hypervisor_uuid)
+        result = virtwho.run_service()
+        assert (result['error'] == 0
+                and result['send'] == 1
+                and result['thread'] == 1
+                and hypervisor_uuid not in str(result['mappings']))
+
+        # run virt-who with filter_hosts=* and exclude_hosts=[host_uuid]
+        function_hypervisor.update('filter_hosts', '*')
+        function_hypervisor.update('exclude_hosts', hypervisor_uuid)
+        result = virtwho.run_service()
+        assert (result['error'] == 0
+                and result['send'] == 1
+                and result['thread'] == 1
+                and hypervisor_uuid not in str(result['mappings']))
+
+        # run virt-who with exclude_hosts= and filter_hosts=[host_uuid]
+        function_hypervisor.update('filter_hosts', hypervisor_uuid)
+        function_hypervisor.update('exclude_hosts', '')
+        result = virtwho.run_service()
+        assert (result['error'] == 0
+                and result['send'] == 1
+                and result['thread'] == 1
+                and hypervisor_uuid in str(result['mappings']))

--- a/tests/hypervisor/test_rhevm.py
+++ b/tests/hypervisor/test_rhevm.py
@@ -197,7 +197,7 @@ class TestRHEVMPositive:
 @pytest.mark.usefixtures('globalconf_clean')
 class TestRHEVMNegative:
     @pytest.mark.tier2
-    def test_type(self, virtwho, function_hypervisor, esx_assertion):
+    def test_type(self, virtwho, function_hypervisor, rhevm_assertion):
         """Test the type= option in /etc/virt-who.d/test_rhevm.conf
 
         :title: virt-who: rhevm: test type option
@@ -219,7 +219,7 @@ class TestRHEVMNegative:
             4. The good config works fine
         """
         # type option is invalid value
-        assertion = esx_assertion['type']
+        assertion = rhevm_assertion['type']
         assertion_invalid_list = list(assertion['invalid'].keys())
         for value in assertion_invalid_list:
             function_hypervisor.update('type', value)

--- a/tests/hypervisor/test_rhevm.py
+++ b/tests/hypervisor/test_rhevm.py
@@ -259,7 +259,7 @@ class TestRHEVMNegative:
             assert result['error'] == 0
 
     @pytest.mark.tier2
-    def test_server(self, virtwho, function_hypervisor, esx_assertion):
+    def test_server(self, virtwho, function_hypervisor, rhevm_assertion):
         """Test the server= option in /etc/virt-who.d/test_rhevm.conf
 
         :title: virt-who: rhevm: test server option
@@ -282,7 +282,7 @@ class TestRHEVMNegative:
             works fine
         """
         # server option is invalid value
-        assertion = esx_assertion['server']
+        assertion = rhevm_assertion['server']
         assertion_invalid_list = list(assertion['invalid'].keys())
         for value in assertion_invalid_list:
             function_hypervisor.update('server', value)
@@ -316,7 +316,7 @@ class TestRHEVMNegative:
                 and assertion['null_multi_configs'] in result['error_msg'])
 
     @pytest.mark.tier2
-    def test_username(self, function_hypervisor, virtwho, esx_assertion):
+    def test_username(self, function_hypervisor, virtwho, rhevm_assertion):
         """Test the username= option in /etc/virt-who.d/test_rhevm.conf
 
         :title: virt-who: rhevm: test username option
@@ -339,7 +339,7 @@ class TestRHEVMNegative:
             4. Find error message: 'Unable to login to ESX', the good config works fine
         """
         # username option is invalid value
-        assertion = esx_assertion['username']
+        assertion = rhevm_assertion['username']
         assertion_invalid_list = list(assertion['invalid'].keys())
         for value in assertion_invalid_list:
             function_hypervisor.update('username', value)
@@ -374,7 +374,7 @@ class TestRHEVMNegative:
                 and assertion['null_multi_configs'] in result['error_msg'])
 
     @pytest.mark.tier2
-    def test_password(self, virtwho, function_hypervisor, esx_assertion):
+    def test_password(self, virtwho, function_hypervisor, rhevm_assertion):
         """Test the password= option in /etc/virt-who.d/test_rhevm.conf
 
         :title: virt-who: rhevm: test password option
@@ -397,7 +397,7 @@ class TestRHEVMNegative:
             4. Find error message: 'Unable to login to ESX', the good config works fine
         """
         # password option is invalid value
-        assertion = esx_assertion['password']
+        assertion = rhevm_assertion['password']
         assertion_invalid_list = list(assertion['invalid'].keys())
         for value in assertion_invalid_list:
             function_hypervisor.update('password', value)
@@ -596,55 +596,3 @@ class TestRHEVMNegative:
                     and result['send'] == 1
                     and result['thread'] == 1
                     and hostname not in str(result['mappings']))
-
-    @pytest.mark.tier2
-    def test_filter_exclude_mix(self, virtwho, function_hypervisor, hypervisor_data):
-        """Test the filter_hosts= and exclude_hosts= mix option in /etc/virt-who.d/hypervisor.conf
-
-        :title: virt-who: rhevm: test filter_hosts and exclude_hosts related mix function
-        :id: 0d8ed2d8-b646-40b0-accb-2780b9961d2c
-        :caseimportance: High
-        :tags: tier1
-        :customerscenario: false
-        :upstream: no
-        :steps:
-            1. Set hypervisor_id=host_uuid.
-            2. run virt-who with filter_hosts=[host_uuid] and exclude_hosts=[host_uuid]
-            3. run virt-who with filter_hosts=* and exclude_hosts=[host_uuid]
-            4. run virt-who with exclude_hosts= and filter_hosts=[host_uuid]
-
-        :expectedresults:
-            2. Succeeded to run the virt-who, cannot find the log message "hypervisorId": "{host_uuid}"
-            3. Succeeded to run the virt-who, cannot find the log message "hypervisorId": "{host_uuid}"
-            4. Succeeded to run the virt-who, can find the log message "hypervisorId": "{host_uuid}"
-
-        """
-        function_hypervisor.update('hypervisor_id', 'uuid')
-        hypervisor_uuid = hypervisor_data['hypervisor_uuid']
-
-        # run virt-who with filter_hosts=[host_uuid] and exclude_hosts=[host_uuid]
-        function_hypervisor.update('filter_hosts', hypervisor_uuid)
-        function_hypervisor.update('exclude_hosts', hypervisor_uuid)
-        result = virtwho.run_service()
-        assert (result['error'] == 0
-                and result['send'] == 1
-                and result['thread'] == 1
-                and hypervisor_uuid not in str(result['mappings']))
-
-        # run virt-who with filter_hosts=* and exclude_hosts=[host_uuid]
-        function_hypervisor.update('filter_hosts', '*')
-        function_hypervisor.update('exclude_hosts', hypervisor_uuid)
-        result = virtwho.run_service()
-        assert (result['error'] == 0
-                and result['send'] == 1
-                and result['thread'] == 1
-                and hypervisor_uuid not in str(result['mappings']))
-
-        # run virt-who with exclude_hosts= and filter_hosts=[host_uuid]
-        function_hypervisor.update('filter_hosts', hypervisor_uuid)
-        function_hypervisor.update('exclude_hosts', '')
-        result = virtwho.run_service()
-        assert (result['error'] == 0
-                and result['send'] == 1
-                and result['thread'] == 1
-                and hypervisor_uuid in str(result['mappings']))

--- a/tests/hypervisor/test_rhevm.py
+++ b/tests/hypervisor/test_rhevm.py
@@ -432,7 +432,7 @@ class TestRHEVMNegative:
                 and assertion['null_multi_configs'] in result['error_msg'])
 
     @pytest.mark.tier2
-    def test_encrypted_password(self, virtwho, function_hypervisor, esx_assertion,
+    def test_encrypted_password(self, virtwho, function_hypervisor, rhevm_assertion,
                                 hypervisor_data, ssh_host):
         """Test the encrypted_password= option in /etc/virt-who.d/test_rhevm.conf
 
@@ -453,7 +453,7 @@ class TestRHEVMNegative:
         """
         # encrypted_password option is invalid value
         function_hypervisor.delete('password')
-        assertion = esx_assertion['encrypted_password']
+        assertion = rhevm_assertion['encrypted_password']
         assertion_invalid_list = list(assertion['invalid'].keys())
         for value in assertion_invalid_list:
             function_hypervisor.update('encrypted_password', value)

--- a/tests/hypervisor/test_rhevm.py
+++ b/tests/hypervisor/test_rhevm.py
@@ -175,6 +175,7 @@ class TestRHEVMPositive:
         """
         host_uuid = hypervisor_data['hypervisor_uuid']
         guest_uuid = hypervisor_data['guest_uuid']
+        function_hypervisor.update('hypervisor_id', 'uuid')
         virtwho.run_cli(prt=True, oneshot=False)
         function_hypervisor.destroy()
 


### PR DESCRIPTION
**Description**
Create the test_rhesm.py cloning the test_esx.py, need to debug it one by one, will select the checkbox for every case once I debug it.

Positive:
- [X] test_encrypted_password
- [X] test_hypervisor_id
- [X] test_filter_hosts
- [X] test_exclude_hosts
- [X] test_fake_type

Negative:
- [X] test_type
- [X] test_server
- [X] test_username
- [X] test_password
- [X] test_encrypted_password
- [X] test_filter_hosts
- [X] test_exclude_hosts

**Test Result**
```
[hkx303@kuhuang virtwho-test]$ pytest -v tests/hypervisor/test_rhevm.py::TestRHEVMPositive::test_encrypted_password -s
==================================== test session starts =====================================
platform linux -- Python 3.7.3, pytest-5.4.3, py-1.8.0, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /home/hkx303/Documents/CI/virtwho-test, inifile: pytest.ini
plugins: services-1.3.1, mock-1.10.4, forked-1.0.2, ibutsu-1.0.34, cov-2.7.1, xdist-1.34.0
collected 1 item  

PASSED

================================ 1 passed in 60.25s (0:01:00) ================================

pytest -v tests/hypervisor/test_rhevm.py::TestRHEVMPositive::test_hypervisor_id -s
==================================== test session starts =====================================
platform linux -- Python 3.7.3, pytest-5.4.3, py-1.8.0, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /home/hkx303/Documents/CI/virtwho-test, inifile: pytest.ini
plugins: services-1.3.1, mock-1.10.4, forked-1.0.2, ibutsu-1.0.34, cov-2.7.1, xdist-1.34.0
collected 1 item   

PASSED

=============================== 1 passed in 262.77s (0:04:22) ================================

[hkx303@kuhuang virtwho-test]$ pytest -v tests/hypervisor/test_rhevm.py::TestRHEVMPositive::test_filter_hosts -s
==================================== test session starts =====================================
platform linux -- Python 3.7.3, pytest-5.4.3, py-1.8.0, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /home/hkx303/Documents/CI/virtwho-test, inifile: pytest.ini
plugins: services-1.3.1, mock-1.10.4, forked-1.0.2, ibutsu-1.0.34, cov-2.7.1, xdist-1.34.0
collected 1 item   

PASSED

=============================== 1 passed in 152.21s (0:02:32) ================================

[hkx303@kuhuang virtwho-test]$ pytest -v tests/hypervisor/test_rhevm.py::TestRHEVMPositive::test_exclude_hosts -s
==================================== test session starts =====================================
platform linux -- Python 3.7.3, pytest-5.4.3, py-1.8.0, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /home/hkx303/Documents/CI/virtwho-test, inifile: pytest.ini
plugins: services-1.3.1, mock-1.10.4, forked-1.0.2, ibutsu-1.0.34, cov-2.7.1, xdist-1.34.0
collected 1 item  

PASSED

=============================== 1 passed in 135.12s (0:02:15) ================================

[hkx303@kuhuang virtwho-test]$ pytest -v tests/hypervisor/test_rhevm.py::TestRHEVMPositive::test_fake_type -s
==================================== test session starts =====================================
platform linux -- Python 3.7.3, pytest-5.4.3, py-1.8.0, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /home/hkx303/Documents/CI/virtwho-test, inifile: pytest.ini
plugins: services-1.3.1, mock-1.10.4, forked-1.0.2, ibutsu-1.0.34, cov-2.7.1, xdist-1.34.0
collected 1 item         

PASSED

=============================== 1 passed in 107.65s (0:01:47) ================================

[hkx303@kuhuang virtwho-test]$ pytest -v tests/hypervisor/test_rhevm.py::TestRHEVMNegative::test_type -s
==================================== test session starts =====================================
platform linux -- Python 3.7.3, pytest-5.4.3, py-1.8.0, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /home/hkx303/Documents/CI/virtwho-test, inifile: pytest.ini
plugins: services-1.3.1, mock-1.10.4, forked-1.0.2, ibutsu-1.0.34, cov-2.7.1, xdist-1.34.0
collected 1 item  

PASSED

=============================== 1 passed in 279.09s (0:04:39) ================================

[hkx303@kuhuang virtwho-test]$ pytest -v tests/hypervisor/test_rhevm.py::TestRHEVMNegative::test_server -s
==================================== test session starts =====================================
platform linux -- Python 3.7.3, pytest-5.4.3, py-1.8.0, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /home/hkx303/Documents/CI/virtwho-test, inifile: pytest.ini
plugins: services-1.3.1, mock-1.10.4, forked-1.0.2, ibutsu-1.0.34, cov-2.7.1, xdist-1.34.0
collected 1 item 

PASSED

=============================== 1 passed in 396.80s (0:06:36) ================================

[hkx303@kuhuang virtwho-test]$ pytest -v tests/hypervisor/test_rhevm.py::TestRHEVMNegative::test_username -s
==================================== test session starts =====================================
platform linux -- Python 3.7.3, pytest-5.4.3, py-1.8.0, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /home/hkx303/Documents/CI/virtwho-test, inifile: pytest.ini
plugins: services-1.3.1, mock-1.10.4, forked-1.0.2, ibutsu-1.0.34, cov-2.7.1, xdist-1.34.0
collected 1 item   

PASSED

=============================== 1 passed in 311.40s (0:05:11) ================================

[hkx303@kuhuang virtwho-test]$ pytest -v tests/hypervisor/test_rhevm.py::TestRHEVMNegative::test_password -s
==================================== test session starts =====================================
platform linux -- Python 3.7.3, pytest-5.4.3, py-1.8.0, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /home/hkx303/Documents/CI/virtwho-test, inifile: pytest.ini
plugins: services-1.3.1, mock-1.10.4, forked-1.0.2, ibutsu-1.0.34, cov-2.7.1, xdist-1.34.0
collected 1 item   

PASSED

=============================== 1 passed in 145.95s (0:04:25) ================================

[hkx303@kuhuang virtwho-test]$ pytest -v tests/hypervisor/test_rhevm.py::TestRHEVMNegative::test_encrypted_password -s
==================================== test session starts =====================================
platform linux -- Python 3.7.3, pytest-5.4.3, py-1.8.0, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /home/hkx303/Documents/CI/virtwho-test, inifile: pytest.ini
plugins: services-1.3.1, mock-1.10.4, forked-1.0.2, ibutsu-1.0.34, cov-2.7.1, xdist-1.34.0
collected 1 item 

PASSED

=============================== 1 passed in 171.39s (0:02:51) ================================

[hkx303@kuhuang virtwho-test]$ pytest -v tests/hypervisor/test_rhevm.py::TestRHEVMNegative::test_filter_hosts -s
==================================== test session starts =====================================
platform linux -- Python 3.7.3, pytest-5.4.3, py-1.8.0, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /home/hkx303/Documents/CI/virtwho-test, inifile: pytest.ini
plugins: services-1.3.1, mock-1.10.4, forked-1.0.2, ibutsu-1.0.34, cov-2.7.1, xdist-1.34.0
collected 1 item      

PASSED

=============================== 1 passed in 567.14s (0:09:27) ================================

[hkx303@kuhuang virtwho-test]$ pytest -v tests/hypervisor/test_rhevm.py::TestRHEVMNegative::test_exclude_host -s
==================================== test session starts =====================================
platform linux -- Python 3.7.3, pytest-5.4.3, py-1.8.0, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /home/hkx303/Documents/CI/virtwho-test, inifile: pytest.ini
plugins: services-1.3.1, mock-1.10.4, forked-1.0.2, ibutsu-1.0.34, cov-2.7.1, xdist-1.34.0
collected 1 item    

PASSED

=============================== 1 passed in 470.10s (0:07:50) ================================
```