### PR TITLE
fix the package_url issue

### DIFF
--- a/tests/function/test_service.py
+++ b/tests/function/test_service.py
@@ -129,17 +129,17 @@ class TestVirtwhoService:
         port = config.virtwho.port
         ssh_access_no_password(ssh_guest, ssh_host, server, port)
         # stop
-        ssh_guest.runcmd(f"ssh {server} -p {port} " f'"systemctl stop virt-who"')
+        ssh_guest.runcmd(f"ssh {server} -p {port} 'systemctl stop virt-who'")
         _, status = virtwho.operate_service(action="status")
         assert status == "dead"
 
         # start
-        ssh_guest.runcmd(f"ssh {server} -p {port} " f'"systemctl restart virt-who"')
+        ssh_guest.runcmd(f"ssh {server} -p {port} 'systemctl restart virt-who'")
         _, status = virtwho.operate_service(action="status")
         assert status == "running"
 
         # stop
-        ssh_guest.runcmd(f"ssh {server} -p {port} " f'"systemctl stop virt-who"')
+        ssh_guest.runcmd(f"ssh {server} -p {port} 'systemctl stop virt-who'")
         _, status = virtwho.operate_service(action="status")
         assert status == "dead"
 

--- a/tests/function/test_service.py
+++ b/tests/function/test_service.py
@@ -134,9 +134,7 @@ class TestVirtwhoService:
         assert status == "dead"
 
         # start
-        ssh_guest.runcmd(
-            f"ssh {server} -p {port} " f'"systemctl restart virt-who"'
-        )
+        ssh_guest.runcmd(f"ssh {server} -p {port} " f'"systemctl restart virt-who"')
         _, status = virtwho.operate_service(action="status")
         assert status == "running"
 

--- a/tests/package/test_install_uninstall.py
+++ b/tests/package/test_install_uninstall.py
@@ -8,7 +8,7 @@ import re
 
 import pytest
 from virtwho import VIRTWHO_PKG, RHEL_COMPOSE, RHEL_COMPOSE_PATH
-from virtwho.base import rhel_compose_url
+from virtwho.base import virtwho_package_url
 from virtwho.base import package_check, package_install, package_uninstall
 from virtwho.base import wget_download, random_string
 
@@ -86,10 +86,9 @@ class TestInstallUninstall:
             package_uninstall(ssh_host, "virt-who", rpm=VIRTWHO_PKG)
             assert package_check(ssh_host, "virt-who") is False
 
-            _, compose_url_extra = rhel_compose_url(
-                RHEL_COMPOSE, RHEL_COMPOSE_PATH
+            pkg_url = virtwho_package_url(
+                VIRTWHO_PKG, RHEL_COMPOSE, RHEL_COMPOSE_PATH
             )
-            pkg_url = compose_url_extra + "/Packages/" + VIRTWHO_PKG + ".rpm"
             file_path = "/tmp/packageInstallUninstall-" + random_string()
             wget_download(ssh_host, url=pkg_url, file_path=file_path)
             package_install(ssh_host, "virt-who",

--- a/tests/package/test_install_uninstall.py
+++ b/tests/package/test_install_uninstall.py
@@ -7,7 +7,8 @@
 import re
 
 import pytest
-from virtwho import VIRTWHO_PKG, RHEL_COMPOSE
+from virtwho import VIRTWHO_PKG, RHEL_COMPOSE, RHEL_COMPOSE_PATH
+from virtwho.base import rhel_compose_url
 from virtwho.base import package_check, package_install, package_uninstall
 from virtwho.base import wget_download, random_string
 
@@ -82,15 +83,18 @@ class TestInstallUninstall:
             1. virt-who can be remove and reinstall successfully.
         """
         try:
-            package_uninstall(ssh_host, 'virt-who', rpm=VIRTWHO_PKG)
-            assert package_check(ssh_host, 'virt-who') is False
+            package_uninstall(ssh_host, "virt-who", rpm=VIRTWHO_PKG)
+            assert package_check(ssh_host, "virt-who") is False
 
-            pkg_url = virtwho_pacakge_url(VIRTWHO_PKG)
-            file_path = '/root/' + random_string()
+            _, compose_url_extra = rhel_compose_url(
+                RHEL_COMPOSE, RHEL_COMPOSE_PATH
+            )
+            pkg_url = compose_url_extra + "/Packages/" + VIRTWHO_PKG + ".rpm"
+            file_path = "/tmp/packageInstallUninstall-" + random_string()
             wget_download(ssh_host, url=pkg_url, file_path=file_path)
-            package_install(ssh_host, 'virt-who',
-                            rpm=f'{file_path}/{VIRTWHO_PKG}.rpm')
-            assert package_check(ssh_host, 'virt-who') == VIRTWHO_PKG
+            package_install(ssh_host, "virt-who",
+                            rpm=f"{file_path}/{VIRTWHO_PKG}.rpm")
+            assert package_check(ssh_host, "virt-who") == VIRTWHO_PKG
         finally:
-            if package_check(ssh_host, 'virt-who') is False:
-                package_install(ssh_host, 'virt-who')
+            if package_check(ssh_host, "virt-who") is False:
+                package_install(ssh_host, "virt-who")

--- a/tests/package/test_install_uninstall.py
+++ b/tests/package/test_install_uninstall.py
@@ -91,9 +91,7 @@ class TestInstallUninstall:
             )
             file_path = "/tmp/packageInstallUninstall-" + random_string()
             wget_download(ssh_host, url=pkg_url, file_path=file_path)
-            package_install(
-                ssh_host, "virt-who", rpm=f"{file_path}/{VIRTWHO_PKG}.rpm"
-            )
+            package_install(ssh_host, "virt-who", rpm=f"{file_path}/{VIRTWHO_PKG}.rpm")
             assert package_check(ssh_host, "virt-who") == VIRTWHO_PKG
         finally:
             if package_check(ssh_host, "virt-who") is False:

--- a/tests/package/test_install_uninstall.py
+++ b/tests/package/test_install_uninstall.py
@@ -91,8 +91,9 @@ class TestInstallUninstall:
             )
             file_path = "/tmp/packageInstallUninstall-" + random_string()
             wget_download(ssh_host, url=pkg_url, file_path=file_path)
-            package_install(ssh_host, "virt-who",
-                            rpm=f"{file_path}/{VIRTWHO_PKG}.rpm")
+            package_install(
+                ssh_host, "virt-who", rpm=f"{file_path}/{VIRTWHO_PKG}.rpm"
+            )
             assert package_check(ssh_host, "virt-who") == VIRTWHO_PKG
         finally:
             if package_check(ssh_host, "virt-who") is False:

--- a/tests/package/test_upgrade_downgrade.py
+++ b/tests/package/test_upgrade_downgrade.py
@@ -132,9 +132,7 @@ class TestUpgradeDowngrade:
             )
             wget_download(ssh_host, old_pkg_url, file_path)
             # downgrade virt-who to check the configurations not change.
-            package_downgrade(
-                ssh_host, "virt-who", rpm=f"{file_path}/{old_pkg}.rpm"
-            )
+            package_downgrade(ssh_host, "virt-who", rpm=f"{file_path}/{old_pkg}.rpm")
             result = virtwho.run_service()
             assert (
                     package_check(ssh_host, "virt-who") == old_pkg and

--- a/tests/package/test_upgrade_downgrade.py
+++ b/tests/package/test_upgrade_downgrade.py
@@ -11,15 +11,15 @@ from virtwho.base import package_check, package_upgrade, package_downgrade
 from virtwho.base import wget_download, rhel_compose_repo, random_string
 from virtwho.base import system_reboot
 
-old_pkg = 'virt-who-1.31.22-1.el9_0.noarch'
-old_compose = 'latest-RHEL-9.0'
-old_compose_path = 'http://download.eng.pek2.redhat.com/' \
-                   'rhel-9/rel-eng/RHEL-9'
-if 'RHEL-8' in RHEL_COMPOSE:
-    old_pkg = 'virt-who-1.30.8-1.el8.noarch'
-    old_compose = 'latest-RHEL-8.5'
-    old_compose_path = 'http://download.eng.pek2.redhat.com/' \
-                       'rhel-8/rel-eng/RHEL-8'
+old_pkg = "virt-who-1.31.22-1.el9_0.noarch"
+old_compose = "latest-RHEL-9.0"
+old_compose_path = "http://download.eng.pek2.redhat.com/" \
+                   "rhel-9/rel-eng/RHEL-9"
+if "RHEL-8" in RHEL_COMPOSE:
+    old_pkg = "virt-who-1.30.8-1.el8.noarch"
+    old_compose = "latest-RHEL-8.5"
+    old_compose_path = "http://download.eng.pek2.redhat.com/" \
+                       "rhel-8/rel-eng/RHEL-8"
 
 
 @pytest.mark.usefixtures('function_globalconf_clean')
@@ -132,18 +132,20 @@ class TestUpgradeDowngrade:
             )
             wget_download(ssh_host, old_pkg_url, file_path)
             # downgrade virt-who to check the configurations not change.
-            package_downgrade(ssh_host, 'virt-who',
-                              rpm=f'{file_path}/{old_pkg}.rpm')
+            package_downgrade(
+                ssh_host, "virt-who", rpm=f"{file_path}/{old_pkg}.rpm"
+            )
             result = virtwho.run_service()
             assert (
-                    package_check(ssh_host, 'virt-who') == old_pkg and
-                    result['send'] == 1 and
-                    result['error'] == 0 and
-                    result['debug'] is True
+                    package_check(ssh_host, "virt-who") == old_pkg and
+                    result["send"] == 1 and
+                    result["error"] == 0 and
+                    result["debug"] is True
             )
             # upgrade virt-who to check the configurations not change.
-            package_upgrade(ssh_host, 'virt-who',
-                            rpm=f'{file_path}/{VIRTWHO_PKG}.rpm')
+            package_upgrade(
+                ssh_host, 'virt-who', rpm=f'{file_path}/{VIRTWHO_PKG}.rpm'
+            )
             result = virtwho.run_service()
             assert (
                     package_check(ssh_host, 'virt-who') == VIRTWHO_PKG and

--- a/tests/package/test_upgrade_downgrade.py
+++ b/tests/package/test_upgrade_downgrade.py
@@ -129,10 +129,10 @@ class TestUpgradeDowngrade:
             package_downgrade(ssh_host, "virt-who", rpm=f"{file_path}/{old_pkg}.rpm")
             result = virtwho.run_service()
             assert (
-                    package_check(ssh_host, "virt-who") == old_pkg and
-                    result["send"] == 1 and
-                    result["error"] == 0 and
-                    result["debug"] is True
+                package_check(ssh_host, "virt-who") == old_pkg
+                and result["send"] == 1
+                and result["error"] == 0
+                and result["debug"] is True
             )
             # upgrade virt-who to check the configurations not change.
             package_upgrade(ssh_host, "virt-who", rpm=f"{file_path}/{VIRTWHO_PKG}.rpm")

--- a/utils/beaker.py
+++ b/utils/beaker.py
@@ -13,6 +13,7 @@ curPath = os.path.abspath(os.path.dirname(__file__))
 rootPath = os.path.split(curPath)[0]
 sys.path.append(rootPath)
 
+
 def install_rhel_by_beaker(args):
     """
     Install rhel os by submitting job to beaker with required arguments.

--- a/utils/docker.py
+++ b/utils/docker.py
@@ -12,6 +12,7 @@ curPath = os.path.abspath(os.path.dirname(__file__))
 rootPath = os.path.split(curPath)[0]
 sys.path.append(rootPath)
 
+
 def create_rhel_container_by_docker(args):
     """
     Create rhel docker container

--- a/utils/kickstart.py
+++ b/utils/kickstart.py
@@ -14,6 +14,7 @@ curPath = os.path.abspath(os.path.dirname(__file__))
 rootPath = os.path.split(curPath)[0]
 sys.path.append(rootPath)
 
+
 def install_rhel_by_grup(args):
     """
     Install a rhel system beased on an available host by change the grub files.

--- a/utils/parse_ci_message.py
+++ b/utils/parse_ci_message.py
@@ -12,6 +12,7 @@ curPath = os.path.abspath(os.path.dirname(__file__))
 rootPath = os.path.split(curPath)[0]
 sys.path.append(rootPath)
 
+
 def umb_ci_message_parser(args):
     """
     Parse the umb ci message to a dic

--- a/utils/polarion_testcase_upload.py
+++ b/utils/polarion_testcase_upload.py
@@ -12,6 +12,7 @@ curPath = os.path.abspath(os.path.dirname(__file__))
 rootPath = os.path.split(curPath)[0]
 sys.path.append(rootPath)
 
+
 def polarion_test_case_upload(args):
     """
     Upload the test cases to Polarion.
@@ -89,7 +90,7 @@ def log_analyzer(job_id):
         ret, output = subprocess.getstatusoutput(f"cat {args.log_file}")
         output = output.replace("&#034;", '"').replace("&#039;", "'")
         log = json.loads(
-            output[output.rfind("Message Content:") + 17:output.rfind("}") + 1],
+            output[output.rfind("Message Content:") + 17 : output.rfind("}") + 1],
             strict=False,
         )
         case_pass_num = 0

--- a/utils/properties_update.py
+++ b/utils/properties_update.py
@@ -10,6 +10,7 @@ curPath = os.path.abspath(os.path.dirname(__file__))
 rootPath = os.path.split(curPath)[0]
 sys.path.append(rootPath)
 
+
 def virtwho_ini_props_update(args):
     """
     Update the property of virtwho.ini for testing/using

--- a/utils/satellite.py
+++ b/utils/satellite.py
@@ -13,6 +13,7 @@ curPath = os.path.abspath(os.path.dirname(__file__))
 rootPath = os.path.split(curPath)[0]
 sys.path.append(rootPath)
 
+
 def satellite_deploy(args):
     """
     Deploy satellite server by cdn or dogfood with required arguments.

--- a/virtwho/base.py
+++ b/virtwho/base.py
@@ -327,6 +327,7 @@ def local_files_compare(file1, file2):
     fp2.close()
     return operator.eq(flist1, flist2)
 
+
 def package_info_analyzer(ssh, pkg):
     """
     Analyze the package information after '#rpm -qi {pkg}'.
@@ -571,9 +572,7 @@ def ssh_access_no_password(ssh_local, ssh_remote, remote_host, remote_port=22):
         raise FailException("Failed to create ssh key ")
 
     # copy id_rsa.pup to remote host
-    ssh_remote.runcmd(
-        f"mkdir ~/.ssh/;" f"echo '{output}' >> ~/.ssh/authorized_keys"
-    )
+    ssh_remote.runcmd(f"mkdir ~/.ssh/;" f"echo '{output}' >> ~/.ssh/authorized_keys")
 
     # creat ~/.ssh/known_hosts for local host
     ssh_local.runcmd(

--- a/virtwho/base.py
+++ b/virtwho/base.py
@@ -634,6 +634,10 @@ def virtwho_package_url(pkg, rhel_compose_id, rhel_compose_path=''):
     """
     Get the virt-who package url from http://download.eng.pek2.redhat.com/
     for downloading.
+    :param pkg: virt-who package, such as virt-who-1.31.26-1.el9.noarch
+    :param rhel_compose_id: rhel compose id
+    :param rhel_compose_path: the path of rhel compose id
+    :return: virt-who pkg url
     """
     _, compose_url_extra = rhel_compose_url(
         rhel_compose_id, rhel_compose_path

--- a/virtwho/base.py
+++ b/virtwho/base.py
@@ -628,3 +628,15 @@ def system_reboot(ssh):
     if ssh_connect(ssh):
         return True
     raise FailException('Failed to reboot system')
+
+
+def virtwho_package_url(pkg, rhel_compose_id, rhel_compose_path=''):
+    """
+    Get the virt-who package url from http://download.eng.pek2.redhat.com/
+    for downloading.
+    """
+    _, compose_url_extra = rhel_compose_url(
+        rhel_compose_id, rhel_compose_path
+    )
+    pkg_url = compose_url_extra + "/Packages/" + pkg + ".rpm"
+    return pkg_url

--- a/virtwho/base.py
+++ b/virtwho/base.py
@@ -627,10 +627,10 @@ def system_reboot(ssh):
     time.sleep(120)
     if ssh_connect(ssh):
         return True
-    raise FailException('Failed to reboot system')
+    raise FailException("Failed to reboot system")
 
 
-def virtwho_package_url(pkg, rhel_compose_id, rhel_compose_path=''):
+def virtwho_package_url(pkg, rhel_compose_id, rhel_compose_path=""):
     """
     Get the virt-who package url from http://download.eng.pek2.redhat.com/
     for downloading.
@@ -639,8 +639,6 @@ def virtwho_package_url(pkg, rhel_compose_id, rhel_compose_path=''):
     :param rhel_compose_path: the path of rhel compose id
     :return: virt-who pkg url
     """
-    _, compose_url_extra = rhel_compose_url(
-        rhel_compose_id, rhel_compose_path
-    )
+    _, compose_url_extra = rhel_compose_url(rhel_compose_id, rhel_compose_path)
     pkg_url = compose_url_extra + "/Packages/" + pkg + ".rpm"
     return pkg_url

--- a/virtwho/base.py
+++ b/virtwho/base.py
@@ -572,7 +572,7 @@ def ssh_access_no_password(ssh_local, ssh_remote, remote_host, remote_port=22):
         raise FailException("Failed to create ssh key ")
 
     # copy id_rsa.pup to remote host
-    ssh_remote.runcmd(f"mkdir ~/.ssh/;" f"echo '{output}' >> ~/.ssh/authorized_keys")
+    ssh_remote.runcmd(f"mkdir ~/.ssh/;echo '{output}' >> ~/.ssh/authorized_keys")
 
     # creat ~/.ssh/known_hosts for local host
     ssh_local.runcmd(

--- a/virtwho/provision/virtwho_host.py
+++ b/virtwho/provision/virtwho_host.py
@@ -16,6 +16,7 @@ curPath = os.path.abspath(os.path.dirname(__file__))
 rootPath = os.path.split(curPath)[0]
 sys.path.append(os.path.split(rootPath)[0])
 
+
 def provision_virtwho_host(args):
     """
     Configure virt-who host for an existing server or a new one installed
@@ -202,9 +203,7 @@ def libvirt_access_no_password(ssh):
     ret, output = ssh.runcmd("cat ~/.ssh/id_rsa.pub")
     if ret != 0 or output is None:
         raise FailException("Failed to create ssh key")
-    ssh_libvirt.runcmd(
-        f"mkdir ~/.ssh/;echo '{output}' >> ~/.ssh/authorized_keys"
-    )
+    ssh_libvirt.runcmd(f"mkdir ~/.ssh/;echo '{output}' >> ~/.ssh/authorized_keys")
     ret, _ = ssh.runcmd(
         f"ssh-keyscan -p 22 {config.libvirt.server} >> ~/.ssh/known_hosts"
     )

--- a/virtwho/provision/virtwho_hypervisor.py
+++ b/virtwho/provision/virtwho_hypervisor.py
@@ -276,7 +276,7 @@ def kubevirt_monitor():
                     f">>>Kubevirt: Check if the guest{guest_name} " f"is running."
                 )
                 if not kubevirt_info["guest_ip"]:
-                    kubevirt_state, _= (state_guest_bad, guest_none)
+                    kubevirt_state, _ = (state_guest_bad, guest_none)
                     logger.error(
                         f"Did not find the rhel guest({guest_name}), "
                         f"please install one."

--- a/virtwho/provision/virtwho_satellite.py
+++ b/virtwho/provision/virtwho_satellite.py
@@ -16,6 +16,7 @@ curPath = os.path.abspath(os.path.dirname(__file__))
 rootPath = os.path.split(curPath)[0]
 sys.path.append(os.path.split(rootPath)[0])
 
+
 def satellite_deploy_for_virtwho(args):
     """
     Deploy satellite by cdn or dogfood with required arguments.
@@ -126,9 +127,7 @@ def satellite_settings(ssh, name, value):
     :param value: the value.
     :return: True or raise Fail.
     """
-    ret, output = ssh.runcmd(
-        f"hammer settings set --name={name} --value={value}"
-    )
+    ret, output = ssh.runcmd(f"hammer settings set --name={name} --value={value}")
     if ret == 0 and f"Setting [{name}] updated to" in output:
         return True
     raise FailException(f"Failed to set {name}:{value} for satellite")
@@ -151,9 +150,7 @@ def satellite_manifest_upload(ssh, org, url, admin_username, admin_password):
         filename = f"{path}/{output.strip()}"
     else:
         raise FailException("No manifest file found")
-    ssh.runcmd(
-        f"hammer subscription delete-manifest --organization-label {org}"
-    )
+    ssh.runcmd(f"hammer subscription delete-manifest --organization-label {org}")
     ret, _ = ssh.runcmd(
         f"hammer subscription upload "
         f"--organization-label {org} "

--- a/virtwho/register.py
+++ b/virtwho/register.py
@@ -827,13 +827,9 @@ class Satellite:
             cmd += f" --quantity {quantity}"
         ret, output = self.ssh.runcmd(cmd)
         if "Subscription added to activation key" in output:
-            logger.info(
-                f"Succeeded to attach subscription for activation key:{key}"
-            )
+            logger.info(f"Succeeded to attach subscription for activation key:{key}")
             return True
-        raise FailException(
-            f"Failed to attach subscription for activation key:{key}"
-        )
+        raise FailException(f"Failed to attach subscription for activation key:{key}")
 
     def activation_key_unattach(self, pool, key=None):
         """


### PR DESCRIPTION
- Define a new function in base named `virtwho_package_url`
- Update case package/test_install_uninstall.py/test_install_uninstall_by_rpm to use the the new function
- Update case package/test_upgrade_downgrade.py/test_install_uninstall_by_rpm to use the the new function 

```
% pytest --disable-warnings -v tests/package/ -k 'by_rpm'
========================================================= test session starts =========================================================
platform darwin -- Python 3.11.2, pytest-7.2.2, pluggy-1.0.0 -- /opt/homebrew/opt/python@3.11/bin/python3.11
cachedir: .pytest_cache
rootdir: /Users/yuefliu/workspace/virtwho-test, configfile: pytest.ini
collected 11 items / 9 deselected / 2 selected                                                                                        

tests/package/test_install_uninstall.py::TestInstallUninstall::test_install_uninstall_by_rpm PASSED                             [ 50%]
tests/package/test_upgrade_downgrade.py::TestUpgradeDowngrade::test_upgrade_downgrade_by_rpm PASSED                             [100%]

======================================= 2 passed, 9 deselected, 2 warnings in 97.42s (0:01:37) ========================================
```