### PR TITLE
virtwho_hypervisor: maintain for esx to get correct guest_uuid

### DIFF
--- a/utils/properties_update.py
+++ b/utils/properties_update.py
@@ -53,7 +53,7 @@ def virtwho_ini_update(section, option, value):
     Used to called by other functions
     """
     os.system(
-        f'python {curPath}/properties_update.py '
+        f'python3 {curPath}/properties_update.py '
         f'--section={section} '
         f'--option={option} '
         f'--value="{value}"'

--- a/virtwho/base.py
+++ b/virtwho/base.py
@@ -488,3 +488,17 @@ def get_host_domain_id(host_hwuuid, log_info):
     domain_id = re.findall(
         fr"Skipping host '{host_hwuuid}' because its parent '(.*?)'", log_info)[0]
     return domain_id
+
+
+def rhel_host_uuid_get(ssh):
+    """
+    Get the host domain_id from rhsm.log using the regular expression
+    :param ssh: ssh access of testing host
+    :return: rhel host uuid
+    """
+    ret, output = ssh.runcmd(f'dmidecode -t system |grep UUID')
+    if ret == 0 and 'UUID' in output:
+        uuid = output.split(':')[1].strip()
+        return uuid
+    return None
+

--- a/virtwho/provision/virtwho_hypervisor.py
+++ b/virtwho/provision/virtwho_hypervisor.py
@@ -11,7 +11,7 @@ sys.path.append(os.path.split(rootPath)[0])
 from virtwho import logger
 from virtwho.settings import config
 from virtwho.ssh import SSHConnect
-from virtwho.base import hostname_get, host_ping, ssh_connect
+from virtwho.base import hostname_get, host_ping, ssh_connect, rhel_host_uuid_get
 from utils.properties_update import virtwho_ini_update
 from hypervisor.virt.libvirt.libvirtcli import LibvirtCLI
 from hypervisor.virt.esx.powercli import PowerCLI
@@ -82,6 +82,12 @@ def esx_monitor():
         if ret1 and ret2 and ret3:
             logger.info(f'>>>vCenter: Get the Hypervisor data.')
             esx_data = esx.guest_search(guest_name, uuid_info=True)
+            ssh_guest = SSHConnect(
+                host=esx_data['guest_ip'],
+                user=config.esx.guest_username,
+                pwd=config.esx.guest_password,
+            )
+            esx_data['guest_uuid'] = rhel_host_uuid_get(ssh_guest)
             esx_data['esx_hostname'] = hostname_get(ssh_esx)
             logger.info(
                 f'=== vCenter Data:\n{esx_data}\n===')


### PR DESCRIPTION
- define the new function `rhel_host_uuid_get` to get correct uuid from guest side, not from vcenter side by powercli
