### PR TITLE
Maintain the virtwho_hypervisor.py for ahv and kubevirt around guest_sw

### DIFF
--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,0 +1,3 @@
+import os
+
+CURRENT_PATH = os.path.abspath(os.path.dirname(__file__))

--- a/utils/beaker.py
+++ b/utils/beaker.py
@@ -1,17 +1,12 @@
-#!/usr/bin/python
-import os
 import re
-import sys
 import time
 import argparse
+import sys
+sys.path.append(".")
 
 from virtwho import logger, FailException
 from virtwho.settings import config
 from virtwho.ssh import SSHConnect
-
-curPath = os.path.abspath(os.path.dirname(__file__))
-rootPath = os.path.split(curPath)[0]
-sys.path.append(rootPath)
 
 
 def install_rhel_by_beaker(args):

--- a/utils/docker.py
+++ b/utils/docker.py
@@ -1,16 +1,12 @@
-#!/usr/bin/python
 import os
 import random
 import argparse
 import sys
+sys.path.append(".")
 
 from virtwho import logger, FailException
 from virtwho.base import rhel_compose_repo
 from virtwho.ssh import SSHConnect
-
-curPath = os.path.abspath(os.path.dirname(__file__))
-rootPath = os.path.split(curPath)[0]
-sys.path.append(rootPath)
 
 
 def create_rhel_container_by_docker(args):

--- a/utils/docker.py
+++ b/utils/docker.py
@@ -7,6 +7,7 @@ sys.path.append(".")
 from virtwho import logger, FailException
 from virtwho.base import rhel_compose_repo
 from virtwho.ssh import SSHConnect
+from utils import CURRENT_PATH
 
 
 def create_rhel_container_by_docker(args):
@@ -34,7 +35,7 @@ def create_rhel_container_by_docker(args):
     ssh_docker.runcmd(
         "rm -rf /tmp/docker/;" "rm -rf /tmp/mkimage*;" "rm -f /etc/yum.repos.d/*.repo"
     )
-    local_dir = os.path.join(curPath, "docker/")
+    local_dir = os.path.join(CURRENT_PATH, "docker/")
     remote_dir = "/tmp/docker/"
     ssh_docker.put_dir(local_dir, remote_dir)
 

--- a/utils/ini2json.py
+++ b/utils/ini2json.py
@@ -1,13 +1,9 @@
-#!/usr/bin/python
 import json
-import os
-import sys
 import argparse
-from configparser import ConfigParser
+import sys
+sys.path.append(".")
 
-curPath = os.path.abspath(os.path.dirname(__file__))
-rootPath = os.path.split(curPath)[0]
-sys.path.append(rootPath)
+from configparser import ConfigParser
 
 
 def ini2json(args):

--- a/utils/kickstart.py
+++ b/utils/kickstart.py
@@ -1,18 +1,13 @@
-#!/usr/bin/python
-import os
 import random
 import argparse
 import string
-import sys
 import time
+import sys
+sys.path.append(".")
 
 from virtwho import base, logger, FailException
 from virtwho.settings import config
 from virtwho.ssh import SSHConnect
-
-curPath = os.path.abspath(os.path.dirname(__file__))
-rootPath = os.path.split(curPath)[0]
-sys.path.append(rootPath)
 
 
 def install_rhel_by_grup(args):

--- a/utils/parse_ci_message.py
+++ b/utils/parse_ci_message.py
@@ -1,16 +1,12 @@
-#!/usr/bin/python
 import json
 import os
 import re
-import sys
 import argparse
+import sys
+sys.path.append(".")
 
 from virtwho import logger, FailException
 from virtwho.settings import config
-
-curPath = os.path.abspath(os.path.dirname(__file__))
-rootPath = os.path.split(curPath)[0]
-sys.path.append(rootPath)
 
 
 def umb_ci_message_parser(args):

--- a/utils/parse_test_result.py
+++ b/utils/parse_test_result.py
@@ -1,14 +1,9 @@
-#!/usr/bin/python
-import os
-import sys
 import argparse
+import sys
+sys.path.append(".")
 
 from xml.dom import minidom
 from properties_update import virtwho_ini_props_update
-
-curPath = os.path.abspath(os.path.dirname(__file__))
-rootPath = os.path.split(curPath)[0]
-sys.path.append(rootPath)
 
 
 def test_result_parser(args):

--- a/utils/polarion_testcase_upload.py
+++ b/utils/polarion_testcase_upload.py
@@ -1,16 +1,11 @@
-#!/usr/bin/python
 import json
-import os
 import subprocess
-import sys
 import argparse
 import time
+import sys
+sys.path.append(".")
 
 from virtwho import logger, FailException
-
-curPath = os.path.abspath(os.path.dirname(__file__))
-rootPath = os.path.split(curPath)[0]
-sys.path.append(rootPath)
 
 
 def polarion_test_case_upload(args):

--- a/utils/properties_update.py
+++ b/utils/properties_update.py
@@ -1,14 +1,9 @@
-#!/usr/bin/python
-
 import os
-import sys
 import argparse
+import sys
+sys.path.append(".")
 
 from virtwho.settings import Configure, TEST_DATA
-
-curPath = os.path.abspath(os.path.dirname(__file__))
-rootPath = os.path.split(curPath)[0]
-sys.path.append(rootPath)
 
 
 def virtwho_ini_props_update(args):
@@ -43,8 +38,9 @@ def virtwho_ini_update(section, option, value):
     Update the property of virtwho.ini for testing/using
     Used to called by other functions
     """
+    cur_path = os.path.abspath(os.path.dirname(__file__))
     os.system(
-        f"python3 {curPath}/properties_update.py "
+        f"python3 {cur_path}/properties_update.py "
         f"--section={section} "
         f"--option={option} "
         f'--value="{value}"'

--- a/utils/properties_update.py
+++ b/utils/properties_update.py
@@ -3,6 +3,7 @@ import argparse
 import sys
 sys.path.append(".")
 
+from utils import CURRENT_PATH
 from virtwho.settings import Configure, TEST_DATA
 
 
@@ -38,9 +39,8 @@ def virtwho_ini_update(section, option, value):
     Update the property of virtwho.ini for testing/using
     Used to called by other functions
     """
-    cur_path = os.path.abspath(os.path.dirname(__file__))
     os.system(
-        f"python3 {cur_path}/properties_update.py "
+        f"python3 {CURRENT_PATH}/properties_update.py "
         f"--section={section} "
         f"--option={option} "
         f'--value="{value}"'

--- a/utils/satellite.py
+++ b/utils/satellite.py
@@ -1,17 +1,12 @@
-#!/usr/bin/python
 import argparse
-import os
 import sys
+sys.path.append(".")
 
 from virtwho import FailException
 from virtwho.base import system_init
 from virtwho.ssh import SSHConnect
 from virtwho.register import SubscriptionManager
 from virtwho.settings import config
-
-curPath = os.path.abspath(os.path.dirname(__file__))
-rootPath = os.path.split(curPath)[0]
-sys.path.append(rootPath)
 
 
 def satellite_deploy(args):

--- a/virtwho/base.py
+++ b/virtwho/base.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 import json
 import os
 import random

--- a/virtwho/provision/virtwho_host.py
+++ b/virtwho/provision/virtwho_host.py
@@ -1,7 +1,7 @@
-#!/usr/bin/python
 import os
-import sys
 import argparse
+import sys
+sys.path.append(".")
 
 from virtwho import logger, FailException
 from virtwho.settings import config
@@ -11,10 +11,6 @@ from virtwho.base import url_validation, url_file_download
 from utils.parse_ci_message import umb_ci_message_parser
 from utils.beaker import install_rhel_by_beaker
 from utils.properties_update import virtwho_ini_props_update
-
-curPath = os.path.abspath(os.path.dirname(__file__))
-rootPath = os.path.split(curPath)[0]
-sys.path.append(os.path.split(rootPath)[0])
 
 
 def provision_virtwho_host(args):

--- a/virtwho/provision/virtwho_hypervisor.py
+++ b/virtwho/provision/virtwho_hypervisor.py
@@ -267,17 +267,13 @@ def kubevirt_monitor():
 
         else:
             for guest_name, guest_info in guest_dict.items():
-                logger.info(
-                    f">>>Kubevirt: Get the hypervisor data of {guest_name}."
-                )
+                logger.info(f">>>Kubevirt: Get the hypervisor data of {guest_name}.")
                 kubevirt_info = kubevirt.guest_search(
                     guest_name, guest_info["guest_port"]
                 )
                 logger.info(f"=== Kubevirt data:\n{kubevirt_info}\n===")
 
-                logger.info(
-                    f">>>Kubevirt: Check if the guest{guest_name} is running."
-                )
+                logger.info(f">>>Kubevirt: Check if the guest{guest_name} is running.")
                 if not kubevirt_info["guest_ip"]:
                     kubevirt_state, _ = (state_guest_bad, guest_none)
                     logger.error(
@@ -286,9 +282,7 @@ def kubevirt_monitor():
                     )
                 else:
                     if ssh_connect(guest_info["ssh_guest"]):
-                        logger.info(
-                            f"The rhel guest({guest_name}) is running well."
-                        )
+                        logger.info(f"The rhel guest({guest_name}) is running well.")
                     else:
                         kubevirt_state, _ = (state_guest_bad, guest_down)
                         logger.warning(

--- a/virtwho/provision/virtwho_hypervisor.py
+++ b/virtwho/provision/virtwho_hypervisor.py
@@ -463,7 +463,7 @@ def ahv_monitor():
                 if "BAD" not in ahv_state:
                     ahv_state = state_update
                 if "BAD" in ahv_state and state_update not in ahv_state:
-                    ahv_state = f"Part {ahv_state}, part {state_update}:
+                    ahv_state = f"Part {ahv_state}, part {state_update}
 
         if not ahv_data and not ahv_data_sw:
             ahv_state = state_server_bad

--- a/virtwho/provision/virtwho_hypervisor.py
+++ b/virtwho/provision/virtwho_hypervisor.py
@@ -463,7 +463,7 @@ def ahv_monitor():
                 if "BAD" not in ahv_state:
                     ahv_state = state_update
                 if "BAD" in ahv_state and state_update not in ahv_state:
-                    ahv_state = f"Part {ahv_state}, part {state_update}
+                    ahv_state = f"Part {ahv_state}, part {state_update}"
 
         if not ahv_data and not ahv_data_sw:
             ahv_state = state_server_bad

--- a/virtwho/provision/virtwho_hypervisor.py
+++ b/virtwho/provision/virtwho_hypervisor.py
@@ -1,8 +1,7 @@
-#!/usr/bin/python
-import os
 import re
-import sys
 import argparse
+import sys
+sys.path.append(".")
 
 from virtwho import logger
 from virtwho.settings import config
@@ -15,10 +14,6 @@ from hypervisor.virt.esx.powercli import PowerCLI
 from hypervisor.virt.hyperv.hypervcli import HypervCLI
 from hypervisor.virt.kubevirt.kubevirtapi import KubevirtApi
 from hypervisor.virt.ahv.ahvapi import AHVApi
-
-curPath = os.path.abspath(os.path.dirname(__file__))
-rootPath = os.path.split(curPath)[0]
-sys.path.append(os.path.split(rootPath)[0])
 
 state_good = "GOOD"
 state_update = "UPDATED"

--- a/virtwho/provision/virtwho_hypervisor.py
+++ b/virtwho/provision/virtwho_hypervisor.py
@@ -309,7 +309,8 @@ def kubevirt_monitor():
                     "cpu": [config.kubevirt.cpu, kubevirt_data["cpu"]],
                     "guest_ip": [config.kubevirt.guest_ip, kubevirt_data["hostname"]],
                     "guest_uuid": [
-                        config.kubevirt.guest_uuid, kubevirt_data["guest_uuid"]
+                        config.kubevirt.guest_uuid,
+                        kubevirt_data["guest_uuid"],
                     ],
                 }
             )
@@ -320,14 +321,17 @@ def kubevirt_monitor():
                     {
                         "uuid_sw": [config.kubevirt.uuid_sw, kubevirt_data_sw["uuid"]],
                         "hostname_sw": [
-                            config.kubevirt.hostname_sw, kubevirt_data_sw["hostname"],
+                            config.kubevirt.hostname_sw,
+                            kubevirt_data_sw["hostname"],
                         ],
                         "version_sw": [
-                            config.kubevirt.version_sw, kubevirt_data_sw["version"]
+                            config.kubevirt.version_sw,
+                            kubevirt_data_sw["version"],
                         ],
                         "cpu_sw": [config.kubevirt.cpu_sw, kubevirt_data_sw["cpu"]],
                         "guest_ip_sw": [
-                            config.kubevirt.guest_ip_sw, kubevirt_data_sw["hostname"],
+                            config.kubevirt.guest_ip_sw,
+                            kubevirt_data_sw["hostname"],
                         ],
                         "guest_uuid_sw": [
                             config.kubevirt.guest_uuid_sw,
@@ -449,10 +453,12 @@ def ahv_monitor():
                 compare_dict.update(
                     {
                         "guest_ip_sw": [
-                            config.ahv.guest_ip_sw, ahv_data_sw["guest_ip"]
+                            config.ahv.guest_ip_sw,
+                            ahv_data_sw["guest_ip"],
                         ],
                         "guest_uuid_sw": [
-                            config.ahv.guest_uuid_sw, ahv_data_sw["guest_uuid"]
+                            config.ahv.guest_uuid_sw,
+                            ahv_data_sw["guest_uuid"],
                         ],
                     }
                 )

--- a/virtwho/provision/virtwho_satellite.py
+++ b/virtwho/provision/virtwho_satellite.py
@@ -1,8 +1,6 @@
-#!/usr/bin/python
-
-import os
-import sys
 import argparse
+import sys
+sys.path.append(".")
 
 from virtwho import FailException, logger
 from virtwho.register import Satellite
@@ -11,10 +9,6 @@ from virtwho.settings import config
 from utils.beaker import install_rhel_by_beaker
 from utils.satellite import satellite_deploy
 from utils.properties_update import virtwho_ini_props_update
-
-curPath = os.path.abspath(os.path.dirname(__file__))
-rootPath = os.path.split(curPath)[0]
-sys.path.append(os.path.split(rootPath)[0])
 
 
 def satellite_deploy_for_virtwho(args):


### PR DESCRIPTION
Changed for the `ahv` and `kubevirt`, will skip to test the guest_sw when the value is null.

**Test Result**
```
% pytest --disable-warnings -v tests/hypervisor/test_hypervisors_state.py -k 'ahv or kubevirt'
========================================================= test session starts =========================================================
platform darwin -- Python 3.11.2, pytest-7.2.2, pluggy-1.0.0 -- /opt/homebrew/opt/python@3.11/bin/python3.11
cachedir: .pytest_cache
rootdir: /Users/yuefliu/workspace/virtwho-test, configfile: pytest.ini
collected 7 items / 5 deselected / 2 selected                                                                                         

tests/hypervisor/test_hypervisors_state.py::TestHypervisorsState::test_state_kubevirt PASSED                                    [ 50%]
tests/hypervisor/test_hypervisors_state.py::TestHypervisorsState::test_state_ahv PASSED                                         [100%]

============================================ 2 passed, 5 deselected, 2 warnings in 32.61s =============================================
```