### PR TITLE
Add test case test_url_without_ovirt_engine

### DIFF
--- a/tests/hypervisor/test_rhevm.py
+++ b/tests/hypervisor/test_rhevm.py
@@ -664,3 +664,36 @@ class TestRHEVMNegative:
                 and result["thread"] == 1
                 and hostname not in str(result["mappings"])
             )
+
+    @pytest.mark.tier2
+    def test_url_without_ovirt_engine(self, virtwho, function_hypervisor, hypervisor_data):
+        """Test the rhevm url without ovirt engine
+
+        :title: virt-who: rhevm: test server url (negative)
+        :id: 530d86f7-d8f9-44f6-b860-579611758cd8
+        :caseimportance: High
+        :tags: tier2
+        :customerscenario: false
+        :upstream: no
+        :steps:
+            1. run virt-who for rhevm with ovirt-engine/
+            2. run virt-who for rhevm without /ovirt-engine
+        :expectedresults:
+            1. Succeed to run the virt-who service
+            2. Succeed to run the virt-who service
+
+        """
+        # run virt-who for rhevm with ovirt-engine/
+        function_hypervisor.update("server", function_hypervisor.rhevm_hypervisor_url + "/")
+        result = virtwho.run_service()
+        assert (result['error'] == 0
+                and result['send'] == 1
+                and result['thread'] == 1)
+
+        # run virt-who for rhevm without /ovirt-engine
+        function_hypervisor.update("server",
+                                   function_hypervisor.rhevm_hypervisor_url.rstrip("/ovirt-engine/"))
+        result = virtwho.run_service()
+        assert (result['error'] == 0
+                and result['send'] == 1
+                and result['thread'] == 1)

--- a/tests/hypervisor/test_rhevm.py
+++ b/tests/hypervisor/test_rhevm.py
@@ -666,7 +666,9 @@ class TestRHEVMNegative:
             )
 
     @pytest.mark.tier2
-    def test_url_without_ovirt_engine(self, virtwho, function_hypervisor, hypervisor_data):
+    def test_url_without_ovirt_engine(
+        self, virtwho, function_hypervisor, hypervisor_data
+    ):
         """Test the rhevm url without ovirt engine
 
         :title: virt-who: rhevm: test server url (negative)
@@ -684,16 +686,15 @@ class TestRHEVMNegative:
 
         """
         # run virt-who for rhevm with ovirt-engine/
-        function_hypervisor.update("server", function_hypervisor.rhevm_hypervisor_url + "/")
+        function_hypervisor.update(
+            "server", function_hypervisor.rhevm_hypervisor_url + "/"
+        )
         result = virtwho.run_service()
-        assert (result['error'] == 0
-                and result['send'] == 1
-                and result['thread'] == 1)
+        assert result["error"] == 0 and result["send"] == 1 and result["thread"] == 1
 
         # run virt-who for rhevm without /ovirt-engine
-        function_hypervisor.update("server",
-                                   function_hypervisor.rhevm_hypervisor_url.rstrip("/ovirt-engine/"))
+        function_hypervisor.update(
+            "server", function_hypervisor.rhevm_hypervisor_url.rstrip("/ovirt-engine/")
+        )
         result = virtwho.run_service()
-        assert (result['error'] == 0
-                and result['send'] == 1
-                and result['thread'] == 1)
+        assert result["error"] == 0 and result["send"] == 1 and result["thread"] == 1

--- a/virtwho/configure.py
+++ b/virtwho/configure.py
@@ -27,6 +27,7 @@ class VirtwhoHypervisorConfig:
         self.register = get_register_handler(register_type)
         self.hypervisor = get_hypervisor_handler(mode)
         self.remote_ssh = virtwho_ssh_connect(mode)
+        self.rhevm_hypervisor_url = None
         if not os.path.exists(TEMP_DIR):
             os.mkdir(TEMP_DIR)
         self.local_file = os.path.join(TEMP_DIR, f"{mode}.conf")
@@ -65,6 +66,7 @@ class VirtwhoHypervisorConfig:
                     hypervisor_server = (
                         f"https://{hostname_get(ssh_rhevm)}:443/ovirt-engine"
                     )
+                    self.rhevm_hypervisor_url = hypervisor_server
                 self.update("server", hypervisor_server)
                 self.update("username", self.hypervisor.username)
                 self.update("password", self.hypervisor.password)


### PR DESCRIPTION
**Description**
Add test case test_url_without_ovirt_engine from [tc_2055_validate_rhevm_url_without_ovirt_engine.py](https://github.com/VirtwhoQE/virtwho-ci/blob/master/tests/tier2/tc_2055_validate_rhevm_url_without_ovirt_engine.py)

Need the value `rhevm_hypervisor_url `from `VirtwhoHypervisorConfig`

**Test Result**
```
[hkx303@kuhuang virtwho-test]$ pytest tests/hypervisor/test_rhevm.py -k test_url_without_ovirt_engine -s
==================================== test session starts =====================================
platform linux -- Python 3.7.3, pytest-5.4.3, py-1.8.0, pluggy-0.13.1
rootdir: /home/hkx303/Documents/CI/virtwho-test, inifile: pytest.ini
plugins: services-1.3.1, mock-1.10.4, forked-1.0.2, ibutsu-1.0.34, cov-2.7.1, xdist-1.34.0
collected 13 items / 12 deselected / 1 selected   
======================== 1 passed, 12 deselected in 92.47s (0:01:32) =========================
```
