### PR TITLE
Add cases for hyperv hypervisor

### DIFF
--- a/tests/hypervisor/conftest.py
+++ b/tests/hypervisor/conftest.py
@@ -121,3 +121,64 @@ def rhevm_assertion():
     }
 
     return data
+
+
+@pytest.fixture(scope='session')
+def hyperv_assertion():
+    """
+    Collect all the assertion info for rhevm to this fixture
+    :return:
+    """
+    login_error = 'Incorrect domain/username/password'
+    data = {
+        'type': {
+            'invalid': {
+                'xxx': "Unsupported virtual type 'xxx' is set",
+                '红帽€467aa': "Unsupported virtual type '红帽€467aa' is set",
+                '': "Unsupported virtual type '' is set",
+            },
+            'non_rhel9': "virt-who can't be started",
+            'disable': "no connection driver available for URI",
+            'disable_multi_configs': "no connection driver available for URI"
+        },
+        'server': {
+            'invalid': {
+                'xxx': 'Name or service not known',
+                '红帽€467aa': 'Unable to connect to Hyper-V server',
+                '': 'Option server needs to be set in config',
+            },
+            'disable': "virt-who can't be started",
+            'disable_multi_configs': 'Required option: "server" not set',
+            'null_multi_configs': 'Option server needs to be set in config',
+        },
+        'username': {
+            'invalid': {
+                'xxx': login_error,
+                '红帽€467aa': login_error,
+                '': login_error,
+            },
+            'disable': 'Required option: "username" not set',
+            'disable_multi_configs': 'Required option: "username" not set',
+            'null_multi_configs': login_error,
+        },
+        'password': {
+            'invalid': {
+                'xxx': login_error,
+                '红帽€467aa': login_error,
+                '': login_error,
+            },
+            'disable': 'Required option: "password" not set',
+            'disable_multi_configs': 'Required option: "password" not set',
+            'null_multi_configs': login_error,
+        },
+        'encrypted_password': {
+            'invalid': {
+                'xxx': 'Required option: "password" not set',
+                '': 'Required option: "password" not set',
+            },
+            'valid_multi_configs': 'Required option: "password" not set'
+        }
+
+    }
+
+    return data

--- a/tests/hypervisor/test_hyperv.py
+++ b/tests/hypervisor/test_hyperv.py
@@ -190,7 +190,7 @@ class TestHypervNegative:
         """Test the type= option in /etc/virt-who.d/test_hyperv.conf
 
         :title: virt-who: hyperv: test type option
-        :id: f2533fe1-5536-4bd5-830b-b2141f0896d7
+        :id: c51a3bcc-bca7-4b45-a55a-8230bb25d7f0
         :caseimportance: High
         :tags: tier2
         :customerscenario: false
@@ -252,7 +252,7 @@ class TestHypervNegative:
         """Test the server= option in /etc/virt-who.d/test_hyperv.conf
 
         :title: virt-who: hyperv: test server option
-        :id: 70eec0cb-317b-4ee9-933c-88ff3310137e
+        :id: ea6c1a97-575d-4b8b-9100-bfd90ab5f26f
         :caseimportance: High
         :tags: tier2
         :customerscenario: false
@@ -309,7 +309,7 @@ class TestHypervNegative:
         """Test the username= option in /etc/virt-who.d/test_hyperv.conf
 
         :title: virt-who: hyperv: test username option
-        :id: 19f8643b-0aa9-4380-b91c-afe6384dbb75
+        :id: ea6c1a97-575d-4b8b-9100-bfd90ab5f26f
         :caseimportance: High
         :tags: tier2
         :customerscenario: false
@@ -367,7 +367,7 @@ class TestHypervNegative:
         """Test the password= option in /etc/virt-who.d/test_hyperv.conf
 
         :title: virt-who: hyperv: test password option
-        :id: 10127e23-95df-4906-a77f-943cf2a271b9
+        :id: efe153df-c9ac-4ae2-9ec1-e5c05a3cc3d0
         :caseimportance: High
         :tags: tier2
         :customerscenario: false
@@ -426,7 +426,7 @@ class TestHypervNegative:
         """Test the encrypted_password= option in /etc/virt-who.d/test_hyperv.conf
 
         :title: virt-who: hyperv: test encrypted_password option
-        :id: 0e2197fe-c806-4f8c-b6ca-e93fb69b07a1
+        :id: 273f9701-1eab-49b1-98c3-d1b38f6f6493
         :caseimportance: High
         :tags: tier2
         :customerscenario: false
@@ -450,7 +450,7 @@ class TestHypervNegative:
             assert (result['error'] is not 0
                     and result['send'] == 0
                     and result['thread'] == 0
-                    and assertion['invalid'][f'{value}'] in result['warning_msg'])
+                    and assertion['invalid'][f'{value}'] in result['error_msg'])
 
         # encrypted_password option is valid but another config is ok
         hypervisor_create(HYPERVISOR, REGISTER, SECOND_HYPERVISOR_FILE, SECOND_HYPERVISOR_SECTION)
@@ -458,14 +458,14 @@ class TestHypervNegative:
         assert (result['error'] is not 0
                 and result['send'] == 1
                 and result['thread'] == 1
-                and assertion['valid_multi_configs'] in result['warning_msg'])
+                and assertion['valid_multi_configs'] in result['error_msg'])
 
     @pytest.mark.tier2
     def test_filter_hosts(self, virtwho, function_hypervisor, hypervisor_data):
         """Test the filter_hosts= option in /etc/virt-who.d/hypervisor.conf
 
         :title: virt-who: hyperv: test filter_hosts negative option
-        :id: f8f4dae1-7c00-4224-a685-fe86762d795c
+        :id: 8531124d-cff1-4ca8-acca-56f28345dcaf
         :caseimportance: High
         :tags: tier2
         :customerscenario: false
@@ -530,7 +530,7 @@ class TestHypervNegative:
         """Test the exclude_hosts= option in /etc/virt-who.d/hypervisor.conf
 
         :title: virt-who: hyperv: test exclude_hosts negative option
-        :id: d779d83c-a5a9-44c2-a331-315c00a78f0c
+        :id: b8b3d98a-0376-48de-88b6-9f7b4da849ac
         :caseimportance: High
         :tags: tier2
         :customerscenario: false

--- a/tests/hypervisor/test_hyperv.py
+++ b/tests/hypervisor/test_hyperv.py
@@ -5,40 +5,583 @@
 :caseautomation: Automated
 """
 import pytest
-from virtwho import logger
+
+from virtwho import REGISTER
+from virtwho import RHEL_COMPOSE
+from virtwho import HYPERVISOR
+from virtwho import PRINT_JSON_FILE
+from virtwho import SECOND_HYPERVISOR_FILE
+from virtwho import SECOND_HYPERVISOR_SECTION
 
 
-class TestHyperv:
+from virtwho.base import encrypt_password
+from virtwho.configure import hypervisor_create
+
+
+@pytest.mark.usefixtures('function_virtwho_d_conf_clean')
+@pytest.mark.usefixtures('debug_true')
+@pytest.mark.usefixtures('globalconf_clean')
+class TestHypervPositive:
     @pytest.mark.tier1
-    def test_hostname_option(self):
-        """Just a demo
+    def test_encrypted_password(self, virtwho, function_hypervisor,
+                                hypervisor_data, ssh_host):
+        """Test the encrypted_password= option in /etc/virt-who.d/test_hyperv.conf
 
-        :title: virt-who: hyperv: test hostname option
-        :id: 4ab41c9b-3b74-4987-a73c-cacf2c9601e1
+        :title: virt-who: hyperv: test encrypted_password option
+        :id: f6f6523f-28f7-4cf7-8282-5820383c68f9
         :caseimportance: High
         :tags: tier1
         :customerscenario: false
         :upstream: no
         :steps:
-            1.
+            1. Delete the password option, encrypted password for the hypervisor.
+            2. Configure encrypted_password option with valid value, run the virt-who service.
+
         :expectedresults:
-            1.
+            2. Succeeded to run the virt-who, no error messages in the log info
         """
-        logger.info("Succeeded to run the 'test_hostname_option'")
+        # encrypted_password option is valid value
+        function_hypervisor.delete('password')
+        encrypted_pwd = encrypt_password(ssh_host, hypervisor_data['hypervisor_password'])
+        function_hypervisor.update('encrypted_password', encrypted_pwd)
+        result = virtwho.run_service()
+        assert (result['error'] == 0
+                and result['send'] == 1
+                and result['thread'] == 1)
 
+    @pytest.mark.tier1
+    def test_hypervisor_id(self, virtwho, function_hypervisor, hypervisor_data, globalconf, rhsm, satellite):
+        """Test the hypervisor_id= option in /etc/virt-who.d/hypervisor.conf
+
+        :title: virt-who: hyperv: test hypervisor_id function
+        :id: 49349a44-18c1-45c8-8edf-758a4f95109d
+        :caseimportance: High
+        :tags: tier1
+        :customerscenario: false
+        :upstream: no
+        :steps:
+
+            1. clean all virt-who global configurations
+            2. run virt-who with hypervisor_id=uuid
+            3. run virt-who with hypervisor_id=hostname
+
+        :expectedresults:
+
+            hypervisor id shows uuid/hostname in mapping as the setting.
+        """
+        hypervisor_ids = ['hostname', 'uuid']
+        for hypervisor_id in hypervisor_ids:
+            function_hypervisor.update('hypervisor_id', hypervisor_id)
+            result = virtwho.run_service()
+            assert (result['error'] == 0
+                    and result['send'] == 1
+                    and result['thread'] == 1
+                    and result['hypervisor_id'] == hypervisor_data[f'hypervisor_{hypervisor_id}'])
+            if REGISTER == 'rhsm':
+                assert rhsm.consumers(hypervisor_data['hypervisor_hostname'])
+                rhsm.delete(hypervisor_data['hypervisor_hostname'])
+            else:
+                if hypervisor_id == 'hostname':
+                    assert satellite.host_id(hypervisor_data['hypervisor_hostname'])
+                    assert not satellite.host_id(hypervisor_data['hypervisor_uuid'])
+                elif hypervisor_id == 'uuid':
+                    assert satellite.host_id(hypervisor_data['hypervisor_uuid'])
+                    assert not satellite.host_id(hypervisor_data['hypervisor_hostname'])
+
+    @pytest.mark.tier1
+    def test_filter_hosts(self, virtwho, function_hypervisor, hypervisor_data):
+        """Test the filter_hosts= option in /etc/virt-who.d/hypervisor.conf
+
+        :title: virt-who: hyperv: test filter_hosts option
+        :id: 45bd062a-96a9-44cf-ac00-4c108a4d3351
+        :caseimportance: High
+        :tags: tier1
+        :customerscenario: false
+        :upstream: no
+        :steps:
+            1. Set hypervisor_id=hostname.
+            2. Configure filter_hosts={hostname}, run the virt-who service.
+            3. Configure filter_hosts={host_uuid}, run the virt-who service.
+        :expectedresults:
+            2. Succeeded to run the virt-who, can find hostname in the log message
+            3. Succeeded to run the virt-who, can find host_uuid in the log message
+        """
+        hypervisor_ids = ['hostname', 'uuid']
+        for hypervisor_id in hypervisor_ids:
+            function_hypervisor.update('hypervisor_id', hypervisor_id)
+            hypervisor_id_data = hypervisor_data[f'hypervisor_{hypervisor_id}']
+
+            function_hypervisor.update('filter_hosts', hypervisor_id_data)
+            result = virtwho.run_service()
+            assert (result['error'] == 0
+                    and result['send'] == 1
+                    and result['thread'] == 1
+                    and hypervisor_id_data in str(result['mappings']))
+
+    @pytest.mark.tier1
+    def test_exclude_hosts(self, virtwho, function_hypervisor, hypervisor_data):
+        """Test the exclude_hosts= option in /etc/virt-who.d/hypervisor.conf
+
+        :title: virt-who: hyperv: test exclude_hosts option
+        :id: 41677d4c-2bef-4e6d-8e48-55d1d6f7ae14
+        :caseimportance: High
+        :tags: tier1
+        :customerscenario: false
+        :upstream: no
+        :steps:
+            1. Set hypervisor_id=hostname.
+            2. Configure exclude_hosts={hostname}, run the virt-who service.
+            3. Configure exclude_hosts={host_uuid}, run the virt-who service.
+        :expectedresults:
+            2. Succeeded to run the virt-who, cannot find hostname in the log message
+            3. Succeeded to run the virt-who, cannot find host_uuid in the log message
+        """
+        hypervisor_ids = ['hostname', 'uuid']
+        for hypervisor_id in hypervisor_ids:
+            function_hypervisor.update('hypervisor_id', hypervisor_id)
+            hypervisor_id_data = hypervisor_data[f'hypervisor_{hypervisor_id}']
+
+            function_hypervisor.update('exclude_hosts', hypervisor_id_data)
+            result = virtwho.run_service()
+            assert (result['error'] == 0
+                    and result['send'] == 1
+                    and result['thread'] == 1
+                    and hypervisor_id_data not in str(result['mappings']))
+
+    def test_fake_type(self, virtwho, function_hypervisor, hypervisor_data):
+        """Test the fake type in /etc/virt-who.d/hypervisor.conf
+
+        :title: virt-who: hyperv: test fake type
+        :id: a2c30d57-4eae-451e-b131-2547f046463c
+            1. Generate the json file by virt-who -p -d command
+            2. Create the virt-who config for the fake mode testing
+            3. Check the rhsm.log
+
+        :expectedresults:
+            1. Can find the json data in the specific path
+            2. Succeed to run the virt-who service, can find the host_uuid and guest_uuid in the
+            rhsm.log file
+        """
+        host_uuid = hypervisor_data['hypervisor_uuid']
+        guest_uuid = hypervisor_data['guest_uuid']
+        function_hypervisor.update('hypervisor_id', 'uuid')
+        virtwho.run_cli(prt=True, oneshot=False)
+        function_hypervisor.destroy()
+
+        fake_config = hypervisor_create('fake', REGISTER, rhsm=False)
+        fake_config.update('file', PRINT_JSON_FILE)
+        fake_config.update('is_hypervisor', 'True')
+        result = virtwho.run_service()
+        assert (result['error'] == 0
+                and result['send'] == 1
+                and result['thread'] == 1
+                and host_uuid in result['log']
+                and guest_uuid in result['log'])
+        # Todo: Need to add the test cases for host-guest association in mapping, web and the test
+        #  cases for the vdc pool's subscription.
+
+
+@pytest.mark.usefixtures('function_virtwho_d_conf_clean')
+@pytest.mark.usefixtures('debug_true')
+@pytest.mark.usefixtures('globalconf_clean')
+class TestHypervNegative:
     @pytest.mark.tier2
-    def test_http_option(self):
-        """Just a demo
+    def test_type(self, virtwho, function_hypervisor, hyperv_assertion):
+        """Test the type= option in /etc/virt-who.d/test_hyperv.conf
 
-        :title: virt-who: hyperv: test http option
-        :id: 52f8f2df-ef7b-48b3-9579-364ea77e8409
+        :title: virt-who: hyperv: test type option
+        :id: f2533fe1-5536-4bd5-830b-b2141f0896d7
         :caseimportance: High
         :tags: tier2
         :customerscenario: false
         :upstream: no
         :steps:
-            1.
+            1. Configure type option with invalid value.
+            2. Disable the type option in the config file.
+            3. Create another valid config file
+            4. Update the type option with null value
+
         :expectedresults:
-            1.
+            1. Failed to run the virt-who service, find error messages
+            2. Find error message: Error in libvirt backend
+            3. Find error message, the good config works fine
+            4. The good config works fine
         """
-        logger.info("Succeeded to run the 'test_http_option'")
+        # type option is invalid value
+        assertion = hyperv_assertion['type']
+        assertion_invalid_list = list(assertion['invalid'].keys())
+        for value in assertion_invalid_list:
+            function_hypervisor.update('type', value)
+            result = virtwho.run_service()
+            assert (result['error'] is not 0
+                    and result['send'] == 0
+                    and result['thread'] == 0)
+            if 'RHEL-9' in RHEL_COMPOSE:
+                assert assertion['invalid'][f'{value}'] in result['error_msg']
+            else:
+                assert assertion['non_rhel9'] in result['error_msg']
+
+        # type option is disable
+        function_hypervisor.delete('type')
+        result = virtwho.run_service()
+        assert (result['error'] is not 0
+                and result['send'] == 0
+                and result['thread'] == 1
+                and assertion['disable'] in result['error_msg'])
+
+        # type option is disable but another config is ok
+        hypervisor_create(HYPERVISOR, REGISTER, SECOND_HYPERVISOR_FILE, SECOND_HYPERVISOR_SECTION)
+        result = virtwho.run_service()
+        assert (result['error'] is not 0
+                and result['send'] == 1
+                and result['thread'] == 1
+                and assertion['disable_multi_configs'] in result['error_msg'])
+
+        # type option is null but another config is ok
+        function_hypervisor.update('type', '')
+        result = virtwho.run_service()
+        assert (result['send'] == 1
+                and result['thread'] == 1)
+        if 'RHEL-9' in RHEL_COMPOSE:
+            assert result['error'] == 1
+        else:
+            assert result['error'] == 0
+
+    @pytest.mark.tier2
+    def test_server(self, virtwho, function_hypervisor, hyperv_assertion):
+        """Test the server= option in /etc/virt-who.d/test_hyperv.conf
+
+        :title: virt-who: hyperv: test server option
+        :id: 70eec0cb-317b-4ee9-933c-88ff3310137e
+        :caseimportance: High
+        :tags: tier2
+        :customerscenario: false
+        :upstream: no
+        :steps:
+            1. Configure server option with invalid value.
+            2. Disable the server option in the config file.
+            3. Create another valid config file
+            4. Update the server option with null value
+
+        :expectedresults:
+            1. Failed to run the virt-who service, find error messages
+            2. Find error message: virt-who can't be started
+            3. Find error message: 'Required option: "server" not set', the good config works fine
+            4. Find error message: 'Option server needs to be set in config', the good config
+            works fine
+        """
+        # server option is invalid value
+        assertion = hyperv_assertion['server']
+        assertion_invalid_list = list(assertion['invalid'].keys())
+        for value in assertion_invalid_list:
+            function_hypervisor.update('server', value)
+            result = virtwho.run_service()
+            assert (result['error'] is not 0
+                    and result['send'] == 0
+                    and assertion['invalid'][f'{value}'] in result['error_msg'])
+
+        # server option is disable
+        function_hypervisor.delete('server')
+        result = virtwho.run_service()
+        assert (result['error'] is not 0
+                and result['send'] == 0
+                and result['thread'] == 0
+                and assertion['disable'] in result['error_msg'])
+
+        # server option is disable but another config is ok
+        hypervisor_create(HYPERVISOR, REGISTER, SECOND_HYPERVISOR_FILE, SECOND_HYPERVISOR_SECTION)
+        result = virtwho.run_service()
+        assert (result['error'] is not 0
+                and result['send'] == 1
+                and result['thread'] == 1
+                and assertion['disable_multi_configs'] in result['error_msg'])
+
+        # server option is null but another config is ok
+        function_hypervisor.update('server', '')
+        result = virtwho.run_service()
+        assert (result['error'] is not 0
+                and result['send'] == 1
+                and result['thread'] == 1
+                and assertion['null_multi_configs'] in result['error_msg'])
+
+    @pytest.mark.tier2
+    def test_username(self, function_hypervisor, virtwho, hyperv_assertion):
+        """Test the username= option in /etc/virt-who.d/test_hyperv.conf
+
+        :title: virt-who: hyperv: test username option
+        :id: 19f8643b-0aa9-4380-b91c-afe6384dbb75
+        :caseimportance: High
+        :tags: tier2
+        :customerscenario: false
+        :upstream: no
+        :steps:
+            1. Configure username option with invalid value.
+            2. Disable the username option in the config file.
+            3. Create another valid config file
+            4. Update the username option with null value
+
+        :expectedresults:
+            1. Failed to run the virt-who service, find error message: 'Unable to login to ESX'
+            2. Find error message: 'Required option: "username" not set'
+            3. Find error message: 'Required option: "username" not set', the good config
+            works fine
+            4. Find error message: 'Unable to login to ESX', the good config works fine
+        """
+        # username option is invalid value
+        assertion = hyperv_assertion['username']
+        assertion_invalid_list = list(assertion['invalid'].keys())
+        for value in assertion_invalid_list:
+            function_hypervisor.update('username', value)
+            result = virtwho.run_service()
+            assert (result['error'] is not 0
+                    and result['send'] == 0
+                    and result['thread'] == 1
+                    and assertion['invalid'][f'{value}'] in result['error_msg'])
+
+        # username option is disable
+        function_hypervisor.delete('username')
+        result = virtwho.run_service()
+        assert (result['error'] is not 0
+                and result['send'] == 0
+                and result['thread'] == 0
+                and assertion['disable'] in result['error_msg'])
+
+        # username option is disable but another config is ok
+        hypervisor_create(HYPERVISOR, REGISTER, SECOND_HYPERVISOR_FILE, SECOND_HYPERVISOR_SECTION)
+        result = virtwho.run_service()
+        assert (result['error'] is not 0
+                and result['send'] == 1
+                and result['thread'] == 1
+                and assertion['disable_multi_configs'] in result['error_msg'])
+
+        # username option is null but another config is ok
+        function_hypervisor.update('username', '')
+        result = virtwho.run_service()
+        assert (result['error'] is not 0
+                and result['send'] == 1
+                and result['thread'] == 1
+                and assertion['null_multi_configs'] in result['error_msg'])
+
+    @pytest.mark.tier2
+    def test_password(self, virtwho, function_hypervisor, hyperv_assertion):
+        """Test the password= option in /etc/virt-who.d/test_hyperv.conf
+
+        :title: virt-who: hyperv: test password option
+        :id: 10127e23-95df-4906-a77f-943cf2a271b9
+        :caseimportance: High
+        :tags: tier2
+        :customerscenario: false
+        :upstream: no
+        :steps:
+            1. Configure password option with invalid value.
+            2. Disable the password option in the config file.
+            3. Create another valid config file
+            4. Update the password option with null value
+
+        :expectedresults:
+            1. Failed to run the virt-who service, find error message: 'Unable to login to ESX'
+            2. Find error message: 'Required option: "password" not set'
+            3. Find error message: 'Required option: "password" not set', the good config
+            works fine
+            4. Find error message: 'Unable to login to ESX', the good config works fine
+        """
+        # password option is invalid value
+        assertion = hyperv_assertion['password']
+        assertion_invalid_list = list(assertion['invalid'].keys())
+        for value in assertion_invalid_list:
+            function_hypervisor.update('password', value)
+            result = virtwho.run_service()
+            assert (result['error'] is not 0
+                    and result['send'] == 0
+                    and result['thread'] == 1
+                    and assertion['invalid'][f'{value}'] in result['error_msg'])
+
+        # password option is disable
+        function_hypervisor.delete('password')
+        result = virtwho.run_service()
+        assert (result['error'] is not 0
+                and result['send'] == 0
+                and result['thread'] == 0
+                and assertion['disable'] in result['error_msg'])
+
+        # password option is disable but another config is ok
+        hypervisor_create(HYPERVISOR, REGISTER, SECOND_HYPERVISOR_FILE, SECOND_HYPERVISOR_SECTION)
+        result = virtwho.run_service()
+        assert (result['error'] is not 0
+                and result['send'] == 1
+                and result['thread'] == 1
+                and assertion['disable_multi_configs'] in result['error_msg'])
+
+        # password option is null but another config is ok
+        function_hypervisor.update('password', '')
+        result = virtwho.run_service()
+        assert (result['error'] is not 0
+                and result['send'] == 1
+                and result['thread'] == 1
+                and assertion['null_multi_configs'] in result['error_msg'])
+
+    @pytest.mark.tier2
+    def test_encrypted_password(self, virtwho, function_hypervisor, hyperv_assertion,
+                                hypervisor_data, ssh_host):
+        """Test the encrypted_password= option in /etc/virt-who.d/test_hyperv.conf
+
+        :title: virt-who: hyperv: test encrypted_password option
+        :id: 0e2197fe-c806-4f8c-b6ca-e93fb69b07a1
+        :caseimportance: High
+        :tags: tier2
+        :customerscenario: false
+        :upstream: no
+        :steps:
+            1. Configure password option with invalid value.
+            2. Create another valid config file, run the virt-who service
+
+        :expectedresults:
+            1. Failed to run the virt-who service, find warning message:
+            'Option "encrypted_password" cannot be decrypted'
+            2. Find warning message: 'Option "encrypted_password" cannot be decrypted'
+        """
+        # encrypted_password option is invalid value
+        function_hypervisor.delete('password')
+        assertion = hyperv_assertion['encrypted_password']
+        assertion_invalid_list = list(assertion['invalid'].keys())
+        for value in assertion_invalid_list:
+            function_hypervisor.update('encrypted_password', value)
+            result = virtwho.run_service()
+            assert (result['error'] is not 0
+                    and result['send'] == 0
+                    and result['thread'] == 0
+                    and assertion['invalid'][f'{value}'] in result['warning_msg'])
+
+        # encrypted_password option is valid but another config is ok
+        hypervisor_create(HYPERVISOR, REGISTER, SECOND_HYPERVISOR_FILE, SECOND_HYPERVISOR_SECTION)
+        result = virtwho.run_service()
+        assert (result['error'] is not 0
+                and result['send'] == 1
+                and result['thread'] == 1
+                and assertion['valid_multi_configs'] in result['warning_msg'])
+
+    @pytest.mark.tier2
+    def test_filter_hosts(self, virtwho, function_hypervisor, hypervisor_data):
+        """Test the filter_hosts= option in /etc/virt-who.d/hypervisor.conf
+
+        :title: virt-who: hyperv: test filter_hosts negative option
+        :id: f8f4dae1-7c00-4224-a685-fe86762d795c
+        :caseimportance: High
+        :tags: tier2
+        :customerscenario: false
+        :upstream: no
+        :steps:
+            1. Set hypervisor_id=hostname.
+            2. Configure filter_hosts='*', run the virt-who service.
+            3. Configure filter_hosts=wildcard, run the virt-who service.
+            4. Configure filter_hosts=, run the virt-who service.
+            5. Configure filter_hosts='', run the virt-who service.
+            6. Configure filter_hosts="", run the virt-who service.
+            7. Configure filter_hosts='{hostname}', run the virt-who service.
+            8. Configure filter_hosts="{hostname}, run the virt-who service.
+        :expectedresults:
+            2. Succeeded to run the virt-who, can find hostname in the log message
+            3. Succeeded to run the virt-who, can find hostname in the log message
+            4. Succeeded to run the virt-who, cannot find hostname in the log message
+            5. Succeeded to run the virt-who, cannot find hostname in the log message
+            6. Succeeded to run the virt-who, cannot find hostname in the log message
+            7. Succeeded to run the virt-who, can find hostname in the log message
+            8. Succeeded to run the virt-who, can find hostname in the log message
+        """
+        hypervisor_ids = ['hostname', 'uuid']
+        for hypervisor_id in hypervisor_ids:
+            function_hypervisor.update('hypervisor_id', hypervisor_id)
+            hypervisor_id_data = hypervisor_data[f'hypervisor_{hypervisor_id}']
+            wildcard = hypervisor_id_data[:3] + '*' + hypervisor_id_data[4:]
+
+            for filter_hosts in ['*', wildcard]:
+                function_hypervisor.update('filter_hosts', filter_hosts)
+                result = virtwho.run_service()
+                assert (result['error'] == 0
+                        and result['send'] == 1
+                        and result['thread'] == 1
+                        and hypervisor_id_data in str(result['mappings']))
+
+            function_hypervisor.delete('hypervisor_id')
+
+        hostname = hypervisor_data['hypervisor_hostname']
+        function_hypervisor.update('hypervisor_id', 'hostname')
+
+        # config filter_hosts with null option
+        for filter_hosts in ['', "''", '""']:
+            function_hypervisor.update('filter_hosts', filter_hosts)
+            result = virtwho.run_service()
+            assert (result['error'] == 0
+                    and result['send'] == 1
+                    and result['thread'] == 1
+                    and hostname not in str(result['mappings']))
+
+        # config filter_hosts with 'hostname' and "hostname"
+        for filter_hosts in [f"'{hostname}'", f'"{hostname}"']:
+            function_hypervisor.update('filter_hosts', filter_hosts)
+            result = virtwho.run_service()
+            assert (result['error'] == 0
+                    and result['send'] == 1
+                    and result['thread'] == 1
+                    and hostname in str(result['mappings']))
+
+    @pytest.mark.tier2
+    def test_exclude_host(self, virtwho, function_hypervisor, hypervisor_data):
+        """Test the exclude_hosts= option in /etc/virt-who.d/hypervisor.conf
+
+        :title: virt-who: hyperv: test exclude_hosts negative option
+        :id: d779d83c-a5a9-44c2-a331-315c00a78f0c
+        :caseimportance: High
+        :tags: tier2
+        :customerscenario: false
+        :upstream: no
+        :steps:
+            1. Set hypervisor_id=hostname.
+            2. Configure exclude_hosts='*', run the virt-who service.
+            3. Configure exclude_hosts=wildcard, run the virt-who service.
+            4. Configure exclude_hosts=, run the virt-who service.
+            5. Configure exclude_hosts='', run the virt-who service.
+            6. Configure exclude_hosts="", run the virt-who service.
+            7. Configure exclude_hosts='{hostname}', run the virt-who service.
+            8. Configure exclude_hosts="{hostname}, run the virt-who service.
+        :expectedresults:
+            2. Succeeded to run the virt-who, cannot find hostname in the log message
+            3. Succeeded to run the virt-who, cannot find hostname in the log message
+            4. Succeeded to run the virt-who, can find hostname in the log message
+            5. Succeeded to run the virt-who, can find hostname in the log message
+            6. Succeeded to run the virt-who, can find hostname in the log message
+            7. Succeeded to run the virt-who, cannot find hostname in the log message
+            8. Succeeded to run the virt-who, cannot find hostname in the log message
+        """
+        hypervisor_ids = ['hostname', 'uuid']
+        for hypervisor_id in hypervisor_ids:
+            function_hypervisor.update('hypervisor_id', hypervisor_id)
+            hypervisor_id_data = hypervisor_data[f'hypervisor_{hypervisor_id}']
+            wildcard = hypervisor_id_data[:3] + '*' + hypervisor_id_data[4:]
+
+            for exclude_hosts in ['*', wildcard]:
+                function_hypervisor.update('exclude_hosts', exclude_hosts)
+                result = virtwho.run_service()
+                assert (result['error'] == 0
+                        and result['send'] == 1
+                        and result['thread'] == 1
+                        and hypervisor_id_data not in str(result['mappings']))
+
+        hostname = hypervisor_data['hypervisor_hostname']
+        function_hypervisor.update('hypervisor_id', 'hostname')
+
+        for exclude_hosts in ['', "''", '""']:
+            function_hypervisor.update('exclude_hosts', exclude_hosts)
+            result = virtwho.run_service()
+            assert (result['error'] == 0
+                    and result['send'] == 1
+                    and result['thread'] == 1
+                    and hostname in str(result['mappings']))
+
+        for exclude_hosts in [f"'{hostname}'", f'"{hostname}"']:
+            function_hypervisor.update('exclude_hosts', exclude_hosts)
+            result = virtwho.run_service()
+            assert (result['error'] == 0
+                    and result['send'] == 1
+                    and result['thread'] == 1
+                    and hostname not in str(result['mappings']))


### PR DESCRIPTION
**Description**
Positive
- [x] test_encrypted_password
- [x] test_hypervisor_id
- [x] test_filter_hosts
- [x] test_exclude_hosts
- [x] test_fake_type

Negative

- [x] test_type
- [x] test_server
- [x] test_username
- [x] test_password
- [x] test_encrypted_password
- [x] test_filter_hosts
- [x] test_exclude_host

**Test Result**

```
[hkx303@kuhuang virtwho-test]$ pytest -v tests/hypervisor/test_hyperv.py::TestHypervPositive::test_encrypted_password -s
==================================== test session starts =====================================
platform linux -- Python 3.7.3, pytest-5.4.3, py-1.8.0, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /home/hkx303/Documents/CI/virtwho-test, inifile: pytest.ini
plugins: services-1.3.1, mock-1.10.4, forked-1.0.2, ibutsu-1.0.34, cov-2.7.1, xdist-1.34.0
collected 1 item

PASSED
===================================== 1 passed in 59.69s =====================================

[hkx303@kuhuang virtwho-test]$ pytest -v tests/hypervisor/test_hyperv.py::TestHypervPositive::test_hypervisor_id -s
==================================== test session starts =====================================
platform linux -- Python 3.7.3, pytest-5.4.3, py-1.8.0, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /home/hkx303/Documents/CI/virtwho-test, inifile: pytest.ini
plugins: services-1.3.1, mock-1.10.4, forked-1.0.2, ibutsu-1.0.34, cov-2.7.1, xdist-1.34.0
collected 1 item

PASSED
=============================== 1 passed in 127.70s (0:02:07) ================================

[hkx303@kuhuang virtwho-test]$ pytest -v tests/hypervisor/test_hyperv.py::TestHypervPositive::test_filter_hosts -s
==================================== test session starts =====================================
platform linux -- Python 3.7.3, pytest-5.4.3, py-1.8.0, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /home/hkx303/Documents/CI/virtwho-test, inifile: pytest.ini
plugins: services-1.3.1, mock-1.10.4, forked-1.0.2, ibutsu-1.0.34, cov-2.7.1, xdist-1.34.0
collected 1 item

PASSED
================================ 1 passed in 95.68s (0:01:35) ================================

[hkx303@kuhuang virtwho-test]$ pytest -v tests/hypervisor/test_hyperv.py::TestHypervPositive::test_exclude_hosts -s
==================================== test session starts =====================================
platform linux -- Python 3.7.3, pytest-5.4.3, py-1.8.0, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /home/hkx303/Documents/CI/virtwho-test, inifile: pytest.ini
plugins: services-1.3.1, mock-1.10.4, forked-1.0.2, ibutsu-1.0.34, cov-2.7.1, xdist-1.34.0
collected 1 item

PASSED
================================ 1 passed in 95.18s (0:01:35) ================================

[hkx303@kuhuang virtwho-test]$ pytest -v tests/hypervisor/test_hyperv.py::TestHypervPositive::test_fake_type -s
==================================== test session starts =====================================
platform linux -- Python 3.7.3, pytest-5.4.3, py-1.8.0, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /home/hkx303/Documents/CI/virtwho-test, inifile: pytest.ini
plugins: services-1.3.1, mock-1.10.4, forked-1.0.2, ibutsu-1.0.34, cov-2.7.1, xdist-1.34.0
collected 1 item

PASSED
================================ 1 passed in 99.86s (0:01:39) ================================

[hkx303@kuhuang virtwho-test]$ pytest -v tests/hypervisor/test_hyperv.py::TestHypervNegative::test_type -s
==================================== test session starts =====================================
platform linux -- Python 3.7.3, pytest-5.4.3, py-1.8.0, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /home/hkx303/Documents/CI/virtwho-test, inifile: pytest.ini
plugins: services-1.3.1, mock-1.10.4, forked-1.0.2, ibutsu-1.0.34, cov-2.7.1, xdist-1.34.0
collected 1 item

PASSED
=============================== 1 passed in 245.84s (0:04:05) ================================

[hkx303@kuhuang virtwho-test]$ pytest -v tests/hypervisor/test_hyperv.py::TestHypervNegative::test_server -s
==================================== test session starts =====================================
platform linux -- Python 3.7.3, pytest-5.4.3, py-1.8.0, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /home/hkx303/Documents/CI/virtwho-test, inifile: pytest.ini
plugins: services-1.3.1, mock-1.10.4, forked-1.0.2, ibutsu-1.0.34, cov-2.7.1, xdist-1.34.0
collected 1 item

PASSED
=============================== 1 passed in 249.05s (0:04:09) ================================

[hkx303@kuhuang virtwho-test]$ pytest -v tests/hypervisor/test_hyperv.py::TestHypervNegative::test_username -s
==================================== test session starts =====================================
platform linux -- Python 3.7.3, pytest-5.4.3, py-1.8.0, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /home/hkx303/Documents/CI/virtwho-test, inifile: pytest.ini
plugins: services-1.3.1, mock-1.10.4, forked-1.0.2, ibutsu-1.0.34, cov-2.7.1, xdist-1.34.0
collected 1 item

PASSED
=============================== 1 passed in 248.54s (0:04:08) ================================

[hkx303@kuhuang virtwho-test]$ pytest -v tests/hypervisor/test_hyperv.py::TestHypervNegative::test_password -s
==================================== test session starts =====================================
platform linux -- Python 3.7.3, pytest-5.4.3, py-1.8.0, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /home/hkx303/Documents/CI/virtwho-test, inifile: pytest.ini
plugins: services-1.3.1, mock-1.10.4, forked-1.0.2, ibutsu-1.0.34, cov-2.7.1, xdist-1.34.0
collected 1 item

PASSED
=============================== 1 passed in 247.57s (0:04:07) ================================

[hkx303@kuhuang virtwho-test]$ pytest -v tests/hypervisor/test_hyperv.py::TestHypervNegative::test_encrypted_password -s
==================================== test session starts =====================================
platform linux -- Python 3.7.3, pytest-5.4.3, py-1.8.0, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /home/hkx303/Documents/CI/virtwho-test, inifile: pytest.ini
plugins: services-1.3.1, mock-1.10.4, forked-1.0.2, ibutsu-1.0.34, cov-2.7.1, xdist-1.34.0
collected 1 item

PASSED
=============================== 1 passed in 138.54s (0:02:18) ================================

[hkx303@kuhuang virtwho-test]$ pytest -v tests/hypervisor/test_hyperv.py::TestHypervNegative::test_filter_hosts -s
==================================== test session starts =====================================
platform linux -- Python 3.7.3, pytest-5.4.3, py-1.8.0, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /home/hkx303/Documents/CI/virtwho-test, inifile: pytest.ini
plugins: services-1.3.1, mock-1.10.4, forked-1.0.2, ibutsu-1.0.34, cov-2.7.1, xdist-1.34.0
collected 1 item
PASSED
=============================== 1 passed in 357.73s (0:05:57) ================================

[hkx303@kuhuang virtwho-test]$ pytest -v tests/hypervisor/test_hyperv.py::TestHypervNegative::test_exclude_host -s
==================================== test session starts =====================================
platform linux -- Python 3.7.3, pytest-5.4.3, py-1.8.0, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /home/hkx303/Documents/CI/virtwho-test, inifile: pytest.ini
plugins: services-1.3.1, mock-1.10.4, forked-1.0.2, ibutsu-1.0.34, cov-2.7.1, xdist-1.34.0
collected 1 item

PASSED
=============================== 1 passed in 354.09s (0:05:54) ================================
```