### PR TITLE
Fix msg bugs in send_number function caused by linter intergration PR

### DIFF
--- a/virtwho/runner.py
+++ b/virtwho/runner.py
@@ -322,9 +322,9 @@ class VirtwhoRunner:
         elif "virtwho.main DEBUG" in rhsm_log or "rhsm.connection DEBUG" in rhsm_log:
             if "satellite" in self.register_type:
                 if self.mode == "local":
-                    msg = r'Response: status=200, request="PUT /rhsm/consumers"'
+                    msg = r'Response: status=200, request="PUT /rhsm/consumers'
                 else:
-                    msg = r'Response: status=200, request="POST /rhsm/hypervisors"'
+                    msg = r'Response: status=200, request="POST /rhsm/hypervisors'
             if "rhsm" in self.register_type:
                 if self.mode == "local":
                     msg = (


### PR DESCRIPTION
Kunxin have mentioned the msg inaccurate revise in Linter set up PR, which can see the comments here:
https://github.com/VirtwhoQE/virtwho-test/pull/141

I have been fixed this two msg error in this PR.