### PR TITLE
virtwho_host: perfet to support the stable hosts for gating test

### DIFF
--- a/virtwho/base.py
+++ b/virtwho/base.py
@@ -135,7 +135,7 @@ def host_ping(host, port=22):
     :param host: host ip/fqdn
     :param port: host port
     """
-    ret = os.system(f'ping -w 5 {host} -p {port}')
+    ret = os.system(f'ping -c 5 {host} -p {port}')
     if ret == 0:
         return True
     return False

--- a/virtwho/provision/virtwho_host.py
+++ b/virtwho/provision/virtwho_host.py
@@ -25,17 +25,26 @@ def provision_virtwho_host(args):
     logger.info("+++ Start to deploy the virt-who host +++")
 
     virtwho_ini_props = dict()
+    # Parse CI_MESSAGE for gating test
     if args.gating_msg:
         msg = umb_ci_message_parser(args)
         args.virtwho_pkg_url = msg['pkg_url']
-        if 'el9' in msg['pkg_nvr']:
+        if (
+                'el9' in msg['pkg_nvr']
+                and
+                host_ping(config.gating.host_el9)
+        ):
             args.server = config.gating.host_el9
-        if 'el8' in msg['pkg_nvr']:
+        if (
+                'el8' in msg['pkg_nvr']
+                and
+                host_ping(config.gating.host_el9)
+        ):
             args.server = config.gating.host_el8
-        if not host_ping(args.server):
-            args.server = ''
-            if not args.rhel_compose:
-                args.rhel_compose = rhel_latest_compose(msg['rhel_release'])
+
+        if not args.rhel_compose:
+            args.rhel_compose = rhel_latest_compose(msg['rhel_release'])
+
         virtwho_ini_props['gating'] = {
             'package_nvr': msg['pkg_nvr'],
             'build_id': str(msg['build_id']),


### PR DESCRIPTION
- update the `base.host_ping()` to use `-c` to support the both linux and mac os, mac doesn't support the `-w`
- update `virtwho_host.py` for gating test, will firstly try to ping and use the solid virt-who host, if fail to ping will deploy a new one by beaker.