### PR TITLE
Add positive and negative cases for kubevirt mode

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -196,7 +196,7 @@ def hypervisor_data(ssh_guest):
         data['cpu'] = hypervisor_handler.cpu
     if HYPERVISOR == 'ahv':
         data['cluster'] = hypervisor_handler.cluster
-    if HYPERVISOR is not 'kubevirt':
+    if HYPERVISOR != 'kubevirt':
         data['hypervisor_password'] = hypervisor_handler.password
     return data
 

--- a/tests/hypervisor/conftest.py
+++ b/tests/hypervisor/conftest.py
@@ -182,3 +182,25 @@ def hyperv_assertion():
     }
 
     return data
+
+
+@pytest.fixture(scope='session')
+def kubevirt_assertion():
+    """
+    Collect all the assertion info for kubevirt to this fixture
+    :return:
+    """
+    data = {
+        'type': {
+            'invalid': {
+                'xxx': "Unsupported virtual type 'xxx' is set",
+                '红帽€467aa': "Unsupported virtual type '红帽€467aa' is set",
+                '': "Unsupported virtual type '' is set",
+            },
+            'non_rhel9': "virt-who can't be started",
+            'disable': "Failed to connect socket to '/var/run/libvirt/libvirt-sock-ro'",
+            'disable_multi_configs': "Failed to connect socket to '/var/run/libvirt/libvirt-sock-ro'"
+        },
+    }
+
+    return data

--- a/tests/hypervisor/test_kubevirt.py
+++ b/tests/hypervisor/test_kubevirt.py
@@ -5,40 +5,342 @@
 :caseautomation: Automated
 """
 import pytest
-from virtwho import logger
+
+from virtwho import REGISTER
+from virtwho import RHEL_COMPOSE
+from virtwho import HYPERVISOR
+from virtwho import PRINT_JSON_FILE
+from virtwho import SECOND_HYPERVISOR_FILE
+from virtwho import SECOND_HYPERVISOR_SECTION
 
 
-class TestKubevirt:
+from virtwho.configure import hypervisor_create
+
+
+@pytest.mark.usefixtures('function_virtwho_d_conf_clean')
+@pytest.mark.usefixtures('debug_true')
+@pytest.mark.usefixtures('globalconf_clean')
+class TestKubevirtPositive:
     @pytest.mark.tier1
-    def test_hostname_option(self):
-        """Just a demo
+    def test_hypervisor_id(self, virtwho, function_hypervisor, hypervisor_data, globalconf, rhsm, satellite):
+        """Test the hypervisor_id= option in /etc/virt-who.d/hypervisor.conf
 
-        :title: virt-who: kubevirt: test hostname option
-        :id: 633ca810-0fc1-4861-a54c-f2b00b98ed59
+        :title: virt-who: kubevirt: test hypervisor_id function
+        :id: c72b5b8b-3b10-49e4-8268-540d1b5a2630
         :caseimportance: High
         :tags: tier1
         :customerscenario: false
         :upstream: no
         :steps:
-            1.
+
+            1. clean all virt-who global configurations
+            2. run virt-who with hypervisor_id=uuid
+            3. run virt-who with hypervisor_id=hostname
+
         :expectedresults:
-            1.
+
+            hypervisor id shows uuid/hostname in mapping as the setting.
         """
-        logger.info("Succeeded to run the 'test_hostname_option'")
+        hypervisor_ids = ['hostname', 'uuid']
+        for hypervisor_id in hypervisor_ids:
+            function_hypervisor.update('hypervisor_id', hypervisor_id)
+            result = virtwho.run_service()
+            assert (result['error'] == 0
+                    and result['send'] == 1
+                    and result['thread'] == 1
+                    and result['hypervisor_id'] == hypervisor_data[f'hypervisor_{hypervisor_id}'])
+            if REGISTER == 'rhsm':
+                assert rhsm.consumers(hypervisor_data['hypervisor_hostname'])
+                rhsm.delete(hypervisor_data['hypervisor_hostname'])
+            else:
+                if hypervisor_id == 'hostname':
+                    assert satellite.host_id(hypervisor_data['hypervisor_hostname'])
+                    assert not satellite.host_id(hypervisor_data['hypervisor_uuid'])
+                elif hypervisor_id == 'uuid':
+                    assert satellite.host_id(hypervisor_data['hypervisor_uuid'])
+                    assert not satellite.host_id(hypervisor_data['hypervisor_hostname'])
 
+    @pytest.mark.tier1
+    def test_filter_hosts(self, virtwho, function_hypervisor, hypervisor_data):
+        """Test the filter_hosts= option in /etc/virt-who.d/hypervisor.conf
+
+        :title: virt-who: kubevirt: test filter_hosts option
+        :id: b26052e6-daba-467c-ac2c-012fe0fd8248
+        :caseimportance: High
+        :tags: tier1
+        :customerscenario: false
+        :upstream: no
+        :steps:
+            1. Set hypervisor_id=hostname.
+            2. Configure filter_hosts={hostname}, run the virt-who service.
+            3. Configure filter_hosts={host_uuid}, run the virt-who service.
+        :expectedresults:
+            2. Succeeded to run the virt-who, can find hostname in the log message
+            3. Succeeded to run the virt-who, can find host_uuid in the log message
+        """
+        hypervisor_ids = ['hostname', 'uuid']
+        for hypervisor_id in hypervisor_ids:
+            function_hypervisor.update('hypervisor_id', hypervisor_id)
+            hypervisor_id_data = hypervisor_data[f'hypervisor_{hypervisor_id}']
+
+            function_hypervisor.update('filter_hosts', hypervisor_id_data)
+            result = virtwho.run_service()
+            assert (result['error'] == 0
+                    and result['send'] == 1
+                    and result['thread'] == 1
+                    and hypervisor_id_data in str(result['mappings']))
+
+    @pytest.mark.tier1
+    def test_exclude_hosts(self, virtwho, function_hypervisor, hypervisor_data):
+        """Test the exclude_hosts= option in /etc/virt-who.d/hypervisor.conf
+
+        :title: virt-who: kubevirt: test exclude_hosts option
+        :id: 7067ef5a-6289-4db1-b7bd-a4466407f522
+        :caseimportance: High
+        :tags: tier1
+        :customerscenario: false
+        :upstream: no
+        :steps:
+            1. Set hypervisor_id=hostname.
+            2. Configure exclude_hosts={hostname}, run the virt-who service.
+            3. Configure exclude_hosts={host_uuid}, run the virt-who service.
+        :expectedresults:
+            2. Succeeded to run the virt-who, cannot find hostname in the log message
+            3. Succeeded to run the virt-who, cannot find host_uuid in the log message
+        """
+        hypervisor_ids = ['hostname', 'uuid']
+        for hypervisor_id in hypervisor_ids:
+            function_hypervisor.update('hypervisor_id', hypervisor_id)
+            hypervisor_id_data = hypervisor_data[f'hypervisor_{hypervisor_id}']
+
+            function_hypervisor.update('exclude_hosts', hypervisor_id_data)
+            result = virtwho.run_service()
+            assert (result['error'] == 0
+                    and result['send'] == 1
+                    and result['thread'] == 1
+                    and hypervisor_id_data not in str(result['mappings']))
+
+    def test_fake_type(self, virtwho, function_hypervisor, hypervisor_data):
+        """Test the fake type in /etc/virt-who.d/hypervisor.conf
+
+        :title: virt-who: kubevirt: test fake type
+        :id: 8f130d78-28c4-4efb-9e02-3167b4e15be1
+            1. Generate the json file by virt-who -p -d command
+            2. Create the virt-who config for the fake mode testing
+            3. Check the rhsm.log
+
+        :expectedresults:
+            1. Can find the json data in the specific path
+            2. Succeed to run the virt-who service, can find the host_uuid and guest_uuid in the
+            rhsm.log file
+        """
+        host_uuid = hypervisor_data['hypervisor_uuid']
+        guest_uuid = hypervisor_data['guest_uuid']
+        function_hypervisor.update('hypervisor_id', 'uuid')
+        virtwho.run_cli(prt=True, oneshot=False)
+        function_hypervisor.destroy()
+
+        fake_config = hypervisor_create('fake', REGISTER, rhsm=False)
+        fake_config.update('file', PRINT_JSON_FILE)
+        fake_config.update('is_hypervisor', 'True')
+        result = virtwho.run_service()
+        assert (result['error'] == 0
+                and result['send'] == 1
+                and result['thread'] == 1
+                and host_uuid in result['log']
+                and guest_uuid in result['log'])
+        # Todo: Need to add the test cases for host-guest association in mapping, web and the test
+        #  cases for the vdc pool's subscription.
+
+
+@pytest.mark.usefixtures('function_virtwho_d_conf_clean')
+@pytest.mark.usefixtures('debug_true')
+@pytest.mark.usefixtures('globalconf_clean')
+class TestKubevirtNegative:
     @pytest.mark.tier2
-    def test_http_option(self):
-        """Just a demo
+    def test_type(self, virtwho, function_hypervisor, kubevirt_assertion):
+        """Test the type= option in /etc/virt-who.d/test_kubevirt.conf
 
-        :title: virt-who: kubevirt: test http option
-        :id: cd99fc7e-0d26-4ba3-8aca-a5f6a9c656b0
+        :title: virt-who: kubevirt: test type option
+        :id: cf06f7a2-e417-45bd-bcea-48d1cac3736c
         :caseimportance: High
         :tags: tier2
         :customerscenario: false
         :upstream: no
         :steps:
-            1.
+            1. Configure type option with invalid value.
+            2. Disable the type option in the config file.
+            3. Create another valid config file
+            4. Update the type option with null value
+
         :expectedresults:
-            1.
+            1. Failed to run the virt-who service, find error messages
+            2. Find error message: Error in libvirt backend
+            3. Find error message, the good config works fine
+            4. The good config works fine
         """
-        logger.info("Succeeded to run the 'test_http_option'")
+        # type option is invalid value
+        assertion = kubevirt_assertion['type']
+        assertion_invalid_list = list(assertion['invalid'].keys())
+        for value in assertion_invalid_list:
+            function_hypervisor.update('type', value)
+            result = virtwho.run_service()
+            assert (result['error'] is not 0
+                    and result['send'] == 0
+                    and result['thread'] == 0)
+            if 'RHEL-9' in RHEL_COMPOSE:
+                assert assertion['invalid'][f'{value}'] in result['error_msg']
+            else:
+                assert assertion['non_rhel9'] in result['error_msg']
+
+        # type option is disable
+        function_hypervisor.delete('type')
+        result = virtwho.run_service()
+        assert (result['error'] is not 0
+                and result['send'] == 0
+                and result['thread'] == 1
+                and assertion['disable'] in result['error_msg'])
+
+        # type option is disable but another config is ok
+        hypervisor_create(HYPERVISOR, REGISTER, SECOND_HYPERVISOR_FILE, SECOND_HYPERVISOR_SECTION)
+        result = virtwho.run_service()
+        assert (result['error'] is not 0
+                and result['send'] == 1
+                and result['thread'] == 1
+                and assertion['disable_multi_configs'] in result['error_msg'])
+
+        # type option is null but another config is ok
+        function_hypervisor.update('type', '')
+        result = virtwho.run_service()
+        assert (result['send'] == 1
+                and result['thread'] == 1)
+        if 'RHEL-9' in RHEL_COMPOSE:
+            assert result['error'] == 1
+        else:
+            assert result['error'] == 0
+
+    @pytest.mark.tier2
+    def test_filter_hosts(self, virtwho, function_hypervisor, hypervisor_data):
+        """Test the filter_hosts= option in /etc/virt-who.d/kubevirtisor.conf
+
+        :title: virt-who: kubevirt: test filter_hosts negative option
+        :id: 24d7bb49-cd9b-4cd3-85d1-fa86af2d581d
+        :caseimportance: High
+        :tags: tier2
+        :customerscenario: false
+        :upstream: no
+        :steps:
+            1. Set hypervisor_id=hostname.
+            2. Configure filter_hosts='*', run the virt-who service.
+            3. Configure filter_hosts=wildcard, run the virt-who service.
+            4. Configure filter_hosts=, run the virt-who service.
+            5. Configure filter_hosts='', run the virt-who service.
+            6. Configure filter_hosts="", run the virt-who service.
+            7. Configure filter_hosts='{hostname}', run the virt-who service.
+            8. Configure filter_hosts="{hostname}, run the virt-who service.
+        :expectedresults:
+            2. Succeeded to run the virt-who, can find hostname in the log message
+            3. Succeeded to run the virt-who, can find hostname in the log message
+            4. Succeeded to run the virt-who, cannot find hostname in the log message
+            5. Succeeded to run the virt-who, cannot find hostname in the log message
+            6. Succeeded to run the virt-who, cannot find hostname in the log message
+            7. Succeeded to run the virt-who, can find hostname in the log message
+            8. Succeeded to run the virt-who, can find hostname in the log message
+        """
+        hypervisor_ids = ['hostname', 'uuid']
+        for hypervisor_id in hypervisor_ids:
+            function_hypervisor.update('hypervisor_id', hypervisor_id)
+            hypervisor_id_data = hypervisor_data[f'hypervisor_{hypervisor_id}']
+            wildcard = hypervisor_id_data[:3] + '*' + hypervisor_id_data[4:]
+
+            for filter_hosts in ['*', wildcard]:
+                function_hypervisor.update('filter_hosts', filter_hosts)
+                result = virtwho.run_service()
+                assert (result['error'] == 0
+                        and result['send'] == 1
+                        and result['thread'] == 1
+                        and hypervisor_id_data in str(result['mappings']))
+
+            function_hypervisor.delete('hypervisor_id')
+
+        hostname = hypervisor_data['hypervisor_hostname']
+        function_hypervisor.update('hypervisor_id', 'hostname')
+
+        # config filter_hosts with null option
+        for filter_hosts in ['', "''", '""']:
+            function_hypervisor.update('filter_hosts', filter_hosts)
+            result = virtwho.run_service()
+            assert (result['error'] == 0
+                    and result['send'] == 1
+                    and result['thread'] == 1
+                    and hostname not in str(result['mappings']))
+
+        # config filter_hosts with 'hostname' and "hostname"
+        for filter_hosts in [f"'{hostname}'", f'"{hostname}"']:
+            function_hypervisor.update('filter_hosts', filter_hosts)
+            result = virtwho.run_service()
+            assert (result['error'] == 0
+                    and result['send'] == 1
+                    and result['thread'] == 1
+                    and hostname in str(result['mappings']))
+
+    @pytest.mark.tier2
+    def test_exclude_host(self, virtwho, function_hypervisor, hypervisor_data):
+        """Test the exclude_hosts= option in /etc/virt-who.d/hypervisor.conf
+
+        :title: virt-who: kubevirt: test exclude_hosts negative option
+        :id: ee14d972-cd47-4f64-9237-f704f275cf56
+        :caseimportance: High
+        :tags: tier2
+        :customerscenario: false
+        :upstream: no
+        :steps:
+            1. Set hypervisor_id=hostname.
+            2. Configure exclude_hosts='*', run the virt-who service.
+            3. Configure exclude_hosts=wildcard, run the virt-who service.
+            4. Configure exclude_hosts=, run the virt-who service.
+            5. Configure exclude_hosts='', run the virt-who service.
+            6. Configure exclude_hosts="", run the virt-who service.
+            7. Configure exclude_hosts='{hostname}', run the virt-who service.
+            8. Configure exclude_hosts="{hostname}, run the virt-who service.
+        :expectedresults:
+            2. Succeeded to run the virt-who, cannot find hostname in the log message
+            3. Succeeded to run the virt-who, cannot find hostname in the log message
+            4. Succeeded to run the virt-who, can find hostname in the log message
+            5. Succeeded to run the virt-who, can find hostname in the log message
+            6. Succeeded to run the virt-who, can find hostname in the log message
+            7. Succeeded to run the virt-who, cannot find hostname in the log message
+            8. Succeeded to run the virt-who, cannot find hostname in the log message
+        """
+        hypervisor_ids = ['hostname', 'uuid']
+        for hypervisor_id in hypervisor_ids:
+            function_hypervisor.update('hypervisor_id', hypervisor_id)
+            hypervisor_id_data = hypervisor_data[f'hypervisor_{hypervisor_id}']
+            wildcard = hypervisor_id_data[:3] + '*' + hypervisor_id_data[4:]
+
+            for exclude_hosts in ['*', wildcard]:
+                function_hypervisor.update('exclude_hosts', exclude_hosts)
+                result = virtwho.run_service()
+                assert (result['error'] == 0
+                        and result['send'] == 1
+                        and result['thread'] == 1
+                        and hypervisor_id_data not in str(result['mappings']))
+
+        hostname = hypervisor_data['hypervisor_hostname']
+        function_hypervisor.update('hypervisor_id', 'hostname')
+
+        for exclude_hosts in ['', "''", '""']:
+            function_hypervisor.update('exclude_hosts', exclude_hosts)
+            result = virtwho.run_service()
+            assert (result['error'] == 0
+                    and result['send'] == 1
+                    and result['thread'] == 1
+                    and hostname in str(result['mappings']))
+
+        for exclude_hosts in [f"'{hostname}'", f'"{hostname}"']:
+            function_hypervisor.update('exclude_hosts', exclude_hosts)
+            result = virtwho.run_service()
+            assert (result['error'] == 0
+                    and result['send'] == 1
+                    and result['thread'] == 1
+                    and hostname not in str(result['mappings']))


### PR DESCRIPTION
**Description**
TestKubevirtPositive
- [x] test_hypervisor_id
- [x] test_filter_hosts
- [x] test_exclude_hosts
- [x] test_fake_type

 TestKubevirtNegative
- [x] test_type
- [x] test_filter_hosts
- [x] test_exclude_host

**Test Result**
```
[hkx303@kuhuang virtwho-test]$ pytest tests/hypervisor/test_kubevirt.py -k test_hypervisor_id -s
================================ test session starts ================================
platform linux -- Python 3.7.3, pytest-5.4.3, py-1.8.0, pluggy-0.13.1
rootdir: /home/hkx303/Documents/CI/virtwho-test, inifile: pytest.ini
plugins: services-1.3.1, mock-1.10.4, forked-1.0.2, ibutsu-1.0.34, cov-2.7.1, xdist-1.34.0
collected 11 items / 10 deselected / 1 selected
.
=================== 1 passed, 10 deselected in 132.67s (0:02:12) ====================

[hkx303@kuhuang virtwho-test]$ pytest tests/hypervisor/test_kubevirt.py::TestKubevirtPositive::test_filter_hosts -s
==================================== test session starts =====================================
platform linux -- Python 3.7.3, pytest-5.4.3, py-1.8.0, pluggy-0.13.1
rootdir: /home/hkx303/Documents/CI/virtwho-test, inifile: pytest.ini
plugins: services-1.3.1, mock-1.10.4, forked-1.0.2, ibutsu-1.0.34, cov-2.7.1, xdist-1.34.0
collected 1 item
.
================================ 1 passed in 95.12s (0:01:35) ================================

[hkx303@kuhuang virtwho-test]$ pytest tests/hypervisor/test_kubevirt.py::TestKubevirtPositive::test_exclude_hosts -s
==================================== test session starts =====================================
platform linux -- Python 3.7.3, pytest-5.4.3, py-1.8.0, pluggy-0.13.1
rootdir: /home/hkx303/Documents/CI/virtwho-test, inifile: pytest.ini
plugins: services-1.3.1, mock-1.10.4, forked-1.0.2, ibutsu-1.0.34, cov-2.7.1, xdist-1.34.0
collected 1 item
.
================================ 1 passed in 96.58s (0:01:36) ================================

[hkx303@kuhuang virtwho-test]$ pytest tests/hypervisor/test_kubevirt.py::TestKubevirtPositive::test_fake_type -s
==================================== test session starts =====================================
platform linux -- Python 3.7.3, pytest-5.4.3, py-1.8.0, pluggy-0.13.1
rootdir: /home/hkx303/Documents/CI/virtwho-test, inifile: pytest.ini
plugins: services-1.3.1, mock-1.10.4, forked-1.0.2, ibutsu-1.0.34, cov-2.7.1, xdist-1.34.0
collected 1 item
=============================== 1 passed in 101.57s (0:01:41) ================================

[hkx303@kuhuang virtwho-test]$ pytest tests/hypervisor/test_kubevirt.py::TestKubevirtNegative::test_type -s
==================================== test session starts =====================================
platform linux -- Python 3.7.3, pytest-5.4.3, py-1.8.0, pluggy-0.13.1
rootdir: /home/hkx303/Documents/CI/virtwho-test, inifile: pytest.ini
plugins: services-1.3.1, mock-1.10.4, forked-1.0.2, ibutsu-1.0.34, cov-2.7.1, xdist-1.34.0
collected 1 item
.
=============================== 1 passed in 242.94s (0:04:02) ================================

[hkx303@kuhuang virtwho-test]$ pytest -v tests/hypervisor/test_kubevirt.py::TestKubevirtNegative::test_filter_hosts tests/hypervisor/test_kubevirt.py::TestKubevirtNegative::test_exclude_host
==================================== test session starts =====================================
platform linux -- Python 3.7.3, pytest-5.4.3, py-1.8.0, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /home/hkx303/Documents/CI/virtwho-test, inifile: pytest.ini
plugins: services-1.3.1, mock-1.10.4, forked-1.0.2, ibutsu-1.0.34, cov-2.7.1, xdist-1.34.0
collected 2 items
tests/hypervisor/test_kubevirt.py::TestKubevirtNegative::test_filter_hosts PASSED      [ 50%]
tests/hypervisor/test_kubevirt.py::TestKubevirtNegative::test_exclude_host PASSED      [100%]
=============================== 2 passed in 724.31s (0:12:04) ================================
```
