### PR TITLE
Design test case to report hypervisor for subscription watch team

### DIFF
--- a/tests/hypervisor/test_hypervisors_state.py
+++ b/tests/hypervisor/test_hypervisors_state.py
@@ -14,7 +14,7 @@ from virtwho.provision.virtwho_hypervisor import rhevm_monitor
 from virtwho.provision.virtwho_hypervisor import xen_monitor
 
 
-class TestHypervisorsState:
+class TestHypervisorsMonitor:
     def test_state_esx(self):
         """Test the esx state"""
         assert esx_monitor() == 'GOOD'

--- a/tests/hypervisor/test_hypervisors_state.py
+++ b/tests/hypervisor/test_hypervisors_state.py
@@ -14,7 +14,7 @@ from virtwho.provision.virtwho_hypervisor import rhevm_monitor
 from virtwho.provision.virtwho_hypervisor import xen_monitor
 
 
-class TestHypervisorsMonitor:
+class TestHypervisorsState:
     def test_state_esx(self):
         """Test the esx state"""
         assert esx_monitor() == 'GOOD'

--- a/tests/hypervisor/test_hypervisors_sw.py
+++ b/tests/hypervisor/test_hypervisors_sw.py
@@ -1,0 +1,76 @@
+import pytest
+from virtwho.configure import config, hypervisor_create
+from virtwho.register import SubscriptionManager, RHSM
+from virtwho.runner import VirtwhoRunner
+from virtwho.base import hostname_get
+from virtwho.ssh import SSHConnect
+
+
+@pytest.mark.usefixtures('class_globalconf_clean')
+@pytest.mark.usefixtures('class_virtwho_d_conf_clean')
+class TestHypervisorsSW:
+    def test_report_hypervisor_for_sw(self):
+        """
+        Report hypervisors mapping and register guest to stage candlepin for
+        the con-work with Subscription Watch team.
+        """
+        hypervisors = config.job.multi_hypervisors
+        hosts = []
+        virtwho = VirtwhoRunner(mode='', register_type='rhsm')
+        sm_host = SubscriptionManager(host=config.virtwho.server,
+                                      username=config.virtwho.username,
+                                      password=config.virtwho.password,
+                                      register_type='rhsm_sw')
+        rhsm = RHSM(rhsm='rhsm_sw')
+        try:
+            # remove all systems from stage account
+            rhsm.host_delete()
+            # register virt-who host to the stage
+            sm_host.register()
+            # start to report mapping and register guest
+            if 'ahv' in hypervisors:
+                hypervisor_create(mode='ahv',
+                                  register_type='rhsm_sw',
+                                  rhsm=False)
+                sm_guest = SubscriptionManager(
+                    host=config.ahv.guest_ip_sw,
+                    username=config.ahv.guest_username_sw,
+                    password=config.ahv.guest_password_sw,
+                    register_type='rhsm_sw'
+                )
+                sm_guest.register()
+
+                ssh_guest = SSHConnect(host=config.ahv.guest_ip_sw,
+                                       user=config.ahv.guest_username_sw,
+                                       pwd=config.ahv.guest_password_sw)
+                guest_hostname = hostname_get(ssh_guest)
+                hosts.append(config.ahv.hostname)
+                hosts.append(guest_hostname)
+            if 'kubevirt' in hypervisors:
+                hypervisor_create(mode='kubevirt',
+                                  register_type='rhsm_sw',
+                                  rhsm=False)
+                sm_guest = SubscriptionManager(
+                    host=config.kubevirt.guest_ip_sw,
+                    username=config.kubevirt.guest_username_sw,
+                    password=config.kubevirt.guest_password_sw,
+                    port=config.kubevirt.guest_port_sw,
+                    register_type='rhsm_sw'
+                )
+                sm_guest.register()
+
+                ssh_guest = SSHConnect(host=config.kubevirt.guest_ip_sw,
+                                       user=config.kubevirt.guest_username_sw,
+                                       pwd=config.kubevirt.guest_password_sw,
+                                       port=config.kubevirt.guest_port_sw)
+                guest_hostname = hostname_get(ssh_guest)
+                hosts.append(config.kubevirt.hostname)
+                hosts.append(guest_hostname)
+
+            result = virtwho.run_cli(config=None)
+            assert (result['send'] != 0
+                    and result['error'] == 0
+                    and all(rhsm.info(name) for name in hosts))
+
+        finally:
+            sm_host.unregister()

--- a/virtwho/configure.py
+++ b/virtwho/configure.py
@@ -252,6 +252,8 @@ def get_register_handler(register_type):
     register = config.rhsm
     if register_type == 'satellite':
         register = config.satellite
+    if register_type == 'rhsm_sw':
+        register = config.rhsm_sw
     return register
 
 

--- a/virtwho/register.py
+++ b/virtwho/register.py
@@ -341,14 +341,16 @@ class SubscriptionManager:
 
 class RHSM:
 
-    def __init__(self):
+    def __init__(self, rhsm='rhsm'):
         """
         Using rhsm api to check/get/delete consumers,  attach/remove
         subscription, and check the host-to-guest associations.
+        :param rhsm: rhsm org rhsm_sw.
         """
-        self.org = config.rhsm.default_org
-        self.api = f'https://{config.rhsm.server}/subscription'
-        self.auth = (config.rhsm.username, config.rhsm.password)
+        register = get_register_handler(rhsm)
+        self.org = register.default_org
+        self.api = f'https://{register.server}/subscription'
+        self.auth = (register.username, register.password)
 
     def consumers(self, host_name=None):
         """

--- a/virtwho/runner.py
+++ b/virtwho/runner.py
@@ -503,7 +503,7 @@ class VirtwhoRunner:
         Get the hypervisor id by mapping
         :param mapping: the host-to-guest mapping
         """
-        if mapping:
+        if mapping and self.mode:
             guest_uuid = get_hypervisor_handler(self.mode).guest_uuid
             for org in mapping['orgs']:
                 org_dict = mapping[org]


### PR DESCRIPTION
**Test Steps**
When the hypervisor/guest change, we will run the test case to report the latest mapping to the specified stage account.

1. delete all hosts from the account
2. register virt-who host to the stage
3. run virt-who to report mappings 
4. register guests


**Test Result**
```
% pytest --disable-warnings -v tests/hypervisor/test_hypervisors_sw.py
========================================================= test session starts =========================================================
platform darwin -- Python 3.11.2, pytest-7.2.2, pluggy-1.0.0 -- /opt/homebrew/opt/python@3.11/bin/python3.11
cachedir: .pytest_cache
rootdir: /Users/yuefliu/workspace/virtwho-test, configfile: pytest.ini
collected 1 item                                                                                                                      

tests/hypervisor/test_hypervisors_sw.py::TestHypervisorsSW::test_report_hypervisor_for_sw PASSED                                [100%]

============================================== 1 passed, 2 warnings in 200.30s (0:03:20) =============================================
```