### PR TITLE
update several fixtures in cases due to the name changes in conftest

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -65,6 +65,13 @@ def function_virtwho_d_conf_clean(ssh_host):
     ssh_host.runcmd(cmd)
 
 
+@pytest.fixture(scope='class')
+def class_virtwho_d_conf_clean(ssh_host):
+    """Clean all config files in /etc/virt-who.d/ folder"""
+    cmd = "rm -rf /etc/virt-who.d/*"
+    ssh_host.runcmd(cmd)
+
+
 @pytest.fixture(scope='function')
 def function_sysconfig():
     return VirtwhoSysConfig(HYPERVISOR)

--- a/tests/function/test_cli.py
+++ b/tests/function/test_cli.py
@@ -8,8 +8,8 @@ import pytest
 from virtwho import HYPERVISOR_FILE
 
 
-@pytest.mark.usefixtures('globalconf_clean')
-@pytest.mark.usefixtures('hypervisor')
+@pytest.mark.usefixtures('class_globalconf_clean')
+@pytest.mark.usefixtures('class_hypervisor')
 class TestCli:
     @pytest.mark.tier1
     def test_debug(self, virtwho):

--- a/tests/function/test_config.py
+++ b/tests/function/test_config.py
@@ -13,8 +13,8 @@ from virtwho import REGISTER
 from virtwho.base import hostname_get
 
 
-@pytest.mark.usefixtures('globalconf_clean')
-@pytest.mark.usefixtures('hypervisor')
+@pytest.mark.usefixtures('class_globalconf_clean')
+@pytest.mark.usefixtures('class_hypervisor')
 class TestConfiguration:
     @pytest.mark.tier1
     def test_debug_in_virtwho_conf(self, virtwho, globalconf):
@@ -346,7 +346,7 @@ class TestConfiguration:
 
     @pytest.mark.tier1
     def test_owner_in_virtwho_conf(self, virtwho, globalconf, hypervisor, hypervisor_data,
-                                   owner_data, debug_true):
+                                   owner_data, class_debug_true):
         """Test the owner option in /etc/virtwho.conf
 
         :title: virt-who: config: test owner option
@@ -505,7 +505,7 @@ class TestConfiguration:
 @pytest.mark.rhel8
 class TestSysConfiguration:
     @pytest.mark.tier1
-    def test_debug_in_virtwho_sysconfig(self, virtwho, sysconfig):
+    def test_debug_in_virtwho_sysconfig(self, virtwho, function_sysconfig):
         """Test the VIRTWHO_DEBUG option in /etc/sysconfig/virt-who
 
         :title: virt-who: config: test VIRTWHO_DEBUG option
@@ -524,22 +524,22 @@ class TestSysConfiguration:
             1. no [DEBUG] log printed
             2. [DEBUG] logs are printed with the configuration
         """
-        sysconfig.update(**{'VIRTWHO_DEBUG': '1'})
+        function_sysconfig.update(**{'VIRTWHO_DEBUG': '1'})
         result = virtwho.run_service()
         assert (result['send'] == 1
                 and result['error'] == 0
                 and result['debug'] is True)
 
-        sysconfig.update(**{'VIRTWHO_DEBUG': '0'})
+        function_sysconfig.update(**{'VIRTWHO_DEBUG': '0'})
         result = virtwho.run_service()
         assert (result['send'] == 1
                 and result['error'] == 0
                 and result['debug'] is False)
 
-        sysconfig.clean()
+        function_sysconfig.clean()
 
     @pytest.mark.tier1
-    def test_oneshot_in_virtwho_sysocnfig(self, virtwho, sysconfig):
+    def test_oneshot_in_virtwho_sysocnfig(self, virtwho, function_sysconfig):
         """Test the VIRTWHO_ONE_SHOT option in /etc/sysconfig/virt-who
 
         :title: virt-who: config: test VIRTWHO_ONE_SHOT option
@@ -560,7 +560,7 @@ class TestSysConfiguration:
         """
         sysconfg_options = {'VIRTWHO_DEBUG': '1',
                             'VIRTWHO_ONE_SHOT': '1'}
-        sysconfig.update(**sysconfg_options)
+        function_sysconfig.update(**sysconfg_options)
         result = virtwho.run_service()
         assert (result['send'] == 1
                 and result['error'] == 0
@@ -568,17 +568,17 @@ class TestSysConfiguration:
                 and result['oneshot'] is True)
 
         sysconfg_options['VIRTWHO_ONE_SHOT'] = 0
-        sysconfig.update(**sysconfg_options)
+        function_sysconfig.update(**sysconfg_options)
         result = virtwho.run_service()
         assert (result['send'] == 1
                 and result['error'] == 0
                 and result['terminate'] == 0
                 and result['oneshot'] is False)
 
-        sysconfig.clean()
+        function_sysconfig.clean()
 
     @pytest.mark.tier1
-    def test_interval_in_virtwho_sysocnfig(self, virtwho, sysconfig):
+    def test_interval_in_virtwho_sysocnfig(self, virtwho, function_sysconfig):
         """Test the VIRTWHO_INTERVAL option in /etc/sysconfig/virt-who
 
         :title: virt-who: config: test VIRTWHO_INTERVAL option
@@ -598,17 +598,17 @@ class TestSysConfiguration:
         """
         sysconfg_options = {'VIRTWHO_DEBUG': '1',
                             'VIRTWHO_INTERVAL': '10'}
-        sysconfig.update(**sysconfg_options)
+        function_sysconfig.update(**sysconfg_options)
         result = virtwho.run_service()
         assert (result['send'] == 1
                 and result['error'] == 0
                 and result['interval'] == 3600)
 
         sysconfg_options['VIRTWHO_INTERVAL'] = 60
-        sysconfig.update(**sysconfg_options)
+        function_sysconfig.update(**sysconfg_options)
         result = virtwho.run_service(wait=60)
         assert (result['send'] == 1
                 and result['error'] == 0
                 and result['loop'] == 60)
 
-        sysconfig.clean()
+        function_sysconfig.clean()

--- a/tests/function/test_config.py
+++ b/tests/function/test_config.py
@@ -15,6 +15,7 @@ from virtwho.base import hostname_get
 
 @pytest.mark.usefixtures('class_globalconf_clean')
 @pytest.mark.usefixtures('class_hypervisor')
+@pytest.mark.usefixtures('class_virtwho_d_conf_clean')
 class TestConfiguration:
     @pytest.mark.tier1
     def test_debug_in_virtwho_conf(self, virtwho, globalconf):
@@ -500,8 +501,9 @@ class TestConfiguration:
             globalconf.delete('system_environment')
 
 
-@pytest.mark.usefixtures('globalconf_clean')
-@pytest.mark.usefixtures('hypervisor')
+@pytest.mark.usefixtures('class_globalconf_clean')
+@pytest.mark.usefixtures('class_hypervisor')
+@pytest.mark.usefixtures('class_virtwho_d_conf_clean')
 @pytest.mark.rhel8
 class TestSysConfiguration:
     @pytest.mark.tier1

--- a/tests/function/test_service.py
+++ b/tests/function/test_service.py
@@ -7,7 +7,7 @@
 import pytest
 
 
-@pytest.mark.usefixtures('globalconf_clean')
+@pytest.mark.usefixtures('class_globalconf_clean')
 class TestVirtwhoService:
     @pytest.mark.tier1
     def test_start_and_stop(self, virtwho):

--- a/tests/gating/test_gating.py
+++ b/tests/gating/test_gating.py
@@ -8,8 +8,8 @@ import pytest
 from virtwho import HYPERVISOR, REGISTER
 
 
-@pytest.mark.usefixtures('globalconf_clean')
-@pytest.mark.usefixtures('hypervisor')
+@pytest.mark.usefixtures('class_globalconf_clean')
+@pytest.mark.usefixtures('class_hypervisor')
 class TestGating:
     def test_debug(self, virtwho):
         """Test the '-d' option in virt-who command line
@@ -73,7 +73,7 @@ class TestGating:
                 and result['thread'] == 0
                 and result['terminate'] == 1)
 
-    def test_interval(self, virtwho, globalconf, debug_true):
+    def test_interval(self, virtwho, globalconf, class_debug_true):
         """Test the interval option in /etc/virt-who.conf
 
         :title: virt-who: gating: test interval function
@@ -110,7 +110,7 @@ class TestGating:
                 and result['interval'] == 60
                 and result['loop'] == 60)
 
-    def test_hypervisor_id(self, virtwho, hypervisor, hypervisor_data):
+    def test_hypervisor_id(self, virtwho, class_hypervisor, hypervisor_data):
         """Test the hypervisor_id= option in /etc/virt-who.d/hypervisor.conf
 
         :title: virt-who: gating: test hypervisor_id function
@@ -131,14 +131,14 @@ class TestGating:
             hypervisor id shows uuid/hostname/hwuuid in mapping as the setting.
         """
         try:
-            hypervisor.update('hypervisor_id', 'uuid')
+            class_hypervisor.update('hypervisor_id', 'uuid')
             result = virtwho.run_cli()
             assert (result['send'] == 1
                     and
                     result['hypervisor_id'] == hypervisor_data[
                         'hypervisor_uuid'])
 
-            hypervisor.update('hypervisor_id', 'hostname')
+            class_hypervisor.update('hypervisor_id', 'hostname')
             result = virtwho.run_cli()
             assert (result['send'] == 1
                     and
@@ -146,14 +146,14 @@ class TestGating:
                         'hypervisor_hostname'])
 
             if HYPERVISOR in ['esx', 'rhevm']:
-                hypervisor.update('hypervisor_id', 'hwuuid')
+                class_hypervisor.update('hypervisor_id', 'hwuuid')
                 result = virtwho.run_cli()
                 assert (result['send'] == 1
                         and
                         result['hypervisor_id'] == hypervisor_data[
                             'hypervisor_hwuuid'])
         finally:
-            hypervisor.update('hypervisor_id', 'hostname')
+            class_hypervisor.update('hypervisor_id', 'hostname')
 
     def test_host_guest_association(self, virtwho, register_data, hypervisor_data):
         """Test the host to guest association from mapping
@@ -184,7 +184,7 @@ class TestGating:
                 and virtwho.associate_in_mapping(
                     result, default_org, hypervisor_hostname, guest_uuid))
 
-    def test_vdc_bonus_pool(self, virtwho, sm_guest, register_guest,
+    def test_vdc_bonus_pool(self, virtwho, sm_guest, function_guest_register,
                             satellite, rhsm, hypervisor_data, sku_data,
                             vdc_pool_physical):
         """Test the vdc subscription can derive bonus pool for guest using

--- a/tests/hypervisor/test_ahv.py
+++ b/tests/hypervisor/test_ahv.py
@@ -19,8 +19,8 @@ from virtwho.configure import hypervisor_create
 
 
 @pytest.mark.usefixtures('function_virtwho_d_conf_clean')
-@pytest.mark.usefixtures('debug_true')
-@pytest.mark.usefixtures('globalconf_clean')
+@pytest.mark.usefixtures('class_debug_true')
+@pytest.mark.usefixtures('class_globalconf_clean')
 class TestAHVPositive:
     @pytest.mark.tier1
     def test_encrypted_password(self, virtwho, function_hypervisor,
@@ -200,8 +200,8 @@ class TestAHVPositive:
 
 
 @pytest.mark.usefixtures('function_virtwho_d_conf_clean')
-@pytest.mark.usefixtures('debug_true')
-@pytest.mark.usefixtures('globalconf_clean')
+@pytest.mark.usefixtures('class_debug_true')
+@pytest.mark.usefixtures('class_globalconf_clean')
 class TestAHVNegative:
     @pytest.mark.tier2
     def test_type(self, virtwho, function_hypervisor, ahv_assertion):

--- a/tests/hypervisor/test_esx.py
+++ b/tests/hypervisor/test_esx.py
@@ -20,8 +20,8 @@ from virtwho.configure import hypervisor_create
 
 
 @pytest.mark.usefixtures('function_virtwho_d_conf_clean')
-@pytest.mark.usefixtures('debug_true')
-@pytest.mark.usefixtures('globalconf_clean')
+@pytest.mark.usefixtures('class_debug_true')
+@pytest.mark.usefixtures('class_globalconf_clean')
 class TestEsxPositive:
     @pytest.mark.tier1
     def test_encrypted_password(self, virtwho, function_hypervisor,
@@ -298,8 +298,8 @@ class TestEsxPositive:
 
 
 @pytest.mark.usefixtures('function_virtwho_d_conf_clean')
-@pytest.mark.usefixtures('debug_true')
-@pytest.mark.usefixtures('globalconf_clean')
+@pytest.mark.usefixtures('class_debug_true')
+@pytest.mark.usefixtures('class_globalconf_clean')
 class TestEsxNegative:
     @pytest.mark.tier2
     def test_type(self, virtwho, function_hypervisor, esx_assertion):

--- a/tests/hypervisor/test_hyperv.py
+++ b/tests/hypervisor/test_hyperv.py
@@ -19,8 +19,8 @@ from virtwho.configure import hypervisor_create
 
 
 @pytest.mark.usefixtures('function_virtwho_d_conf_clean')
-@pytest.mark.usefixtures('debug_true')
-@pytest.mark.usefixtures('globalconf_clean')
+@pytest.mark.usefixtures('class_debug_true')
+@pytest.mark.usefixtures('class_globalconf_clean')
 class TestHypervPositive:
     @pytest.mark.tier1
     def test_encrypted_password(self, virtwho, function_hypervisor,
@@ -182,8 +182,8 @@ class TestHypervPositive:
 
 
 @pytest.mark.usefixtures('function_virtwho_d_conf_clean')
-@pytest.mark.usefixtures('debug_true')
-@pytest.mark.usefixtures('globalconf_clean')
+@pytest.mark.usefixtures('class_debug_true')
+@pytest.mark.usefixtures('class_globalconf_clean')
 class TestHypervNegative:
     @pytest.mark.tier2
     def test_type(self, virtwho, function_hypervisor, hyperv_assertion):

--- a/tests/hypervisor/test_kubevirt.py
+++ b/tests/hypervisor/test_kubevirt.py
@@ -18,8 +18,8 @@ from virtwho.configure import hypervisor_create
 
 
 @pytest.mark.usefixtures('function_virtwho_d_conf_clean')
-@pytest.mark.usefixtures('debug_true')
-@pytest.mark.usefixtures('globalconf_clean')
+@pytest.mark.usefixtures('class_debug_true')
+@pytest.mark.usefixtures('class_globalconf_clean')
 class TestKubevirtPositive:
     @pytest.mark.tier1
     def test_hypervisor_id(self, virtwho, function_hypervisor, hypervisor_data, globalconf, rhsm, satellite):
@@ -154,8 +154,8 @@ class TestKubevirtPositive:
 
 
 @pytest.mark.usefixtures('function_virtwho_d_conf_clean')
-@pytest.mark.usefixtures('debug_true')
-@pytest.mark.usefixtures('globalconf_clean')
+@pytest.mark.usefixtures('class_debug_true')
+@pytest.mark.usefixtures('class_globalconf_clean')
 class TestKubevirtNegative:
     @pytest.mark.tier2
     def test_type(self, virtwho, function_hypervisor, kubevirt_assertion):

--- a/tests/hypervisor/test_libvirt.py
+++ b/tests/hypervisor/test_libvirt.py
@@ -19,8 +19,8 @@ from virtwho.configure import hypervisor_create
 
 
 @pytest.mark.usefixtures('function_virtwho_d_conf_clean')
-@pytest.mark.usefixtures('debug_true')
-@pytest.mark.usefixtures('globalconf_clean')
+@pytest.mark.usefixtures('class_debug_true')
+@pytest.mark.usefixtures('class_globalconf_clean')
 class TestLibvrtPositive:
     @pytest.mark.tier1
     def test_encrypted_password(self, virtwho, function_hypervisor,
@@ -183,8 +183,8 @@ class TestLibvrtPositive:
 
 
 @pytest.mark.usefixtures('function_virtwho_d_conf_clean')
-@pytest.mark.usefixtures('debug_true')
-@pytest.mark.usefixtures('globalconf_clean')
+@pytest.mark.usefixtures('class_debug_true')
+@pytest.mark.usefixtures('class_globalconf_clean')
 class TestLibvirtNegative:
     @pytest.mark.tier2
     def test_type(self, virtwho, function_hypervisor, libvirt_assertion):

--- a/tests/hypervisor/test_rhevm.py
+++ b/tests/hypervisor/test_rhevm.py
@@ -19,8 +19,8 @@ from virtwho.configure import hypervisor_create
 
 
 @pytest.mark.usefixtures('function_virtwho_d_conf_clean')
-@pytest.mark.usefixtures('debug_true')
-@pytest.mark.usefixtures('globalconf_clean')
+@pytest.mark.usefixtures('class_debug_true')
+@pytest.mark.usefixtures('class_globalconf_clean')
 class TestRHEVMPositive:
     @pytest.mark.tier1
     def test_encrypted_password(self, virtwho, function_hypervisor,
@@ -193,8 +193,8 @@ class TestRHEVMPositive:
 
 
 @pytest.mark.usefixtures('function_virtwho_d_conf_clean')
-@pytest.mark.usefixtures('debug_true')
-@pytest.mark.usefixtures('globalconf_clean')
+@pytest.mark.usefixtures('class_debug_true')
+@pytest.mark.usefixtures('class_globalconf_clean')
 class TestRHEVMNegative:
     @pytest.mark.tier2
     def test_type(self, virtwho, function_hypervisor, rhevm_assertion):

--- a/tests/package/test_upgrade_downgrade.py
+++ b/tests/package/test_upgrade_downgrade.py
@@ -11,8 +11,8 @@ from virtwho.base import wget_download, rhel_compose_repo, random_string
 from virtwho.testing import virtwho_pacakge_url
 
 
-@pytest.mark.usefixtures('globalconf_clean')
-@pytest.mark.usefixtures('hypervisor')
+@pytest.mark.usefixtures('class_globalconf_clean')
+@pytest.mark.usefixtures('class_hypervisor')
 class TestUpgradeDowngrade:
     @pytest.mark.tier1
     def test_upgrade_downgrade_by_yum(self, ssh_host, virtwho, globalconf):

--- a/tests/sca/test_sca.py
+++ b/tests/sca/test_sca.py
@@ -32,14 +32,13 @@ def sca_disable():
     register.sca(sca='disable')
 
 
-@pytest.mark.usefixtures('globalconf_clean')
-@pytest.mark.usefixtures('hypervisor')
-@pytest.mark.usefixtures('debug_true')
+@pytest.mark.usefixtures('class_globalconf_clean')
+@pytest.mark.usefixtures('class_hypervisor')
+@pytest.mark.usefixtures('class_debug_true')
 @pytest.mark.usefixtures('sca_enable')
 @pytest.mark.usefixtures('sca_disable')
 class TestSCA:
-    def test_hypervisor_facts(self, virtwho, hypervisor, hypervisor_data,
-                              register_data):
+    def test_hypervisor_facts(self, virtwho, hypervisor_data, register_data):
         """Test the hypervisor facts in mapping
 
         :title: virt-who: sca: test hypervisor facts
@@ -72,7 +71,7 @@ class TestSCA:
 
     def test_host_to_guest_association(self, virtwho, sm_guest, ssh_guest,
                                        register_data, hypervisor_data,
-                                       register_guest):
+                                       function_guest_register):
         """Test the host-to-guest association in mapping log and register server
         Web UI.
 
@@ -108,7 +107,7 @@ class TestSCA:
         else:
             assert register.associate(hypervisor_hostname, guest_uuid)
 
-    def test_guest_entitlement_status(self, ssh_guest, register_guest,
+    def test_guest_entitlement_status(self, ssh_guest, function_guest_register,
                                       hypervisor_data):
         """Test the guest entitlement status.
 


### PR DESCRIPTION
- define each function and class fixtures starting with `function_` or `class_`.
- add a new fixture `class_virtwho_d_conf_clean`, which should be called in `tests/function/test_config.py`, otherwise it will run all the hypervisors under /etc/virt-who.d/