### PR TITLE
maintain virtwho_host.py to comment create repo

### DIFF
--- a/virtwho/provision/virtwho_host.py
+++ b/virtwho/provision/virtwho_host.py
@@ -50,9 +50,10 @@ def provision_virtwho_host(args):
     )
 
     # Initially setup the virt-who host
-    base.rhel_compose_repo(
-        ssh_host, args.rhel_compose, '/etc/yum.repos.d/compose.repo'
-    )
+    # Comment the rhel_compose_repo because all hosts contains repos default.
+    # base.rhel_compose_repo(
+    #     ssh_host, args.rhel_compose, '/etc/yum.repos.d/compose.repo'
+    # )
     base.system_init(ssh_host, 'virtwho')
     virtwho_pkg = virtwho_install(ssh_host, args.virtwho_pkg_url)
 


### PR DESCRIPTION
No need to create repo individually because all the hosts will be deployed by beaker, so the correct repo will be here normally as default. 