### PR TITLE
Add test case: test_threads_number_after_reconfig_libvirt

### DIFF
--- a/tests/hypervisor/test_local.py
+++ b/tests/hypervisor/test_local.py
@@ -7,40 +7,112 @@
 :caselevel: Component
 """
 import pytest
-from virtwho import logger
+import time
+
+from hypervisor import logger
 
 
-class TestLocal:
+@pytest.mark.usefixtures("function_virtwho_d_conf_clean")
+@pytest.mark.usefixtures("class_debug_true")
+@pytest.mark.usefixtures("class_globalconf_clean")
+class TestLocalPositive:
     @pytest.mark.tier1
-    def test_hostname_option(self):
-        """Just a demo
-
-        :title: virt-who: local: test hostname option
-        :id: 33cc5ba0-c529-481b-8cfa-8613adbe23ee
+    def test_threads_number_after_reconfig_libvirt(self, virtwho, ssh_host):
+        """
+        :title: virt-who: loacl: test threads number after reconfig libvirt config file
+        :id: 4d2552ce-af14-4e4f-84ab-64764db64fe2
         :caseimportance: High
         :tags: hypervisor,local,tier1
         :customerscenario: false
         :upstream: no
         :steps:
-            1.demo
-        :expectedresults:
-            1.demo
-        """
-        logger.info("Succeeded to run the 'test_hostname_option'")
+            1. Run virt-who service to check the thread number
+            2. Update libvirt config, and restart libvirtd service
+            3. Check virt-who thread_num is changed or not
+            4. Recovery libvirt config
 
-    @pytest.mark.tier2
-    def test_http_option(self):
-        """Just a demo
-
-        :title: virt-who: local: test http option
-        :id: a66787b3-1a5f-4b6f-9c09-0873d6490de3
-        :caseimportance: High
-        :tags: hypervisor,local,tier2
-        :customerscenario: false
-        :upstream: no
-        :steps:
-            1. demo
         :expectedresults:
-            1. demo
+            1. Succeeded to start virt-who service and the thread_num is 1
+            2. Succeed to start the libvirtd service
+            3. the thread_num is still 1
         """
-        logger.info("Succeeded to run the 'test_http_option'")
+
+        # run virt-who service to check the thread number
+        result = virtwho.run_service()
+        thread_berfore = result['thread']
+        logger.info(f"Succeeded to start virt-who service and the thread_num is {thread_berfore}")
+
+        # update libvirt config, and restart libvirtd service
+        libvirt_conf = "/etc/libvirt/libvirtd.conf"
+        option_enable("listen_tls", libvirt_conf, ssh_host)
+        option_enable("listen_tcp", libvirt_conf, ssh_host)
+        option_enable("auth_tcp", libvirt_conf, ssh_host)
+        option_enable("tcp_port", libvirt_conf, ssh_host)
+
+        run_service(ssh_host, "libvirtd", "restart")
+        _, output = run_service(ssh_host, "libvirtd", "status")
+        assert "is running" in output or "Active: active (running)" in output
+
+        # check virt-who thread_num is changed or not
+        thread_after = virtwho.thread_number()
+        assert thread_berfore == thread_after
+
+        # recovery libvirt config
+        option_disable("listen_tls", libvirt_conf, ssh_host)
+        option_disable("listen_tcp", libvirt_conf, ssh_host)
+        option_disable("auth_tcp", libvirt_conf, ssh_host)
+        option_disable("tcp_port", libvirt_conf, ssh_host)
+
+        run_service(ssh_host, "libvirtd", "restart")
+        _, output = run_service(ssh_host, "libvirtd", "status")
+        assert "is running" in output or "Active: active (running)" in output
+
+
+def option_enable(option, file, ssh_host):
+    """
+    Enable the option for the specfic file
+    :param option: the name of the option
+    :param file: the name of the file
+    :param ssh_host: the ssh host for running the command
+    :return:
+    """
+    cmd = f'sed -i "s|^#{option}|{option}|g" {file}'
+    ret, output = ssh_host.runcmd(cmd)
+    if ret == 0:
+        logger.info(f"Succeeded to enable option {option}")
+        return True
+    else:
+        logger.error(f"Failed to enable option {option}")
+        return False
+
+
+def option_disable(option, file, ssh_host):
+    """
+    Disable the option for the specfic file
+    :param option: the name of the option
+    :param file: the name of the file
+    :param ssh_host: the ssh host for running the command
+    :return: Succeed to run the command, return True; Else, return False
+    """
+    cmd = f'sed -i "s|^{option}|#{option}|g" {file}'
+    ret, output = ssh_host.runcmd(cmd)
+    if ret == 0:
+        logger.info(f"Succeeded to disable option {option}")
+        return True
+    else:
+        logger.error(f"Failed to disable option {option}")
+        return False
+
+
+def run_service(ssh_host, name, action):
+    """
+    Run the service command, such as service virt-who start
+    :param ssh_host: the ssh host for running the command
+    :param name: the name of the service
+    :param action: Start, Stop, Status
+    :return: Succeed to run the command, return True; Else, return False
+    """
+    cmd = f"service {name} {action}"
+    ret, output = ssh_host.runcmd(cmd)
+    time.sleep(10)
+    return ret, output

--- a/tests/hypervisor/test_local.py
+++ b/tests/hypervisor/test_local.py
@@ -72,9 +72,18 @@ class TestLocalPositive:
 
 
 def operate_option(action, option, file, ssh_host):
-    if action == 'enable':
+    """
+    Disable/Enable the option for the specific file
+    :param action: Disable or Enable
+    :param option: the name of the option
+    :param file: the name of the file
+    :param ssh_host: the ssh host for running the command
+    :return: Succeed to run the command, return True; Else, return False
+    """
+    cmd = ""
+    if action == "enable":
         cmd = f'sed -i "s|^#{option}|{option}|g" {file}'
-    else:
+    elif action == "disable":
         cmd = f'sed -i "s|^{option}|#{option}|g" {file}'
     ret, output = ssh_host.runcmd(cmd)
     if ret == 0:

--- a/tests/hypervisor/test_local.py
+++ b/tests/hypervisor/test_local.py
@@ -39,9 +39,11 @@ class TestLocalPositive:
 
         # run virt-who service to check the thread number
         result = virtwho.run_service()
-        thread_berfore = result['thread']
+        thread_berfore = result["thread"]
         assert thread_berfore == 1
-        logger.info(f"Succeeded to start virt-who service and the thread_num is {thread_berfore}")
+        logger.info(
+            f"Succeeded to start virt-who service and the thread_num is {thread_berfore}"
+        )
 
         # update libvirt config, and restart libvirtd service
         libvirt_conf = "/etc/libvirt/libvirtd.conf"

--- a/tests/hypervisor/test_local.py
+++ b/tests/hypervisor/test_local.py
@@ -103,6 +103,6 @@ def run_service(ssh_host, name, action):
     :return: Succeed to run the command, return True; Else, return False
     """
     cmd = f"service {name} {action}"
-    ret, output = ssh_host.runcmd(cmd)
+    ret, output = ssh_host.runcmd(cmd, True)
     time.sleep(10)
     return ret, output


### PR DESCRIPTION
**Description**
Add test case: test_threads_number_after_reconfig_libvirt from [tc_1103_check_virtwho_threads_number_after_reconfig_libvirt.](https://github.com/VirtwhoQE/virtwho-ci/blob/master/tests/tier1/tc_1103_check_virtwho_threads_number_after_reconfig_libvirt.py)

**Test Result**
```
[hkx303@kuhuang virtwho-test]$ pytest tests/hypervisor/test_local.py -k test_threads_number_after_reconfig_libvirt -s
=================================== test session starts ===================================
platform linux -- Python 3.7.3, pytest-5.4.3, py-1.8.0, pluggy-0.13.1
rootdir: /home/hkx303/Documents/CI/virtwho-test, inifile: pytest.ini
plugins: services-1.3.1, mock-1.10.4, forked-1.0.2, ibutsu-1.0.34, cov-2.7.1, xdist-1.34.0
collected 1 item    

============================== 1 passed in 90.28s (0:01:30) ===============================
```