### PR TITLE
package cases debug: default to install the wget when deploy virt-who host

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -11,5 +11,3 @@ markers =
     notRHEL9: cases not for rhel9
 
     notLocal: cases not for local libvirt mode
-
-    notstage: cases not for stage register server

--- a/tests/package/test_info.py
+++ b/tests/package/test_info.py
@@ -16,6 +16,7 @@ from virtwho.settings import DOCS_DIR, TEMP_DIR
 @pytest.mark.usefixtures("class_hypervisor")
 @pytest.mark.usefixtures("class_virtwho_d_conf_clean")
 class TestVirtwhoPackageInfo:
+    @pytest.mark.tier1
     def test_shipped_in_supported_arch(self):
         """Test the virt-who package is shipped in all supported arch
 

--- a/virtwho/provision/virtwho_host.py
+++ b/virtwho/provision/virtwho_host.py
@@ -62,7 +62,7 @@ def provision_virtwho_host(args):
     )
     rhsm_conf_backup(ssh_host)
     system_init(ssh_host, "virtwho")
-    ssh_host.runcmd("yum install -y expect net-tools")
+    ssh_host.runcmd("yum install -y expect net-tools wget")
     virtwho_pkg = virtwho_install(ssh_host, args.virtwho_pkg_url)
 
     # Update the virtwho.ini properties


### PR DESCRIPTION
Two cases `test_install_uninstall_by_rpm` and `test_upgrade_downgrade_by_rpm` failed in jenkins job https://main-jenkins-csb-virtwhoqe.apps.ocp-c1.prod.psi.redhat.com/job/regression-el9/job/package-runtest/5/console, which was because no the `wget` package found for downloading. So updated the `virtwho-host.py` to default install the package.

```
% pytest --disable-warnings -v tests/package/ -k 'test_install_uninstall_by_rpm or test_upgrade_downgrade_by_rpm'
========================================================= test session starts =========================================================
platform darwin -- Python 3.11.2, pytest-7.2.2, pluggy-1.0.0 -- /opt/homebrew/opt/python@3.11/bin/python3.11
cachedir: .pytest_cache
rootdir: /Users/yuefliu/workspace/virtwho-test, configfile: pytest.ini
collected 11 items / 9 deselected / 2 selected                                                                                        

tests/package/test_install_uninstall.py::TestInstallUninstall::test_install_uninstall_by_rpm PASSED                             [ 50%]
tests/package/test_upgrade_downgrade.py::TestUpgradeDowngrade::test_upgrade_downgrade_by_rpm PASSED                             [100%]

======================================= 2 passed, 9 deselected, 2 warnings in 86.74s (0:01:26) ========================================
```