### PR TITLE
Add test case: test_virtwho_status

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -262,7 +262,9 @@ def hypervisor_data(ssh_guest):
         data["cpu"] = hypervisor_handler.cpu
     if HYPERVISOR == "ahv":
         data["cluster"] = hypervisor_handler.cluster
-    if HYPERVISOR != "kubevirt":
+    if HYPERVISOR == "kubevirt":
+        data["hypervisor_server"] = hypervisor_handler.endpoint
+    else:
         data["hypervisor_password"] = hypervisor_handler.password
         data["hypervisor_server"] = hypervisor_handler.server
         data["hypervisor_username"] = hypervisor_handler.username

--- a/tests/hypervisor/test_default.py
+++ b/tests/hypervisor/test_default.py
@@ -209,7 +209,9 @@ class TestHypervisorPositive:
     @pytest.mark.tier1
     @pytest.mark.notRHEL8
     @pytest.mark.notLocal
-    def test_virtwho_status(self, virtwho, function_hypervisor, hypervisor_data, register_data):
+    def test_virtwho_status(
+        self, virtwho, function_hypervisor, hypervisor_data, register_data
+    ):
         """
         :title: virt-who: hypervisor: test the virtwho status
         :id: 1608c965-c7f5-427b-b45e-c767600cdbf4
@@ -226,17 +228,13 @@ class TestHypervisorPositive:
         """
         # Run virt-who to report the mapping
         result = virtwho.run_cli()
-        assert (
-            result["error"] == 0
-            and result["send"] == 1
-            and result["thread"] == 0
-        )
+        assert result["error"] == 0 and result["send"] == 1 and result["thread"] == 0
 
         # Check '#virt-who --status' with good configuration
         result = virtwho.run_cli(oneshot=False, status=True)
         assert (
-                "success" in result[function_hypervisor.section]["source_status"]
-                and "success" in result[function_hypervisor.section]["destination_status"]
+            "success" in result[function_hypervisor.section]["source_status"]
+            and "success" in result[function_hypervisor.section]["destination_status"]
         )
 
         # Check #virt-who --status --json
@@ -246,9 +244,11 @@ class TestHypervisorPositive:
         elif "esx" in HYPERVISOR:
             source_connection = f"https://{hypervisor_data['hypervisor_server']}"
         elif "rhevm" in HYPERVISOR:
-            source_connection = hypervisor_data['hypervisor_server'].split("ovirt-engine")[0].strip()
+            source_connection = (
+                hypervisor_data["hypervisor_server"].split("ovirt-engine")[0].strip()
+            )
         else:
-            source_connection = hypervisor_data['hypervisor_server']
+            source_connection = hypervisor_data["hypervisor_server"]
         source = result[function_hypervisor.section]["source"]
         destination = result[function_hypervisor.section]["destination"]
         assert (
@@ -274,7 +274,8 @@ class TestHypervisorPositive:
         result = virtwho.run_cli(oneshot=False, status=True, jsn=True)
         assert (
             result[function_hypervisor.section]["source"]["status"] == "failure"
-            and result[function_hypervisor.section]["destination"]["status"] == "failure"
+            and result[function_hypervisor.section]["destination"]["status"]
+            == "failure"
         )
 
     @pytest.mark.tier2

--- a/tests/hypervisor/test_default.py
+++ b/tests/hypervisor/test_default.py
@@ -206,6 +206,77 @@ class TestHypervisorPositive:
         virt_is_guest = output.split(":")[1].strip()
         assert virt_is_guest == "True"
 
+    @pytest.mark.tier1
+    @pytest.mark.notRHEL8
+    @pytest.mark.notLocal
+    def test_virtwho_status(self, virtwho, function_hypervisor, hypervisor_data, register_data):
+        """
+        :title: virt-who: hypervisor: test the virtwho status
+        :id: 1608c965-c7f5-427b-b45e-c767600cdbf4
+            1. Run the virt-who service by cli -do to report the mapping
+            2. Run the virt-who service by cli -s with good configuration
+            3. Run the virt-who service by cli -s -j with good configuration
+            4. Run the virt-who service by cli -s -j with bad configuration
+
+        :expectedresults:
+            1. Succeed to send the mapping
+            2. Succeed to find the success status
+            3. Succeed to print the json status info
+            4. Succeed to find the failure status
+        """
+        # Run virt-who to report the mapping
+        result = virtwho.run_cli()
+        assert (
+            result["error"] == 0
+            and result["send"] == 1
+            and result["thread"] == 0
+        )
+
+        # Check '#virt-who --status' with good configuration
+        result = virtwho.run_cli(oneshot=False, status=True)
+        assert (
+                "success" in result[function_hypervisor.section]["source_status"]
+                and "success" in result[function_hypervisor.section]["destination_status"]
+        )
+
+        # Check #virt-who --status --json
+        result = virtwho.run_cli(oneshot=False, status=True, jsn=True)
+        if "libvirt" in HYPERVISOR:
+            source_connection = f"qemu+ssh://root@{hypervisor_data['hypervisor_server']}/system?no_tty=1"
+        elif "esx" in HYPERVISOR:
+            source_connection = f"https://{hypervisor_data['hypervisor_server']}"
+        elif "rhevm" in HYPERVISOR:
+            source_connection = hypervisor_data['hypervisor_server'].split("ovirt-engine")[0].strip()
+        else:
+            source_connection = hypervisor_data['hypervisor_server']
+        source = result[function_hypervisor.section]["source"]
+        destination = result[function_hypervisor.section]["destination"]
+        assert (
+            source["connection"] == source_connection
+            and source["status"] == "success"
+            and source["last_successful_retrieve"].split(" ")[2] == "UTC"
+            and source["hypervisors"] >= 1
+            and source["guests"] >= 1
+            and destination["connection"] == register_data["server"]
+            and destination["status"] == "success"
+            and destination["last_successful_send"].split(" ")[2] == "UTC"
+            and destination["last_successful_send_job_status"] == "FINISHED"
+        )
+
+        # Check '#virt-who --status --json' with bad configuration
+        option = "password"
+        if "kubevirt" in HYPERVISOR:
+            option = "kubeconfig"
+        if "libvirt" in HYPERVISOR:
+            option = "server"
+        function_hypervisor.update(option, "xxx")
+        function_hypervisor.update("owner", "xxx")
+        result = virtwho.run_cli(oneshot=False, status=True, jsn=True)
+        assert (
+            result[function_hypervisor.section]["source"]["status"] == "failure"
+            and result[function_hypervisor.section]["destination"]["status"] == "failure"
+        )
+
     @pytest.mark.tier2
     def test_delete_host_hypervisor(
         self,


### PR DESCRIPTION
**Description**
Add test case: test_virtwho_status from https://github.com/VirtwhoQE/virtwho-ci/blob/master/tests/tier1/tc_1113_check_virtwho_status.py

**Test Result**
```
[hkx303@kuhuang virtwho-test]$ pytest tests/hypervisor/test_default.py -k test_virtwho_status -s
==================================== test session starts =====================================
platform linux -- Python 3.7.3, pytest-5.4.3, py-1.8.0, pluggy-0.13.1
rootdir: /home/hkx303/Documents/CI/virtwho-test, inifile: pytest.ini
plugins: services-1.3.1, mock-1.10.4, forked-1.0.2, ibutsu-1.0.34, cov-2.7.1, xdist-1.34.0
collected 6 items / 5 deselected / 1 selected    

========================= 1 passed, 5 deselected in 68.73s (0:01:08) =========================
```
