### PR TITLE
test_hypervisors_sw.py: add guest_hostname_sw to .ini file to support…

### DIFF
--- a/tests/hypervisor/test_hypervisors_state.py
+++ b/tests/hypervisor/test_hypervisors_state.py
@@ -15,6 +15,7 @@ from virtwho.provision.virtwho_hypervisor import xen_monitor
 
 
 class TestHypervisorsState:
+    """The test cases for hypervisor-monitor"""
     def test_state_esx(self):
         """Test the esx state"""
         assert esx_monitor() == 'GOOD'

--- a/tests/hypervisor/test_hypervisors_sw.py
+++ b/tests/hypervisor/test_hypervisors_sw.py
@@ -4,6 +4,7 @@ from virtwho.register import SubscriptionManager, RHSM
 from virtwho.runner import VirtwhoRunner
 from virtwho.base import hostname_get
 from virtwho.ssh import SSHConnect
+from utils.properties_update import virtwho_ini_update
 
 
 @pytest.mark.usefixtures('class_globalconf_clean')
@@ -27,6 +28,7 @@ class TestHypervisorsSW:
             rhsm.host_delete()
             # register virt-who host to the stage
             sm_host.register()
+
             # start to report mapping and register guest
             if 'ahv' in hypervisors:
                 hypervisor_create(mode='ahv',
@@ -44,8 +46,10 @@ class TestHypervisorsSW:
                                        user=config.ahv.guest_username_sw,
                                        pwd=config.ahv.guest_password_sw)
                 guest_hostname = hostname_get(ssh_guest)
+                virtwho_ini_update('ahv', 'guest_hostname_sw', guest_hostname)
                 hosts.append(config.ahv.hostname)
                 hosts.append(guest_hostname)
+
             if 'kubevirt' in hypervisors:
                 hypervisor_create(mode='kubevirt',
                                   register_type='rhsm_sw',
@@ -64,6 +68,8 @@ class TestHypervisorsSW:
                                        pwd=config.kubevirt.guest_password_sw,
                                        port=config.kubevirt.guest_port_sw)
                 guest_hostname = hostname_get(ssh_guest)
+                virtwho_ini_update(
+                    'kubevirt', 'guest_hostname_sw', guest_hostname)
                 hosts.append(config.kubevirt.hostname)
                 hosts.append(guest_hostname)
 


### PR DESCRIPTION
the email report needs the `guest hostname`, so update the test file to add the item the virtwho.ini. 

**Test Result**
```
% pytest --disable-warnings -v tests/hypervisor/test_hypervisors_sw.py
========================================================= test session starts =========================================================
platform darwin -- Python 3.11.2, pytest-7.2.2, pluggy-1.0.0 -- /opt/homebrew/opt/python@3.11/bin/python3.11
cachedir: .pytest_cache
rootdir: /Users/yuefliu/workspace/virtwho-test, configfile: pytest.ini
collected 1 item                                                                                                                      

tests/hypervisor/test_hypervisors_sw.py::TestHypervisorsSW::test_report_hypervisor_for_sw PASSED                                [100%]

============================================== 1 passed, 2 warnings in 184.06s (0:03:04) ========================================
```