### PR TITLE
add virt-who cli and service related cases

### DIFF
--- a/tests/function/test_cli.py
+++ b/tests/function/test_cli.py
@@ -255,13 +255,23 @@ class TestCli:
                 interactive mode
             2. encrypt virt-who host password with -p option
             3. encrypt virt-who host password with --password option
+            4. encrypt a special password: ad\"min
 
         :expectedresults:
 
             1. get the same encrypted password with the three methods.
+            2. get the same encrypted password for ad\"min and '"ad\"min"'
         """
         password = config.virtwho.password
         encrypt_1 = encrypt_password(ssh_host, password)
         encrypt_2 = encrypt_password(ssh_host, password, option='-p')
         encrypt_3 = encrypt_password(ssh_host, password, option='--password')
         assert encrypt_1 == encrypt_2 == encrypt_3
+
+        encrypt_1 = encrypt_password(ssh_host, r'ad\"min')
+        encrypt_2 = encrypt_password(ssh_host, r'ad\"min', option='-p')
+        encrypt_3 = encrypt_password(ssh_host, r'"ad\"min"', option='-p')
+        encrypt_4 = encrypt_password(ssh_host, r'ad\"min', option='--password')
+        encrypt_5 = encrypt_password(ssh_host, r'"ad\"min"',
+                                     option='--password')
+        assert encrypt_1 == encrypt_2 == encrypt_3 == encrypt_4 == encrypt_5

--- a/tests/function/test_service.py
+++ b/tests/function/test_service.py
@@ -4,16 +4,24 @@
 :testtype: functional
 :caseautomation: Automated
 """
+
 import pytest
+from virtwho.settings import config
+from virtwho.configure import hypervisor_create
+from virtwho.base import ssh_access_no_password, expect_run
+from virtwho import HYPERVISOR, REGISTER
+from virtwho.ssh import SSHConnect
 
 
 @pytest.mark.usefixtures('class_globalconf_clean')
+@pytest.mark.usefixtures('class_hypervisor')
+@pytest.mark.usefixtures('class_virtwho_d_conf_clean')
 class TestVirtwhoService:
     @pytest.mark.tier1
-    def test_start_and_stop(self, virtwho):
+    def test_virtwho_service_start_and_stop(self, virtwho):
         """
 
-        :title: virt-who: service: test start and stop
+        :title: virt-who: service: test start and stop virt-who service
         :id: 42891e5b-5e84-43d0-ba56-7c4f4348bdc4
         :caseimportance: High
         :tags: tier1
@@ -29,17 +37,17 @@ class TestVirtwhoService:
         _, _ = virtwho.operate_service(action='stop')
         _, _ = virtwho.operate_service(action='start')
         _, output = virtwho.operate_service(action='status')
-        assert 'Active: active (running)' in output
+        assert output is 'running'
 
         _, _ = virtwho.operate_service(action='stop')
         _, output = virtwho.operate_service(action='status')
-        assert 'Active: inactive (dead)' in output
+        assert output is 'dead'
 
     @pytest.mark.tier1
-    def test_restart(self, virtwho):
+    def test_virtwho_service_restart(self, virtwho):
         """
 
-        :title: virt-who: service: test restart
+        :title: virt-who: service: test restart virt-who service
         :id: 60071821-31a8-49d0-a656-4a27f64ec18a
         :caseimportance: High
         :tags: tier1
@@ -52,13 +60,13 @@ class TestVirtwhoService:
         """
         _, _ = virtwho.operate_service(action='restart')
         _, output = virtwho.operate_service(action='status')
-        assert 'Active: active (running)' in output
+        assert output is 'running'
 
     @pytest.mark.tier1
-    def test_try_restart(self, virtwho):
+    def test_virtwho_service_try_restart(self, virtwho):
         """
 
-        :title: virt-who: service: test try-restart
+        :title: virt-who: service: test try-restart virt-who service
         :id: 5fe64b1b-ca5c-4b6e-bf11-207d8d0b7736
         :caseimportance: High
         :tags: tier1
@@ -71,13 +79,13 @@ class TestVirtwhoService:
         """
         _, _ = virtwho.operate_service(action='try-restart')
         _, output = virtwho.operate_service(action='status')
-        assert 'Active: active (running)' in output
+        assert output is 'running'
 
     @pytest.mark.tier1
-    def test_force_reload(self, virtwho):
+    def test_virtwho_service_force_reload(self, virtwho):
         """
 
-        :title: virt-who: service: test force-reload
+        :title: virt-who: service: test force-reload virt-who service
         :id: 91e933c8-88fc-44d9-bf07-d349fe18d8a5
         :caseimportance: High
         :tags: tier1
@@ -90,4 +98,151 @@ class TestVirtwhoService:
         """
         _, _ = virtwho.operate_service(action='force-reload')
         _, output = virtwho.operate_service(action='status')
-        assert 'Active: active (running)' in output
+        assert output is 'running'
+
+    @pytest.mark.tier1
+    def test_virtwho_service_control_by_ssh_connect(self, virtwho, ssh_guest,
+                                                    ssh_host):
+        """
+
+        :title: virt-who: service: test virt-who service control by ssh connect
+        :id: 486e180d-691b-4c89-af66-b93d4dd84b8c
+        :caseimportance: High
+        :tags: tier1
+        :customerscenario: false
+        :upstream: no
+        :steps:
+            1. configure a remote rhel host accessing the virt-who host by ssh
+                without password
+            2. in the remote host, try to stop the virt-who service by command
+                'ssh [server_ip] -p [server_port] "systemctl stop virt-who"'
+            3. in the remote host, try to start the virt-who service by command
+                'ssh [server_ip] -p [server_port] "systemctl start virt-who"'
+            4. in the remote host, try to stop the virt-who service again by
+                'ssh [server_ip] -p [server_port] "systemctl stop virt-who"'
+        :expectedresults:
+            1. we can control the virt-who service in a remote host by
+                ssh login.
+        """
+        server = config.virtwho.server
+        port = config.virtwho.port
+        ssh_access_no_password(ssh_guest, ssh_host, server, port)
+        # stop
+        _, _ = ssh_guest.runcmd(f'ssh {server} -p {port} '
+                                f'"systemctl stop virt-who"')
+        _, status = virtwho.operate_service(action='status')
+        assert status == 'dead'
+
+        # start
+        _, _ = ssh_guest.runcmd(f'ssh {server} -p {port} '
+                                f'"systemctl restart virt-who"')
+        _, status = virtwho.operate_service(action='status')
+        assert status == 'running'
+
+        # stop
+        _, _ = ssh_guest.runcmd(f'ssh {server} -p {port} '
+                                f'"systemctl stop virt-who"')
+        _, status = virtwho.operate_service(action='status')
+        assert status == 'dead'
+
+    @pytest.mark.tier1
+    def test_virtwho_and_rhsmcertd_servce(self, virtwho, ssh_host):
+        """
+
+        :title: virt-who: service: test virt-who and rhsmcertd service
+        :id: ab28679b-f505-47fb-a7ae-760d2cec7045
+        :caseimportance: High
+        :tags: tier1
+        :customerscenario: false
+        :upstream: no
+        :steps:
+            1. restart virt-who service, check virt-who status and thread
+            2. restart rhsmcertd service , check virt-who status and thread
+            3. restart virt-who service again , check virt-who run without error
+        :expectedresults:
+            1. restarting the rhsmcertd service will not impact virt-who service
+        """
+        _, _ = virtwho.operate_service(action='restart')
+        _, output = virtwho.operate_service(action='status')
+        assert output == 'running' and virtwho.thread_number() == 1
+
+        ret, _ = ssh_host.runcmd(f'systemctl restart rhsmcertd')
+        assert ret == 0
+        _, output = virtwho.operate_service(action='status')
+        assert output == 'running' and virtwho.thread_number() == 1
+
+        result = virtwho.run_service()
+        assert (result['send'] == 1
+                and result['error'] == 0
+                and result['thread'] == 1)
+
+    @pytest.mark.tier1
+    def test_virtwho_ignore_swp_file(self, virtwho, ssh_host):
+        """
+
+        :title: virt-who: service: test virt-who service ignores
+            /etc/virt-who.d/*.swp file
+        :id: 85d390dd-5b9c-4428-85d9-ef28568faae8
+        :caseimportance: High
+        :tags: tier1
+        :customerscenario: false
+        :upstream: no
+        :steps:
+            1. create an available /etc/virt-who.d/mode.conf file
+            2. create a bad /etc/virt-who.d/*.swp file
+            3. restart virt-who service to check log
+        :expectedresults:
+            1. virt-who service ignores the /etc/virt-who.d/*.swp file
+        """
+        swp_config_file = '/etc/virt-who.d/.test.conf.swp'
+        swp = hypervisor_create(mode=HYPERVISOR,
+                                register_type=REGISTER,
+                                config_name=swp_config_file,
+                                section='test-swp')
+
+        try:
+            swp.update('type', 'test')
+            ssh_host.runcmd(f'cat /etc/virt-who.d/.test.conf.swp')
+            result = virtwho.run_service()
+            assert (result['send'] == 1 and result['error'] == 0)
+
+        finally:
+            ssh_host.runcmd(f'rm -rf {swp_config_file}')
+
+    @pytest.mark.tier2
+    def test_virtwho_non_root_user(self, virtwho, ssh_host):
+        """
+
+        :title: virt-who: service: test virt-who in non_root user
+        :id: fa260cd0-0f1b-4238-84c6-271a175add94
+        :caseimportance: High
+        :tags: tier2
+        :customerscenario: false
+        :upstream: no
+        :steps:
+            1. create a new non_root user account for virt-who host
+            2. start virt-who service by the new account
+        :expectedresults:
+            1. virt-who service can start and report normally by the non_root
+                account.
+        """
+        host = config.virtwho.server
+        username_new = 'tester'
+        password = config.virtwho.password
+        _, _ = ssh_host.runcmd(f'useradd {username_new}')
+        cmd = r'echo -e "{0}:{1}" | chpasswd'.format(username_new, password)
+        _, _ = ssh_host.runcmd(cmd)
+
+        ssh_new = SSHConnect(host=host,
+                             user=username_new,
+                             pwd=password)
+        virtwho.stop()
+        virtwho.log_clean()
+        _, _ = expect_run(ssh=ssh_new,
+                          cmd='systemctl start virt-who',
+                          attrs=[f'Password:|{password}'])
+        rhsm_log = virtwho.rhsm_log_get()
+        result = virtwho.analyzer(rhsm_log)
+        assert (result['send'] == 1
+                and result['error'] == 0
+                and result['thread'] == 1)

--- a/tests/function/test_service.py
+++ b/tests/function/test_service.py
@@ -230,7 +230,7 @@ class TestVirtwhoService:
         username_new = 'tester'
         password = config.virtwho.password
         _, _ = ssh_host.runcmd(f'useradd {username_new}')
-        cmd = r'echo -e "{0}:{1}" | chpasswd'.format(username_new, password)
+        cmd = fr'echo -e "{username_new}:{password}" | chpasswd'
         _, _ = ssh_host.runcmd(cmd)
 
         ssh_new = SSHConnect(host=host,

--- a/virtwho/configure.py
+++ b/virtwho/configure.py
@@ -138,7 +138,7 @@ class VirtwhoGlobalConfig:
         os.system(f"echo '' > {self.local_file}")
         self.remote_ssh.put_file(self.local_file, self.remote_file)
         self.cfg = Configure(self.local_file, self.remote_ssh, self.remote_file)
-        logger.info(f'*** Clean /etc/virt-who.d/*')
+        logger.info(f'*** Clean /etc/virt-who.conf')
 
 
 class VirtwhoSysConfig:
@@ -270,7 +270,7 @@ def hypervisor_create(mode='esx', register_type='rhsm', config_name=None, sectio
     """ Create the hypervisor config file
     :param mode: The hypervisor mode.
     :param register_type: The subscription server. (rhsm, satellite)
-    :param config_name: the file name for the virt-who config
+    :param config_name: the file path/name for the virt-who config
     :param section: the name for the virt-who config section
     :param rhsm: True is to add all rhsm related options, False will not
     :return:

--- a/virtwho/runner.py
+++ b/virtwho/runner.py
@@ -122,8 +122,7 @@ class VirtwhoRunner:
         data['interval'] = self.interval_time(rhsm_log)
         data['loop'], data['loop_num'] = self.loop_info()
         data['mappings'] = self.mappings(rhsm_log)
-        if cli and '-p ' in cli:
-            data['print_json'] = self.print_json()
+        data['print_json'] = self.print_json(cli)
         data['error'], data['error_msg'] = self.error_warning('error')
         data['warning'], data['warning_msg'] = self.error_warning('warning')
         if HYPERVISOR != 'local':
@@ -513,16 +512,17 @@ class VirtwhoRunner:
                     return mapping[org][guest_uuid]['guest_hypervisor']
         return ''
 
-    def print_json(self):
+    def print_json(self, cli):
         """
         Get and return the json created by print function.
         :return: json output
         """
-        ret, output = self.ssh.runcmd(f"cat {PRINT_JSON_FILE}")
-        if ret == 0 and output != "":
-            return output
-        else:
-            return None
+        _, output = self.ssh.runcmd('cat /etc/virt-who.conf')
+        if (cli and '-p ' in cli) or ('print_=' in output):
+            ret, output = self.ssh.runcmd(f"cat {PRINT_JSON_FILE}")
+            if ret == 0 and output != "":
+                return output
+        return None
 
     def thread_number(self):
         """


### PR DESCRIPTION
**Description**

- [x] test_kill_virtwho_in_terminal_side
- [x] test_run_virtwho_cli_when_the_service_is_running
- [x] test_virtwho_encrypted_password
- [x] test_virtwho_service_control_by_ssh_connect
- [x] test_virtwho_and_rhsmcertd_servce
- [x] test_virtwho_ignore_swp_file
- [x] test_virtwho_non_root_user


**Test Result**
```
% pytest --disable-warnings -v tests/function/test_service.py                   
========================================================= test session starts =========================================================
platform darwin -- Python 3.11.2, pytest-7.2.2, pluggy-1.0.0 -- /opt/homebrew/opt/python@3.11/bin/python3.11
cachedir: .pytest_cache
rootdir: /Users/yuefliu/workspace/virtwho-test, configfile: pytest.ini
collected 8 items                                                                                                                     

tests/function/test_service.py::TestVirtwhoService::test_virtwho_service_start_and_stop PASSED                                  [ 12%]
tests/function/test_service.py::TestVirtwhoService::test_virtwho_service_restart PASSED                                         [ 25%]
tests/function/test_service.py::TestVirtwhoService::test_virtwho_service_try_restart PASSED                                     [ 37%]
tests/function/test_service.py::TestVirtwhoService::test_virtwho_service_force_reload PASSED                                    [ 50%]
tests/function/test_service.py::TestVirtwhoService::test_virtwho_service_control_by_ssh_connect PASSED                          [ 62%]
tests/function/test_service.py::TestVirtwhoService::test_virtwho_and_rhsmcertd_servce PASSED                                    [ 75%]
tests/function/test_service.py::TestVirtwhoService::test_virtwho_ignore_swp_file PASSED                                         [ 87%]
tests/function/test_service.py::TestVirtwhoService::test_virtwho_non_root_user PASSED                                           [100%]

============================================== 8 passed, 2 warnings in 363.94s (0:06:03) ==============================
```
```
 % pytest --disable-warnings -v tests/function/test_service.py                   
========================================================= test session starts ========================================================= 
platform darwin -- Python 3.11.2, pytest-7.2.2, pluggy-1.0.0 -- /opt/homebrew/opt/python@3.11/bin/python3.11
cachedir: .pytest_cache
rootdir: /Users/yuefliu/workspace/virtwho-test, configfile: pytest.ini
collected 8 items                                                                                                                     

tests/function/test_service.py::TestVirtwhoService::test_virtwho_service_start_and_stop PASSED                                  [ 12%]
tests/function/test_service.py::TestVirtwhoService::test_virtwho_service_restart PASSED                                         [ 25%]
tests/function/test_service.py::TestVirtwhoService::test_virtwho_service_try_restart PASSED                                     [ 37%]
tests/function/test_service.py::TestVirtwhoService::test_virtwho_service_force_reload PASSED                                    [ 50%]
tests/function/test_service.py::TestVirtwhoService::test_virtwho_service_control_by_ssh_connect PASSED                          [ 62%]
tests/function/test_service.py::TestVirtwhoService::test_virtwho_and_rhsmcertd_servce PASSED                                    [ 75%]
tests/function/test_service.py::TestVirtwhoService::test_virtwho_ignore_swp_file PASSED                                         [ 87%]
tests/function/test_service.py::TestVirtwhoService::test_virtwho_non_root_user PASSED                                           [100%]

============================================== 8 passed, 2 warnings in 363.94s (0:06:03) ==============================
```