### PR TITLE
Add test case: test_insecure for kubevirt test file

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -272,11 +272,6 @@ def hypervisor_data(ssh_guest):
         data["hypervisor_password"] = hypervisor_handler.password
         data["hypervisor_server"] = hypervisor_handler.server
         data["hypervisor_username"] = hypervisor_handler.username
-        data['hypervisor_uuid'] = hypervisor_handler.uuid
-        data['hypervisor_hostname'] = hypervisor_handler.hostname
-        data['type'] = hypervisor_handler.type
-        data['version'] = hypervisor_handler.version
-        data['cpu'] = hypervisor_handler.cpu
     return data
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -264,10 +264,19 @@ def hypervisor_data(ssh_guest):
         data["cluster"] = hypervisor_handler.cluster
     if HYPERVISOR == "kubevirt":
         data["hypervisor_server"] = hypervisor_handler.endpoint
+        data['hypervisor_config_file'] = hypervisor_handler.config_file
+        data['hypervisor_config_file_no_cert'] = hypervisor_handler.config_file_no_cert
+        data['hypervisor_config_url'] = hypervisor_handler.config_url
+        data['hypervisor_config_url_no_cert'] = hypervisor_handler.config_url_no_cert
     else:
         data["hypervisor_password"] = hypervisor_handler.password
         data["hypervisor_server"] = hypervisor_handler.server
         data["hypervisor_username"] = hypervisor_handler.username
+        data['hypervisor_uuid'] = hypervisor_handler.uuid
+        data['hypervisor_hostname'] = hypervisor_handler.hostname
+        data['type'] = hypervisor_handler.type
+        data['version'] = hypervisor_handler.version
+        data['cpu'] = hypervisor_handler.cpu
     return data
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -264,10 +264,10 @@ def hypervisor_data(ssh_guest):
         data["cluster"] = hypervisor_handler.cluster
     if HYPERVISOR == "kubevirt":
         data["hypervisor_server"] = hypervisor_handler.endpoint
-        data['hypervisor_config_file'] = hypervisor_handler.config_file
-        data['hypervisor_config_file_no_cert'] = hypervisor_handler.config_file_no_cert
-        data['hypervisor_config_url'] = hypervisor_handler.config_url
-        data['hypervisor_config_url_no_cert'] = hypervisor_handler.config_url_no_cert
+        data["hypervisor_config_file"] = hypervisor_handler.config_file
+        data["hypervisor_config_file_no_cert"] = hypervisor_handler.config_file_no_cert
+        data["hypervisor_config_url"] = hypervisor_handler.config_url
+        data["hypervisor_config_url_no_cert"] = hypervisor_handler.config_url_no_cert
     else:
         data["hypervisor_password"] = hypervisor_handler.password
         data["hypervisor_server"] = hypervisor_handler.server

--- a/tests/hypervisor/test_kubevirt.py
+++ b/tests/hypervisor/test_kubevirt.py
@@ -374,3 +374,54 @@ class TestKubevirtNegative:
                 and result["thread"] == 1
                 and hostname not in str(result["mappings"])
             )
+
+    @pytest.mark.tier2
+    @pytest.mark.notRHEL8
+    def test_insecure(self, virtwho, function_hypervisor, hypervisor_data, ssh_host):
+        """Test the insecure option in /etc/virt-who.d/hypervisor.conf
+
+        :title: virt-who: kubevirt: test insecure option
+        :id: bb777123-3210-4392-9c0d-e7fc332dc762
+        :caseimportance: High
+        :tags: tier2
+        :customerscenario: false
+        :upstream: no
+        :steps:
+            1. Configure kubeconfig without cert
+            2. Configure the insecure option with "none", "", "0", "False" value and run virt-who
+            3. Configure the insecure option with "1", "True" value and run virt-who
+        :expectedresults:
+            2. Failed to run the virt-who service with the error message:
+            "certificate verify failed"
+            3. Succeed to start the virt-who service
+        """
+        config_file_no_cert = "/root/kube.conf_no_cert"
+        config_url_no_cert = hypervisor_data['hypervisor_config_url_no_cert']
+        cmd = f"rm -f {config_file_no_cert}; " \
+            f"curl -L {config_url_no_cert} -o {config_file_no_cert}; sync"
+        ssh_host.runcmd(cmd)
+        function_hypervisor.update('kubeconfig', config_file_no_cert)
+
+        # configure kubeconfig without cert and run virt-who
+        for value in ("none", "", "0", "False"):
+            # none -> run virt-who without insecure= option
+            if value != "none":
+                function_hypervisor.update("insecure", value)
+            result = virtwho.run_service()
+            error_msg = "certificate verify failed"
+            assert (result['error'] == 1
+                    and result['send'] == 0
+                    and result['thread'] == 1
+                    and error_msg in result['log'])
+            function_hypervisor.delete("insecure")
+
+        # test insecure=1/True can ignore checking cert"
+        for value in ("1", "True"):
+            function_hypervisor.update("insecure", value)
+            result = virtwho.run_service()
+            assert (result['error'] == 0
+                    and result['send'] == 1
+                    and result['thread'] == 1)
+            function_hypervisor.delete("insecure")
+
+        ssh_host.runcmd(f"rm -rf {config_file_no_cert}")

--- a/tests/hypervisor/test_kubevirt.py
+++ b/tests/hypervisor/test_kubevirt.py
@@ -396,11 +396,13 @@ class TestKubevirtNegative:
             3. Succeed to start the virt-who service
         """
         config_file_no_cert = "/root/kube.conf_no_cert"
-        config_url_no_cert = hypervisor_data['hypervisor_config_url_no_cert']
-        cmd = f"rm -f {config_file_no_cert}; " \
+        config_url_no_cert = hypervisor_data["hypervisor_config_url_no_cert"]
+        cmd = (
+            f"rm -f {config_file_no_cert}; "
             f"curl -L {config_url_no_cert} -o {config_file_no_cert}; sync"
+        )
         ssh_host.runcmd(cmd)
-        function_hypervisor.update('kubeconfig', config_file_no_cert)
+        function_hypervisor.update("kubeconfig", config_file_no_cert)
 
         # configure kubeconfig without cert and run virt-who
         for value in ("none", "", "0", "False"):
@@ -409,19 +411,21 @@ class TestKubevirtNegative:
                 function_hypervisor.update("insecure", value)
             result = virtwho.run_service()
             error_msg = "certificate verify failed"
-            assert (result['error'] == 1
-                    and result['send'] == 0
-                    and result['thread'] == 1
-                    and error_msg in result['log'])
+            assert (
+                result["error"] == 1
+                and result["send"] == 0
+                and result["thread"] == 1
+                and error_msg in result["log"]
+            )
             function_hypervisor.delete("insecure")
 
         # test insecure=1/True can ignore checking cert"
         for value in ("1", "True"):
             function_hypervisor.update("insecure", value)
             result = virtwho.run_service()
-            assert (result['error'] == 0
-                    and result['send'] == 1
-                    and result['thread'] == 1)
+            assert (
+                result["error"] == 0 and result["send"] == 1 and result["thread"] == 1
+            )
             function_hypervisor.delete("insecure")
 
         ssh_host.runcmd(f"rm -rf {config_file_no_cert}")


### PR DESCRIPTION
**Description**
Add test case: test_insecure for kubevirt test file

**Test Result**
```
[hkx303@kuhuang virtwho-test]$ pytest tests/hypervisor/test_kubevirt.py -k test_insecure -s
==================================== test session starts =====================================
platform linux -- Python 3.7.3, pytest-5.4.3, py-1.8.0, pluggy-0.13.1
rootdir: /home/hkx303/Documents/CI/virtwho-test, inifile: pytest.ini
plugins: services-1.3.1, mock-1.10.4, forked-1.0.2, ibutsu-1.0.34, cov-2.7.1, xdist-1.34.0
collected 8 items / 7 deselected / 1 selected  

======================== 1 passed, 7 deselected in 246.10s (0:04:06) =========================
```