### PR TITLE
Perfect the satellite deployment process

### DIFF
--- a/virtwho/register.py
+++ b/virtwho/register.py
@@ -607,7 +607,7 @@ class Satellite:
                 'Name has already been taken' in output
                 and
                 'Label has already been taken' in output
-        ):
+        ) or 'resource have no errors' in output:
             logger.info(f'The organization:{name} already existed')
             return True
         raise FailException(f'Failed to create organization:{name}')


### PR DESCRIPTION
- As the following release note of satellite6.13, use option `--tuning development` to replace the `--disable-system-checks` when >= `6.13`
```
The --disable-system-checks option has been removed from the satellite-installer. A Satellite installation now requires the minimum recommended system resources to be allocated. For non-production deployments, and only if absolutely necessary, you can use --tuning development as an alternative option. 
```

- move function `satellite_manifest_upload` to `virtwho_satellite.py` from `utils/satellite.py` to make it specified only for virt-who testing.
- fix the org create issue when it already exists.
- fix the manifest upload issue by removing it before uploading.