### PR TITLE
design testcase for test_rhsm and test_satellite

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -146,6 +146,13 @@ def function_host_register(sm_host):
     sm_host.register()
 
 
+@pytest.fixture(scope='function')
+def function_host_register_for_local_mode(sm_host):
+    """register the virt-who host only when run for local mode"""
+    if HYPERVISOR == 'local':
+        sm_host.register()
+
+
 @pytest.fixture(scope='class')
 def class_host_unregister(sm_host):
     """unregister the virt-who host"""
@@ -228,7 +235,9 @@ def hypervisor_data(ssh_guest):
         data['version'] = hypervisor_handler.vdsm_version
         data['cpu'] = hypervisor_handler.vdsm_cpu
         data['cluster'] = hypervisor_handler.vdsm_cluster
-    elif HYPERVISOR != 'local':
+    elif HYPERVISOR == 'local':
+        data['hypervisor_hostname'] = hypervisor_handler.hostname
+    else:
         data['hypervisor_uuid'] = hypervisor_handler.uuid
         data['hypervisor_hostname'] = hypervisor_handler.hostname
         data['type'] = hypervisor_handler.type

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -307,15 +307,18 @@ def sku_data():
 @pytest.fixture(scope='session')
 def vdc_pool_physical(sm_guest, sku_data):
     """Get the vdc physical sku pool id"""
-    sku = sku_data['vdc_physical']
-    sm_guest.register()
-    sku_data = sm_guest.available(sku, 'Physical')
-    if sku_data is not None:
-        sku_pool = sku_data['pool_id']
-        logger.info(f'Succeeded to get the vdc physical sku pool id: '
-                    f'{sku_pool}')
-        return sku_pool
-    raise FailException('Failed to get the vdc physical sku pool id')
+    vdc_sku_id = sku_data['vdc_physical']
+    vdc_pool_id = sm_guest.pool_id_get(vdc_sku_id, 'Physical')
+    return vdc_pool_id
+
+    # sm_guest.register()
+    # sku_data = sm_guest.available(sku, 'Physical')
+    # if sku_data is not None:
+    #     sku_pool = sku_data['pool_id']
+    #     logger.info(f'Succeeded to get the vdc physical sku pool id: '
+    #                 f'{sku_pool}')
+    #     return sku_pool
+    # raise FailException('Failed to get the vdc physical sku pool id')
 
 
 def owner_data():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -311,15 +311,6 @@ def vdc_pool_physical(sm_guest, sku_data):
     vdc_pool_id = sm_guest.pool_id_get(vdc_sku_id, 'Physical')
     return vdc_pool_id
 
-    # sm_guest.register()
-    # sku_data = sm_guest.available(sku, 'Physical')
-    # if sku_data is not None:
-    #     sku_pool = sku_data['pool_id']
-    #     logger.info(f'Succeeded to get the vdc physical sku pool id: '
-    #                 f'{sku_pool}')
-    #     return sku_pool
-    # raise FailException('Failed to get the vdc physical sku pool id')
-
 
 def owner_data():
     """Owner data for testing"""

--- a/tests/subscription/test_rhsm.py
+++ b/tests/subscription/test_rhsm.py
@@ -20,14 +20,14 @@ vdc_virtual_sku = config.sku.vdc_virtual
 @pytest.mark.usefixtures('function_host_register_for_local_mode')
 class TestRHSM:
     @pytest.mark.tier1
-    def test_vdc_virtual_pool_attach_by_poolId(self, virtwho, sm_guest,
-                                               rhsm, hypervisor_data,
-                                               vdc_pool_physical):
+    def test_vdc_virtual_pool_attach_by_poolId(
+            self, virtwho, sm_guest, rhsm, hypervisor_data, vdc_pool_physical
+    ):
         """Test the guest can get and attach the virtual vdc pool by pool id
 
         :title: virt-who: satellite: test guest attach virtual vdc pool by
             pool id
-        :id:
+        :id: 39717357-eadb-4ac7-bf44-2b323cda3717
         :caseimportance: High
         :tags: tier1
         :customerscenario: false
@@ -72,13 +72,13 @@ class TestRHSM:
         assert consumed_data is None
 
     @pytest.mark.tier1
-    def test_vdc_virtual_pool_attach_by_auto(self, virtwho, sm_guest, rhsm,
-                                             hypervisor_data,
-                                             vdc_pool_physical):
+    def test_vdc_virtual_pool_attach_by_auto(
+            self, virtwho, sm_guest, rhsm, hypervisor_data, vdc_pool_physical
+    ):
         """Test the guest can get and attach the virtual vdc pool by auto
 
         :title: virt-who: rhsm: test guest attach virtual vdc pool by auto
-        :id:
+        :id: d082e0c1-e925-46ea-8ab1-d65355709f55
         :caseimportance: High
         :tags: tier1
         :customerscenario: false
@@ -122,13 +122,14 @@ class TestRHSM:
         assert consumed_data is None
 
     @pytest.mark.tier1
-    def test_vdc_temporary_pool_by_poolId(self, virtwho, sm_guest, ssh_guest,
-                                          sm_host, rhsm, hypervisor_data,
-                                          vdc_pool_physical):
+    def test_vdc_temporary_pool_by_poolId(
+            self, virtwho, sm_guest, ssh_guest, sm_host, rhsm, hypervisor_data,
+            vdc_pool_physical
+    ):
         """Test the temporary vdc pool in guest
 
         :title: virt-who: rhsm: test temporary vdc pool in guest
-        :id:
+        :id: d1c42adf-dee5-42bf-80b6-017948e77baf
         :caseimportance: High
         :tags: tier1
         :customerscenario: false
@@ -193,14 +194,15 @@ class TestRHSM:
 
     @pytest.mark.tier1
     @pytest.mark.notRemoteMode
-    def test_vdc_physcial_pool_consumed_status_in_physical_host(self, sm_host,
-                                                                vdc_pool_physical):
+    def test_vdc_physcial_pool_consumed_status_in_physical_host(
+            self, sm_host, vdc_pool_physical
+    ):
         """Test vdc physcial pool consumed status in physical host when
             set cpu_socket(s).
 
         :title: virt-who: rhsm: test physcial vdc pool consumed status in
             physical host
-        :id:
+        :id: cbf0e07b-c51c-4e6d-9c80-07c2c8dd7692
         :caseimportance: High
         :tags: tier1
         :customerscenario: false
@@ -247,16 +249,17 @@ class TestRHSM:
             sm_host.facts_remove()
 
     @pytest.mark.tier1
-    def test_vdc_virtual_pool_consumed_status_in_guest(self, virtwho, sm_guest,
-                                                       rhsm, hypervisor_data,
-                                                       vdc_pool_physical):
+    def test_vdc_virtual_pool_consumed_status_in_guest(
+            self, virtwho, sm_guest, rhsm, hypervisor_data,
+            vdc_pool_physical
+    ):
         """Test vdc virtual pool consumed status in guest when
             set cpu_socket(s).
 
         :title: virt-who: rhsm: test vdc virtual pool consumed status in guest
-        :id:
+        :id: 93af0dad-21e6-4732-8a06-2fb2e86a05a3
         :caseimportance: High
-        :tags: tier1
+        :tags: tier2
         :customerscenario: false
         :upstream: no
         :steps:
@@ -300,15 +303,15 @@ class TestRHSM:
         finally:
             sm_guest.facts_remove()
 
-    def test_vdc_virtual_pool_attach_in_fake_mode(self, virtwho, sm_guest,
-                                                  rhsm, hypervisor_data,
-                                                  vdc_pool_physical):
+    def test_vdc_virtual_pool_attach_in_fake_mode(
+            self, virtwho, sm_guest, rhsm, hypervisor_data, vdc_pool_physical
+    ):
         """Test the guest can get and attach the virtual vdc pool in fake mode
 
         :title: virt-who: rhsm: test guest attach virtual vdc pool in fake mode
-        :id:
+        :id: f97afcd8-2b23-4754-8c40-a70605009e8f
         :caseimportance: High
-        :tags: tier1
+        :tags: tier2
         :customerscenario: false
         :upstream: no
         :steps:

--- a/tests/subscription/test_rhsm.py
+++ b/tests/subscription/test_rhsm.py
@@ -1,6 +1,358 @@
 """Test cases Global fields
-
 :casecomponent: virt-who
 :testtype: functional
 :caseautomation: Automated
 """
+import pytest
+from virtwho.base import msg_search
+from virtwho.settings import config
+from virtwho import HYPERVISOR, FAKE_CONFIG_FILE
+from virtwho.configure import hypervisor_create
+
+vdc_physical_sku = config.sku.vdc
+vdc_virtual_sku = config.sku.vdc_virtual
+
+
+@pytest.mark.usefixtures('class_globalconf_clean')
+@pytest.mark.usefixtures('class_hypervisor')
+@pytest.mark.usefixtures('class_guest_register')
+@pytest.mark.usefixtures('function_guest_unattach')
+@pytest.mark.usefixtures('function_host_register_for_local_mode')
+class TestRHSM:
+    @pytest.mark.tier1
+    def test_vdc_virtual_pool_attach_by_poolId(self, virtwho, sm_guest,
+                                               rhsm, hypervisor_data,
+                                               vdc_pool_physical):
+        """Test the guest can get and attach the virtual vdc pool by pool id
+
+        :title: virt-who: satellite: test guest attach virtual vdc pool by
+            pool id
+        :id:
+        :caseimportance: High
+        :tags: tier1
+        :customerscenario: false
+        :upstream: no
+        :steps:
+
+            1. Register guest to entitlement server
+            2. Run virt-who to report mappings to entitlement server
+            3. Attach physical vdc for hypervisor
+            4. Check and attach virtual vdc pool for guest by pool id
+            5. Remove the physical vdc from hypervisor
+            6. Check the consumed status from guest
+
+        :expectedresults:
+
+            1. The hysical vdc pool can derive virtual vdc pool for guest using.
+            2. Guest can subscribe the virtual vdc pool by pool id.
+            3. The vdc virtual pool disappear in guest after remove the
+                physical pool from hypervisor.
+        """
+        hypervisor_hostname = hypervisor_data['hypervisor_hostname']
+        result = virtwho.run_cli()
+        assert (result['send'] == 1
+                and result['error'] == 0)
+
+        # attach physcial vdc for hypervisor
+        rhsm.attach(host_name=hypervisor_hostname, pool=vdc_pool_physical)
+
+        # attach virtual vdc pool for guest by pool id
+        sm_guest.refresh()
+        sku_data_virt = sm_guest.available(vdc_virtual_sku, 'Virtual')
+        sm_guest.attach(pool=sku_data_virt['pool_id'])
+        consumed_data = sm_guest.consumed(sku_id=vdc_virtual_sku)
+        assert (consumed_data['sku'] == vdc_virtual_sku
+                and consumed_data['sku_type'] == 'Virtual'
+                and consumed_data['temporary'] is False)
+
+        # remove the physical vdc from hypervisor
+        rhsm.unattach(host_name=hypervisor_hostname, pool=vdc_pool_physical)
+        sm_guest.refresh()
+        consumed_data = sm_guest.consumed(sku_id=vdc_virtual_sku)
+        assert consumed_data is None
+
+    @pytest.mark.tier1
+    def test_vdc_virtual_pool_attach_by_auto(self, virtwho, sm_guest, rhsm,
+                                             hypervisor_data,
+                                             vdc_pool_physical):
+        """Test the guest can get and attach the virtual vdc pool by auto
+
+        :title: virt-who: rhsm: test guest attach virtual vdc pool by auto
+        :id:
+        :caseimportance: High
+        :tags: tier1
+        :customerscenario: false
+        :upstream: no
+        :steps:
+
+            1. Register guest to entitlement server
+            2. Run virt-who to report mappings to entitlement server
+            3. Attach physical vdc for hypervisor
+            4. Check and attach virtual vdc pool for guest by auto attach
+            5. Unregister/delete the hyperviosr from entitlement server
+            6. Check the consumed status from guest
+
+        :expectedresults:
+
+            1. The hysical vdc pool can derive virtual vdc pool for guest using.
+            2. Guest can subscribe the virtual vdc pool by auto attach.
+            3. The vdc virtual pool disappear in guest after unregister the
+                hypervisor.
+        """
+        hypervisor_hostname = hypervisor_data['hypervisor_hostname']
+        result = virtwho.run_cli()
+        assert (result['send'] == 1
+                and result['error'] == 0)
+
+        # attach physcial vdc for hypervisor
+        rhsm.attach(host_name=hypervisor_hostname, pool=vdc_pool_physical)
+
+        # attach virtual vdc pool for guest by auto
+        sm_guest.refresh()
+        sm_guest.attach(pool=None)
+        consumed_data = sm_guest.consumed(sku_id=vdc_virtual_sku)
+        assert (consumed_data['sku'] == vdc_virtual_sku
+                and consumed_data['sku_type'] == 'Virtual'
+                and consumed_data['temporary'] is False)
+
+        # unregister hypervisor
+        rhsm.host_delete(host_name=hypervisor_hostname)
+        sm_guest.refresh()
+        consumed_data = sm_guest.consumed(sku_id=vdc_virtual_sku)
+        assert consumed_data is None
+
+    @pytest.mark.tier1
+    def test_vdc_temporary_pool_by_poolId(self, virtwho, sm_guest, ssh_guest,
+                                          sm_host, rhsm, hypervisor_data,
+                                          vdc_pool_physical):
+        """Test the temporary vdc pool in guest
+
+        :title: virt-who: rhsm: test temporary vdc pool in guest
+        :id:
+        :caseimportance: High
+        :tags: tier1
+        :customerscenario: false
+        :upstream: no
+        :steps:
+
+            1. Register guest to entitlement server
+            2. Stop the virt-who service
+            3. Delete the hypervisor from entitlement server
+            4. Attach the vdc virtual pool for guest
+            5. Start virt-who service to report mappings to entitlement server
+            6. Attach the physical vdc pool for hypervisor
+            7. Check the virtual vdc pool status in guest
+            8. Check repo status in guest
+            9. Check subscription status in guest
+
+        :expectedresults:
+
+            1. The guest can get and attach a temporary virtual vdc when no
+                hypervisor associated in the entitlement server
+            2. The teporary virtual vdc pool changes to stable one after
+                associating again to the hypervisor with the physical vdc pool
+                attached
+            3. The guest repo status is "Available Repositories"
+            4. The guest subscription status is "Overall Status: Current"
+        """
+        hypervisor_hostname = hypervisor_data['hypervisor_hostname']
+        # delete the host-to-guest association in server
+        virtwho.stop()
+        rhsm.host_delete(host_name=hypervisor_hostname)
+
+        # attach temporary virtual vdc pool for guest
+        sm_guest.refresh()
+        sku_data_virt = sm_guest.available(vdc_virtual_sku, 'Virtual')
+        sm_guest.attach(pool=sku_data_virt['pool_id'])
+        consumed_data = sm_guest.consumed(sku_id=vdc_virtual_sku)
+        assert (consumed_data['sku'] == vdc_virtual_sku
+                and consumed_data['sku_type'] == 'Virtual'
+                and consumed_data['temporary'] is True)
+
+        # run virt-who and attach physcial vdc for hypervisor
+        if HYPERVISOR == 'local':
+            sm_host.register()
+        _ = virtwho.run_cli()
+        rhsm.attach(host_name=hypervisor_hostname, pool=vdc_pool_physical)
+
+        # check the temporary vdc changed to stable one in guest
+        sm_guest.refresh()
+        consumed_data = sm_guest.consumed(sku_id=vdc_virtual_sku)
+        assert (consumed_data['sku'] == vdc_virtual_sku
+                and consumed_data['sku_type'] == 'Virtual'
+                and consumed_data['temporary'] is False)
+
+        # check repo status in guest
+        _, output = ssh_guest.runcmd('subscription-manager repos --list')
+        assert msg_search(output, 'Available Repositories')
+
+        # check subscription status in guest
+        _, output = ssh_guest.runcmd('subscription-manager status')
+        assert (msg_search(output, 'Overall Status: Current')
+                and not msg_search(output, 'Invalid'))
+
+    @pytest.mark.tier1
+    @pytest.mark.notRemoteMode
+    def test_vdc_physcial_pool_consumed_status_in_physical_host(self, sm_host,
+                                                                vdc_pool_physical):
+        """Test vdc physcial pool consumed status in physical host when
+            set cpu_socket(s).
+
+        :title: virt-who: rhsm: test physcial vdc pool consumed status in
+            physical host
+        :id:
+        :caseimportance: High
+        :tags: tier1
+        :customerscenario: false
+        :upstream: no
+        :steps:
+
+            1. Create facts with 'cpu.cpu_socket(s): 4' for physical host
+            2. Attach physcial vdc pool for local host with quantity=1
+            3. Check the consumed status for host
+            4. Remove the consumed pool from host
+            5. Attach physcial vdc pool for local host without quantity setting
+            6. Check the consumed status for host
+            7. Remove the custom facts setting
+
+        :expectedresults:
+
+            1. With cpu_socket(s)=4, the physical host can subscribe only one
+                physical vdc pool with status 'Only supports 2 of 4 sockets.'
+                because 1 pool can cover 2 sockets
+            2. Without quantity setting, the physcial host default to subscribe
+                2 vdc pool with status 'Subscription is current'
+        """
+        try:
+            sm_host.facts_create('cpu.cpu_socket(s)', '4')
+            sm_host.unattach()
+            # Attach physcial vdc pool with quantity=1
+            sm_host.attach(pool=vdc_pool_physical, quantity=1)
+            consumed_data = sm_host.consumed(sku_id=vdc_physical_sku,
+                                             sku_type='Physical')
+            assert (consumed_data['quantity_used'] == '1'
+                    and consumed_data[
+                        'status_details'] == 'Only supports 2 of 4 sockets.')
+
+            # Attach physcial vdc pool without quantity setting
+            sm_host.unattach()
+            sm_host.attach(pool=vdc_pool_physical)
+            consumed_data = sm_host.consumed(sku_id=vdc_physical_sku,
+                                             sku_type='Physical')
+            assert (consumed_data['quantity_used'] == '2'
+                    and consumed_data[
+                        'status_details'] == 'Subscription is current')
+
+        finally:
+            sm_host.facts_remove()
+
+    @pytest.mark.tier1
+    def test_vdc_virtual_pool_consumed_status_in_guest(self, virtwho, sm_guest,
+                                                       rhsm, hypervisor_data,
+                                                       vdc_pool_physical):
+        """Test vdc virtual pool consumed status in guest when
+            set cpu_socket(s).
+
+        :title: virt-who: rhsm: test vdc virtual pool consumed status in guest
+        :id:
+        :caseimportance: High
+        :tags: tier1
+        :customerscenario: false
+        :upstream: no
+        :steps:
+
+            1. Register guest to stage account
+            2. Create facts with 'cpu.cpu_socket(s): 4' for guest
+            3. Run virt-who to report mappings to entitlement server
+            4. Attach physical vdc for hypervisor
+            5. Attach virtual vdc pool for guest with quantity=1
+            6. Check the consumed status for guest
+            7. Remove the consumed pool from host
+            8. Attach physcial vdc pool for local host with quantity=2
+            9. Check the consumed status for guest
+            10. Remove the custom facts setting
+
+        :expectedresults:
+
+            1. With cpu_socket(s)=4, the rhel guest can subscribe only one
+                virtual vdc pool with status 'Subscription is current.'.
+            2. It shows 'Multi-entitlement not supported' when try to attach 2
+                virtual vdc for the guest, that is not supported.
+        """
+        hypervisor_hostname = hypervisor_data['hypervisor_hostname']
+        try:
+            sm_guest.facts_create('cpu.cpu_socket(s)', '4')
+
+            rhsm.attach(host_name=hypervisor_hostname, pool=vdc_pool_physical)
+            _ = virtwho.run_cli()
+            sku_data_virt = sm_guest.available(vdc_virtual_sku, 'Virtual')
+            sm_guest.attach(pool=sku_data_virt['pool_id'])
+
+            consumed_data = sm_guest.consumed(sku_id=vdc_virtual_sku)
+            assert (consumed_data['quantity_used'] == '1'
+                    and consumed_data[
+                        'status_details'] == 'Subscription is current')
+
+            sm_guest.unattach()
+            output = sm_guest.attach(pool=sku_data_virt['pool_id'], quantity=2)
+            assert 'Multi-entitlement not supported' in output
+
+        finally:
+            sm_guest.facts_remove()
+
+    def test_vdc_virtual_pool_attach_in_fake_mode(self, virtwho, sm_guest,
+                                                  rhsm, hypervisor_data,
+                                                  vdc_pool_physical):
+        """Test the guest can get and attach the virtual vdc pool in fake mode
+
+        :title: virt-who: rhsm: test guest attach virtual vdc pool in fake mode
+        :id:
+        :caseimportance: High
+        :tags: tier1
+        :customerscenario: false
+        :upstream: no
+        :steps:
+
+            1. Register guest to entitlement server
+            2. Get fake json with print function
+            2. Run virt-who in fake mode to report mappings
+            3. Attach physical vdc for hypervisor
+            4. Attach virtual vdc pool for guest
+            5. Unregister/delte the hyperviosr
+            6. Check the consumed status from guest
+
+        :expectedresults:
+
+            1. The physical vdc pool can derive virtual vdc pool for guest using.
+            2. Guest can subscribe the virtual vdc pool by auto attach.
+            3. The vdc virtual pool disappear in guest after unregister the
+                hypervisor.
+        """
+        hypervisor_hostname = hypervisor_data['hypervisor_hostname']
+        virtwho.stop()
+        if HYPERVISOR != 'local':
+            rhsm.host_delete(host_name=hypervisor_hostname)
+
+        _ = virtwho.run_cli(prt=True)
+        _ = hypervisor_create(mode='fake', config_name=FAKE_CONFIG_FILE)
+        result = virtwho.run_cli(config=FAKE_CONFIG_FILE)
+        assert (result['send'] == 1
+                and result['error'] == 0)
+
+        # attach vdc for hypervisor
+        rhsm.attach(host_name=hypervisor_hostname, pool=vdc_pool_physical)
+
+        # guest can get the bonus virtual pool.
+        sm_guest.refresh()
+        sku_data_virt = sm_guest.available(vdc_virtual_sku, 'Virtual')
+        sm_guest.attach(pool=sku_data_virt['pool_id'])
+        consumed_data = sm_guest.consumed(sku_id=vdc_virtual_sku)
+        assert (consumed_data['sku'] == vdc_virtual_sku
+                and consumed_data['sku_type'] == 'Virtual'
+                and consumed_data['temporary'] is False)
+
+        # unregister hypervisor
+        rhsm.host_delete(host_name=hypervisor_hostname)
+        sm_guest.refresh()
+        consumed_data = sm_guest.consumed(sku_id=vdc_virtual_sku)
+        assert consumed_data is None

--- a/tests/subscription/test_satellite.py
+++ b/tests/subscription/test_satellite.py
@@ -434,7 +434,7 @@ class TestSatellite:
                 will not be 0
         """
         hypervisor_hostname = hypervisor_data['hypervisor_hostname']
-        if HYPERVISOR == 'libvirt-local':
+        if HYPERVISOR == 'local':
             hypervisor_name = [f'{hypervisor_hostname}']
         else:
             key = f'virt-who-{hypervisor_hostname}'

--- a/tests/subscription/test_satellite.py
+++ b/tests/subscription/test_satellite.py
@@ -1,6 +1,423 @@
 """Test cases Global fields
-
 :casecomponent: virt-who
 :testtype: functional
 :caseautomation: Automated
 """
+import pytest
+from virtwho.base import msg_search
+from virtwho.settings import config
+from virtwho import HYPERVISOR, FAKE_CONFIG_FILE
+from virtwho.configure import hypervisor_create
+from virtwho.configure import get_hypervisor_handler
+from virtwho.register import SubscriptionManager
+
+vdc_physical_sku = config.sku.vdc
+vdc_virtual_sku = config.sku.vdc_virtual
+limit_sku = config.sku.limit
+
+activation_key = config.satellite.activation_key
+
+
+@pytest.mark.tier1
+@pytest.mark.usefixtures('class_globalconf_clean')
+@pytest.mark.usefixtures('class_hypervisor')
+@pytest.mark.usefixtures('class_guest_register')
+@pytest.mark.usefixtures('function_guest_unattach')
+@pytest.mark.usefixtures('function_host_register_for_local_mode')
+class TestSatellite:
+    def test_vdc_virtual_pool_attach_by_poolId(self, virtwho, sm_guest,
+                                               satellite, hypervisor_data,
+                                               vdc_pool_physical):
+        """Test the guest can get and attach the virtual vdc pool by pool id
+
+        :title: virt-who: satellite: test guest attach virtual vdc pool by
+            pool id
+        :id:
+        :caseimportance: High
+        :tags: tier1
+        :customerscenario: false
+        :upstream: no
+        :steps:
+
+            1. Register guest to entitlement server
+            2. Run virt-who to report mappings to entitlement server
+            3. Attach physical vdc for hypervisor
+            4. Check and attach virtual vdc pool for guest by pool id
+            5. Remove the physical vdc from hypervisor
+            6. Check the consumed status from guest
+
+        :expectedresults:
+
+            1. The hysical vdc pool can derive virtual vdc pool for guest using.
+            2. Guest can subscribe the virtual vdc pool by pool id.
+            3. The vdc virtual pool disappear in guest after remove the
+                physical pool from hypervisor.
+        """
+        hypervisor_hostname = hypervisor_data['hypervisor_hostname']
+        result = virtwho.run_cli()
+        assert (result['send'] == 1
+                and result['error'] == 0)
+
+        # attach physcial vdc for hypervisor
+        satellite.attach(host=hypervisor_hostname, pool=vdc_pool_physical)
+
+        # attach virtual vdc pool for guest by pool id
+        sm_guest.refresh()
+        sku_data_virt = sm_guest.available(vdc_virtual_sku, 'Virtual')
+        sm_guest.attach(pool=sku_data_virt['pool_id'])
+        consumed_data = sm_guest.consumed(sku_id=vdc_virtual_sku)
+        assert (consumed_data['sku'] == vdc_virtual_sku
+                and consumed_data['sku_type'] == 'Virtual'
+                and consumed_data['temporary'] is False)
+
+        # remove the physical vdc from hypervisor
+        satellite.unattach(host=hypervisor_hostname, pool=vdc_pool_physical)
+        sm_guest.refresh()
+        consumed_data = sm_guest.consumed(sku_id=vdc_virtual_sku)
+        assert consumed_data is None
+
+    @pytest.mark.tier1
+    def test_vdc_virtual_pool_attach_by_auto(self, virtwho, sm_guest, satellite,
+                                             hypervisor_data,
+                                             vdc_pool_physical):
+        """Test the guest can get and attach the virtual vdc pool by auto
+
+        :title: virt-who: satellite: test guest attach virtual vdc pool by auto
+        :id:
+        :caseimportance: High
+        :tags: tier1
+        :customerscenario: false
+        :upstream: no
+        :steps:
+
+            1. Register guest to entitlement server
+            2. Run virt-who to report mappings to entitlement server
+            3. Attach physical vdc for hypervisor
+            4. Check and attach virtual vdc pool for guest by auto attach
+            5. Unregister/delete the hyperviosr from entitlement server
+            6. Check the consumed status from guest
+
+        :expectedresults:
+
+            1. The hysical vdc pool can derive virtual vdc pool for guest using.
+            2. Guest can subscribe the virtual vdc pool by auto attach.
+            3. The vdc virtual pool disappear in guest after unregister the
+                hypervisor.
+        """
+        hypervisor_hostname = hypervisor_data['hypervisor_hostname']
+        result = virtwho.run_cli()
+        assert (result['send'] == 1
+                and result['error'] == 0)
+
+        # attach physcial vdc for hypervisor
+        satellite.attach(host=hypervisor_hostname, pool=vdc_pool_physical)
+
+        # attach virtual vdc pool for guest by auto
+        sm_guest.refresh()
+        sm_guest.attach(pool=None)
+        consumed_data = sm_guest.consumed(sku_id=vdc_virtual_sku)
+        assert (consumed_data['sku'] == vdc_virtual_sku
+                and consumed_data['sku_type'] == 'Virtual'
+                and consumed_data['temporary'] is False)
+
+        # unregister hypervisor
+        satellite.host_delete(host=hypervisor_hostname)
+        sm_guest.refresh()
+        consumed_data = sm_guest.consumed(sku_id=vdc_virtual_sku)
+        assert consumed_data is None
+
+    @pytest.mark.tier1
+    def test_vdc_temporary_pool_by_poolId(self, virtwho, sm_guest, ssh_guest,
+                                          sm_host, satellite, hypervisor_data,
+                                          vdc_pool_physical):
+        """Test the temporary vdc pool in guest
+
+        :title: virt-who: satellite: test temporary vdc pool in guest
+        :id:
+        :caseimportance: High
+        :tags: tier1
+        :customerscenario: false
+        :upstream: no
+        :steps:
+
+            1. Register guest to entitlement server
+            2. Stop the virt-who service
+            3. Delete the hypervisor from entitlement server
+            4. Attach the vdc virtual pool for guest
+            5. Start virt-who service to report mappings to entitlement server
+            6. Attach the physical vdc pool for hypervisor
+            7. Check the virtual vdc pool status in guest
+            8. Check repo status in guest
+            9. Check subscription status in guest
+
+        :expectedresults:
+
+            1. The guest can get and attach a temporary virtual vdc when no
+                hypervisor associated in the entitlement server
+            2. The teporary virtual vdc pool changes to stable one after
+                associating again to the hypervisor with the physical vdc pool
+                attached
+            3. The guest repo status is "no repositories available"
+            4. The guest subscription status is "Overall Status: Current"
+        """
+        hypervisor_hostname = hypervisor_data['hypervisor_hostname']
+
+        virtwho.stop()
+        satellite.host_delete(host=hypervisor_hostname)
+
+        sm_guest.refresh()
+        available_data_virt = sm_guest.available(vdc_virtual_sku, 'Virtual')
+        sm_guest.attach(pool=available_data_virt['pool_id'])
+        consumed_data = sm_guest.consumed(sku_id=vdc_virtual_sku)
+        assert (consumed_data['sku'] == vdc_virtual_sku
+                and consumed_data['sku_type'] == 'Virtual'
+                and consumed_data['temporary'] is True)
+
+        _ = virtwho.run_cli()
+        satellite.attach(host=hypervisor_hostname, pool=vdc_pool_physical)
+
+        sm_guest.refresh()
+        consumed_data = sm_guest.consumed(sku_id=vdc_virtual_sku)
+        assert (consumed_data['sku'] == vdc_virtual_sku
+                and consumed_data['sku_type'] == 'Virtual'
+                and consumed_data['temporary'] is False)
+
+        # check repo status in guest
+        _, output = ssh_guest.runcmd('subscription-manager repos --list')
+        assert msg_search(output, 'no repositories available')
+
+        # check subscription status in guest
+        _, output = ssh_guest.runcmd('subscription-manager status')
+        assert (msg_search(output, 'Overall Status: Current')
+                and not msg_search(output, 'Invalid'))
+
+    def test_vdc_virtual_pool_attach_in_fake_mode(self, virtwho, sm_guest,
+                                                  satellite, hypervisor_data,
+                                                  vdc_pool_physical):
+        """Test the guest can get and attach the virtual vdc pool in fake mode
+
+        :title: virt-who: satellite: test guest attach virtual vdc pool in
+            fake mode
+        :id:
+        :caseimportance: High
+        :tags: tier1
+        :customerscenario: false
+        :upstream: no
+        :steps:
+
+            1. Register guest to entitlement server
+            2. Get fake json with print function
+            2. Run virt-who in fake mode to report mappings
+            3. Attach physical vdc for hypervisor
+            4. Attach virtual vdc pool for guest
+            5. Unregister/delte the hyperviosr
+            6. Check the consumed status from guest
+
+        :expectedresults:
+
+            1. The physical vdc pool can derive virtual vdc pool for guest using.
+            2. Guest can subscribe the virtual vdc pool by auto attach.
+            3. The vdc virtual pool disappear in guest after unregister the
+                hypervisor.
+        """
+        hypervisor_hostname = hypervisor_data['hypervisor_hostname']
+        virtwho.stop()
+        if HYPERVISOR != 'local':
+            satellite.host_delete(host=hypervisor_hostname)
+
+        _ = virtwho.run_cli(prt=True)
+        _ = hypervisor_create(
+            mode='fake', register_type='satellite', config_name=FAKE_CONFIG_FILE
+        )
+        result = virtwho.run_cli(config=FAKE_CONFIG_FILE)
+        assert (result['send'] == 1
+                and result['error'] == 0)
+
+        # attach vdc for hypervisor
+        satellite.attach(host=hypervisor_hostname, pool=vdc_pool_physical)
+
+        # guest can get the bonus virtual pool.
+        sm_guest.refresh()
+        sku_data_virt = sm_guest.available(vdc_virtual_sku, 'Virtual')
+        sm_guest.attach(pool=sku_data_virt['pool_id'])
+        consumed_data = sm_guest.consumed(sku_id=vdc_virtual_sku)
+        assert (consumed_data['sku'] == vdc_virtual_sku
+                and consumed_data['sku_type'] == 'Virtual'
+                and consumed_data['temporary'] is False)
+
+        # unregister hypervisor
+        satellite.host_delete(host=hypervisor_hostname)
+        sm_guest.refresh()
+        consumed_data = sm_guest.consumed(sku_id=vdc_virtual_sku)
+        assert consumed_data is None
+
+    def test_guest_auto_attach_rule_by_activation_key(
+            self, virtwho, sm_guest_ack, satellite, hypervisor_data,
+            register_data, vdc_pool_physical
+    ):
+        """Test the guest register by activation_key
+
+        :title: virt-who: satellite: test guest attach rule by activation_key
+        :id:
+        :caseimportance: High
+        :tags: tier1
+        :customerscenario: false
+        :upstream: no
+        :steps:
+
+            1. Create a clean activation key
+            2. (Scenario 1) Register guest by activation key with
+                activation key auto-attach disabled and
+                both the virtual limit and vdc sku out of the key
+            3. (Scenario 2) Register guest by activation key with
+                activation key auto-attach disabled and
+                both the virtual limit and vdc sku in the key
+            4. (Scenario 3) Register guest by activation key with
+                activation key auto-attach enabled and
+                virtual limit sku in the key, virtual vdc sku out of the key
+            5. (Scenario 4) Register guest by activation key with
+                activation key auto-attach enabled and
+                both the vdc and limit virt sku out of the key
+
+        :expectedresults:
+
+            1. (Scenario 1) guest will not auto attach any sku
+            2. (Scenario 2) guest will auto attach all the matched sku
+            3. (Scenario 3) guest will only auto attach the virtual sku that
+                in the key
+            4. (Scenario 4) guest will auto attach the matched sku from out of
+                the key
+        """
+        hypervisor_hostname = hypervisor_data['hypervisor_hostname']
+        limit_pool_physical = sm_guest_ack.pool_id_get(limit_sku, 'Physical')
+
+        # create a clean activation key
+        satellite.activation_key_delete(activation_key)
+        satellite.activation_key_create(activation_key)
+
+        # disable the auto-attach for activation key
+        satellite.activation_key_update(auto_attach='no')
+
+        # register guest by activation key with
+        # activation key auto-attach disabled and
+        # both the virtual limit and vdc sku out of the key
+        _ = virtwho.run_cli()
+        satellite.attach(host=hypervisor_hostname, pool=vdc_pool_physical)
+        satellite.attach(host=hypervisor_hostname, pool=limit_pool_physical)
+        sm_guest_ack.unregister()
+        sm_guest_ack.register()
+        vdc_consumed_data = sm_guest_ack.consumed(vdc_virtual_sku, 'Virtual')
+        limit_consumed_data = sm_guest_ack.consumed(limit_sku, 'Virtual')
+        assert (not vdc_consumed_data and not limit_consumed_data)
+
+        # get the vdc and limit sku virtual pool id
+        vdc_available_data = sm_guest_ack.available(vdc_virtual_sku, 'Virtual')
+        vdc_virt_pool = vdc_available_data['pool_id']
+        limit_available_data = sm_guest_ack.available(limit_sku, 'Virtual')
+        limit_virt_pool = limit_available_data['pool_id']
+
+        # register guest by activation key with
+        # activation key auto-attach disabled and
+        # both the virtual limit and vdc sku in the key
+        satellite.activation_key_attach(pool=vdc_virt_pool, key=activation_key)
+        satellite.activation_key_attach(pool=limit_virt_pool,
+                                        key=activation_key)
+        sm_guest_ack.unregister()
+        sm_guest_ack.register()
+        vdc_consumed_data = sm_guest_ack.consumed(vdc_virtual_sku, 'Virtual')
+        limit_consumed_data = sm_guest_ack.consumed(limit_sku, 'Virtual')
+        assert (vdc_consumed_data and limit_consumed_data)
+
+        # enable the auto-attach for activation key
+        satellite.activation_key_update(auto_attach='yes')
+
+        # register guest by activation key with
+        # activation key auto-attach enabled and
+        # virtual limit sku in the key, virtual vdc sku out of the key
+        satellite.activation_key_unattach(pool=vdc_virt_pool,
+                                          key=activation_key)
+        sm_guest_ack.unregister()
+        sm_guest_ack.register()
+        vdc_consumed_data = sm_guest_ack.consumed(vdc_virtual_sku, 'Virtual')
+        limit_consumed_data = sm_guest_ack.consumed(limit_sku, 'Virtual')
+        assert (limit_consumed_data and not vdc_consumed_data)
+
+        # register guest by activation key with
+        # activation key auto-attach enabled and
+        # the both vdc and limit virt sku out of the key
+        satellite.activation_key_unattach(pool=limit_virt_pool,
+                                          key=activation_key)
+        sm_guest_ack.unregister()
+        sm_guest_ack.register()
+        vdc_consumed_data = sm_guest_ack.consumed(vdc_virtual_sku, 'Virtual')
+        limit_consumed_data = sm_guest_ack.consumed(limit_sku, 'Virtual')
+        assert (vdc_consumed_data and not limit_consumed_data)
+
+    def test_guest_auto_attach_temporary_pool_by_activation_key(
+            self, virtwho, sm_guest_ack, satellite, hypervisor_data,
+            register_data, vdc_pool_physical
+    ):
+        """Test the guest can auto attach temporary sku when registering with
+            activation key
+
+        :title: virt-who: satellite: test guest auto attach temporay sku with
+            activation key
+        :id:
+        :caseimportance: High
+        :tags: tier1
+        :customerscenario: false
+        :upstream: no
+        :steps:
+
+            1. Create a clean activation key
+            2. Unregister/delete the hypervisor from satellite
+            3. Register guest with activation key to check comsumed status
+            4. Run virt-who to report mappings to satellite
+            5. Check the guest consumed status again
+
+        :expectedresults:
+
+            1. Guest can auto attach temporary sku with register with
+                activation key.
+            2. After guest is associated to hypervisor, the temporary sku will
+                change to stable by auto.
+        """
+        hypervisor_hostname = hypervisor_data['hypervisor_hostname']
+        satellite.host_delete(host=hypervisor_hostname)
+
+        # create a clean activation key
+        satellite.activation_key_delete(activation_key)
+        satellite.activation_key_create(activation_key)
+        satellite.activation_key_update(auto_attach='yes')
+
+        #
+        sm_guest_ack.unregister()
+        sm_guest_ack.register()
+        consumed_data = sm_guest_ack.consumed(vdc_virtual_sku)
+        assert consumed_data['temporary'] is True
+
+        #
+        _ = virtwho.run_cli()
+        sm_guest_ack.refresh()
+        consumed_data = sm_guest_ack.consumed(vdc_virtual_sku)
+        assert consumed_data['temporary'] is False
+
+
+@pytest.fixture(scope='class')
+def sm_guest_ack(register_data):
+    """
+    Instantication of class SubscriptionManager() for hypervisor guest
+    with default org and activation key
+    """
+    hypervisor_handler = get_hypervisor_handler(HYPERVISOR)
+
+    port = 22
+    if HYPERVISOR == 'kubevirt':
+        port = hypervisor_handler.guest_port
+    return SubscriptionManager(host=hypervisor_handler.guest_ip,
+                               username=hypervisor_handler.guest_username,
+                               password=hypervisor_handler.guest_password,
+                               port=port,
+                               register_type='satellite',
+                               org=config.satellite.default_org,
+                               activation_key=register_data['activation_key'])

--- a/virtwho/__init__.py
+++ b/virtwho/__init__.py
@@ -11,6 +11,10 @@ HYPERVISOR_FILE = f'/etc/virt-who.d/{HYPERVISOR}.conf'
 
 PRINT_JSON_FILE = '/root/print.json'
 
+FAKE_CONFIG_NAME = 'fake.conf'
+
+FAKE_CONFIG_FILE = f'/etc/virt-who.d/{FAKE_CONFIG_NAME}'
+
 SECOND_HYPERVISOR_FILE = f'/etc/virt-who.d/{HYPERVISOR}-second.conf'
 
 SECOND_HYPERVISOR_SECTION = f'virtwho-{HYPERVISOR}-second'

--- a/virtwho/register.py
+++ b/virtwho/register.py
@@ -57,7 +57,7 @@ class SubscriptionManager:
             else:
                 cmd += f'--baseurl={self.baseurl}'
             ret, output = self.ssh.runcmd(cmd)
-            if ret == 0 and 'The system has been registered' in output:
+            if 'The system has been registered' in output:
                 logger.info(f'Succeeded to register host({self.host})')
                 return output
             else:
@@ -65,6 +65,7 @@ class SubscriptionManager:
         else:
             logger.info(f'The host({self.host}) has been registered, '
                         f'no need to register again.')
+            return None
 
     def unregister(self):
         """
@@ -216,7 +217,10 @@ class SubscriptionManager:
                             sku_attr['temporary'] = True
                         else:
                             sku_attr['temporary'] = False
-                        logger.info(f'---- {sku_attr} ----')
+                        # the below commented lines are used in local debug
+                        # logger.info(
+                        # f'---- sku_data of {sku_id}:\n{sku_attr}\n----'
+                        # )
                         return sku_attr
         logger.warning('Failed to get consumed subscriptions.')
         return None
@@ -321,6 +325,17 @@ class SubscriptionManager:
                         f'Succeeded to remove custom.facts for {self.host}')
                     return True
         raise FailException(f'Failed to remove custom.facts for {self.host}')
+
+    def pool_id_get(self, sku_id, sku_type='Physical'):
+        self.register()
+        sku_data = self.available(sku_id, sku_type)
+        if sku_data is not None:
+            sku_pool = sku_data['pool_id']
+            logger.info(f'Succeeded to get the vdc {sku_type} pool id: '
+                        f'{sku_pool}')
+            return sku_pool
+        logger.error('Failed to get the vdc physical sku pool id')
+        return None
 
 
 class RHSM:

--- a/virtwho/register.py
+++ b/virtwho/register.py
@@ -631,14 +631,9 @@ class Satellite:
         :param host: host name/uuid/hwuuid
         :return: host id or None
         """
-        # ret, output = self.ssh.runcmd(f'{self.hammer} host list '
-        #                               f'--organization-id {self.org_id} '
-        #                               f'--search {host} '
-        #                               f'--fields Id')
         ret, output = self.ssh.runcmd(f'{self.hammer} host list '
                                       f'--organization-id {self.org_id} '
                                       f'--search {host}')
-        # logger.info(f'--- {output} ---')
         output = json.loads(output)
         if ret == 0 and len(output) >= 1:
             for item in output:
@@ -994,8 +989,9 @@ def request_put(url, auth, headers, json_data, verify=False):
         TLS certificate
     :return: response status code
     """
-    res = requests.put(url=url, auth=auth, headers=headers, json=json_data,
-                       verify=verify)
+    res = requests.put(
+        url=url, auth=auth, headers=headers, json=json_data, verify=verify
+    )
     return res.status_code
 
 


### PR DESCRIPTION
**Description**
**test_rhsm.py:**
- [x] test_vdc_virtual_pool_attach_by_poolId
- [x] test_vdc_virtual_pool_attach_by_auto
- [x] test_vdc_temporary_pool_by_poolId
- [x] test_vdc_physcial_pool_consumed_status_in_physical_host
- [x] test_vdc_virtual_pool_consumed_status_in_guest
- [x] test_vdc_virtual_pool_attach_in_fake_mode

**test_satellite.py**
- [x] test_vdc_virtual_pool_attach_by_poolId
- [x] test_vdc_virtual_pool_attach_by_auto
- [x] test_vdc_temporary_pool_by_poolId
- [x] test_vdc_virtual_pool_attach_in_fake_mode
- [x] test_guest_auto_attach_rule_by_activation_key
- [x] test_guest_auto_attach_temporary_pool_by_activation_key
- [x] test_vdc_virtual_subscription_on_webui
- [x] test_register_by_item_on_webui (draft)

**Test Result**
```
**% pytest --disable-warnings -v tests/subscription/test_satellite.py**                                  
========================================================= test session starts =========================================================
platform darwin -- Python 3.11.2, pytest-7.2.2, pluggy-1.0.0 -- /opt/homebrew/opt/python@3.11/bin/python3.11
cachedir: .pytest_cache
rootdir: /Users/yuefliu/workspace/virtwho-test, configfile: pytest.ini
collected 7 items                                                                                                                     

tests/subscription/test_satellite.py::TestSatellite::test_vdc_virtual_pool_attach_by_poolId PASSED                              [ 14%]
tests/subscription/test_satellite.py::TestSatellite::test_vdc_virtual_pool_attach_by_auto PASSED                                [ 28%]
tests/subscription/test_satellite.py::TestSatellite::test_vdc_temporary_pool_by_poolId PASSED                                   [ 42%]
tests/subscription/test_satellite.py::TestSatellite::test_vdc_virtual_pool_attach_in_fake_mode PASSED                           [ 57%]
tests/subscription/test_satellite.py::TestSatellite::test_guest_auto_attach_rule_by_activation_key PASSED                       [ 71%]
tests/subscription/test_satellite.py::TestSatellite::test_guest_auto_attach_temporary_pool_by_activation_key PASSED             [ 85%]
tests/subscription/test_satellite.py::TestSatellite::test_vdc_virtual_subscription_on_webui PASSED                              [100%]

============================================== 7 passed, 9 warnings in 682.12s (0:11:22) ==============================================

**pytest --disable-warnings -v tests/subscription/test_rhsm.py**     
========================================================= test session starts =========================================================
platform darwin -- Python 3.11.2, pytest-7.2.2, pluggy-1.0.0 -- /opt/homebrew/opt/python@3.11/bin/python3.11
cachedir: .pytest_cache
rootdir: /Users/yuefliu/workspace/virtwho-test, configfile: pytest.ini
collected 6 items                                                                                                                     

tests/subscription/test_rhsm.py::TestRHSM::test_vdc_virtual_pool_attach_by_poolId PASSED                                        [ 16%]
tests/subscription/test_rhsm.py::TestRHSM::test_vdc_virtual_pool_attach_by_auto PASSED                                          [ 33%]
tests/subscription/test_rhsm.py::TestRHSM::test_vdc_temporary_pool_by_poolId PASSED                                             [ 50%]
tests/subscription/test_rhsm.py::TestRHSM::test_vdc_physcial_pool_consumed_status_in_physical_host PASSED                       [ 66%]
tests/subscription/test_rhsm.py::TestRHSM::test_vdc_virtual_pool_consumed_status_in_guest PASSED                                [ 83%]
tests/subscription/test_rhsm.py::TestRHSM::test_vdc_virtual_pool_attach_in_fake_mode PASSED                                     [100%]

============================================= 6 passed, 12 warnings in 1105.88s (0:18:25) ===========================================
```