### PR TITLE
support the sca mode changing

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -202,24 +202,12 @@ def satellite():
     return None
 
 
-@pytest.fixture(scope="class")
-def class_satellite_sca_disable(satellite):
-    """Enable sca mode for default org"""
-    satellite.sca(sca="disable")
-
-
 @pytest.fixture(scope="session")
 def rhsm():
     """Instantication of class RHSM()"""
     if REGISTER == "rhsm":
         return RHSM()
     return None
-
-
-@pytest.fixture(scope="class")
-def class_rhsm_sca_disable(rhsm):
-    """Disable sca mode for stage candlepin"""
-    rhsm.sca(sca="disable")
 
 
 @pytest.fixture(scope="session")

--- a/tests/subscription/test_rhsm.py
+++ b/tests/subscription/test_rhsm.py
@@ -13,13 +13,14 @@ vdc_physical_sku = config.sku.vdc
 vdc_virtual_sku = config.sku.vdc_virtual
 
 
+@pytest.mark.usefixtures("module_rhsm_sca_recover")
 @pytest.mark.usefixtures("class_globalconf_clean")
 @pytest.mark.usefixtures("class_hypervisor")
 @pytest.mark.usefixtures("class_guest_register")
 @pytest.mark.usefixtures("function_guest_unattach")
 @pytest.mark.usefixtures("function_host_register_for_local_mode")
 @pytest.mark.usefixtures("class_rhsm_sca_disable")
-class TestRHSM:
+class TestRhsmScaDisable:
     @pytest.mark.tier1
     def test_vdc_virtual_pool_attach_by_poolId(
         self, virtwho, sm_guest, rhsm, hypervisor_data, vdc_pool_physical
@@ -379,3 +380,26 @@ class TestRHSM:
         sm_guest.refresh()
         consumed_data = sm_guest.consumed(sku_id=vdc_virtual_sku)
         assert consumed_data is None
+
+
+# @pytest.mark.usefixtures("module_rhsm_sca_recover")
+# @pytest.mark.usefixtures("class_globalconf_clean")
+# @pytest.mark.usefixtures("class_hypervisor")
+# @pytest.mark.usefixtures("class_guest_register")
+# @pytest.mark.usefixtures("function_guest_unattach")
+# @pytest.mark.usefixtures("function_host_register_for_local_mode")
+# @pytest.mark.usefixtures("class_rhsm_sca_enable")
+# class TestRhsmScaEnable:
+
+
+@pytest.fixture(scope="class")
+def class_rhsm_sca_disable(rhsm):
+    """Disable sca mode for stage candlepin"""
+    rhsm.sca(sca="disable")
+
+
+@pytest.fixture(scope="module")
+def module_rhsm_sca_recover(rhsm):
+    """Recover the sca mode as configuration in virtwho.ini."""
+    yield
+    rhsm.sca(sca=config.job.sca)

--- a/tests/subscription/test_satellite.py
+++ b/tests/subscription/test_satellite.py
@@ -24,6 +24,7 @@ second_org = config.satellite.secondary_org
 hypervisor_handler = get_hypervisor_handler(HYPERVISOR)
 
 
+@pytest.mark.usefixtures("module_satellite_sca_recover")
 @pytest.mark.usefixtures("class_hypervisor")
 @pytest.mark.usefixtures("class_virtwho_d_conf_clean")
 @pytest.mark.usefixtures("class_globalconf_clean")
@@ -31,7 +32,7 @@ hypervisor_handler = get_hypervisor_handler(HYPERVISOR)
 @pytest.mark.usefixtures("class_guest_register")
 @pytest.mark.usefixtures("function_host_register_for_local_mode")
 @pytest.mark.usefixtures("class_satellite_sca_disable")
-class TestSatellite:
+class TestSatelliteScaDisable:
     @pytest.mark.tier1
     def test_vdc_virtual_pool_attach_by_poolId(
         self, virtwho, sm_guest, satellite, hypervisor_data, vdc_pool_physical
@@ -668,6 +669,16 @@ class TestSatellite:
     #     register_by = satellite.hosts_info_on_webui(guest_hostname)
     #     assert register_by == 'admin'
 
+# @pytest.mark.usefixtures("module_satellite_sca_recover")
+# @pytest.mark.usefixtures("class_hypervisor")
+# @pytest.mark.usefixtures("class_virtwho_d_conf_clean")
+# @pytest.mark.usefixtures("class_globalconf_clean")
+# @pytest.mark.usefixtures("function_guest_unattach")
+# @pytest.mark.usefixtures("class_guest_register")
+# @pytest.mark.usefixtures("function_host_register_for_local_mode")
+# @pytest.mark.usefixtures("class_satellite_sca_enable")
+# class TestSatelliteScaEnable:
+
 
 @pytest.fixture(scope="class")
 def sm_guest_ack(register_data):
@@ -727,3 +738,15 @@ def satellite_second_org():
 #             return register_by
 #     logger.error(f'Failed to get the register_by value for {host}')
 #     return None
+
+@pytest.fixture(scope="class")
+def class_satellite_sca_disable(satellite):
+    """Disable sca mode for default org"""
+    satellite.sca(org=None, sca="disable")
+
+
+@pytest.fixture(scope="module")
+def module_satellite_sca_recover(satellite):
+    """Recover the sca mode for default org as configuration in virtwho.ini."""
+    yield
+    satellite.sca(org=None, sca=config.job.sca)

--- a/tests/subscription/test_satellite.py
+++ b/tests/subscription/test_satellite.py
@@ -669,6 +669,7 @@ class TestSatelliteScaDisable:
     #     register_by = satellite.hosts_info_on_webui(guest_hostname)
     #     assert register_by == 'admin'
 
+
 # @pytest.mark.usefixtures("module_satellite_sca_recover")
 # @pytest.mark.usefixtures("class_hypervisor")
 # @pytest.mark.usefixtures("class_virtwho_d_conf_clean")
@@ -738,6 +739,7 @@ def satellite_second_org():
 #             return register_by
 #     logger.error(f'Failed to get the register_by value for {host}')
 #     return None
+
 
 @pytest.fixture(scope="class")
 def class_satellite_sca_disable(satellite):

--- a/virtwho/provision/virtwho_rhsm.py
+++ b/virtwho/provision/virtwho_rhsm.py
@@ -1,0 +1,40 @@
+import argparse
+import os
+import sys
+
+curPath = os.path.abspath(os.path.dirname(__file__))
+rootPath = os.path.split(curPath)[0]
+sys.path.append(os.path.split(rootPath)[0])
+
+from virtwho import logger
+from virtwho.register import RHSM
+
+
+def rhsm_setup_for_virtwho(args):
+    """
+    Setup sca mode for rhsm/stage candlepin account.
+    """
+    logger.info("+++ Start to setup the RHSM +++")
+    rhsm = RHSM()
+    rhsm.sca(sca=args.sca)
+
+
+def virtwho_rhsm_arguments_parser():
+    """
+    Parse and convert the arguments from command line to parameters
+    for function using, and generate help and usage messages for
+    each arguments.
+    """
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--sca",
+        default="enable",
+        required=False,
+        help="SCA mode, disable/enable",
+    )
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    args = virtwho_rhsm_arguments_parser()
+    rhsm_setup_for_virtwho(args)

--- a/virtwho/provision/virtwho_satellite.py
+++ b/virtwho/provision/virtwho_satellite.py
@@ -44,7 +44,9 @@ def satellite_deploy_for_virtwho(args):
     satellite_settings(ssh_satellite, "failed_login_attempts_limit", "0")
     satellite_settings(ssh_satellite, "unregister_delete_host", "true")
 
-    # Upload manifest to the default org
+    # Default Org: setup SCA mode and upload manifest as requirement
+    satellite = Satellite(server=args.server)
+    satellite.sca(org=None, sca=args.sca)
     satellite_manifest_upload(
         org="Default_Organization",
         ssh=ssh_satellite,
@@ -53,11 +55,11 @@ def satellite_deploy_for_virtwho(args):
         admin_password=args.admin_password,
     )
 
-    # Create the second org and upload manifest as requirement.
-    satellite = Satellite(server=args.server)
+    # Second org: create org, then setup sca and upload manifest as requirement.
     second_org = config.satellite.secondary_org
     if second_org:
         satellite.org_create(name=second_org, label=second_org)
+        satellite.sca(org=second_org, sca=args.sca)
         satellite_manifest_upload(
             org=second_org,
             ssh=ssh_satellite,
@@ -207,7 +209,13 @@ def virtwho_satellite_arguments_parser():
         "--beaker-host",
         default="%dell-per740-69-vm%",
         required=False,
-        help="Define/filter system as hostrequire. " "Such as: %hp-dl360g9-08-vm%",
+        help="Define/filter system as hostrequire. Such as: %hp-dl360g9-08-vm%",
+    )
+    parser.add_argument(
+        "--sca",
+        default="enable",
+        required=False,
+        help="SCA mode, disable/enable",
     )
     return parser.parse_args()
 

--- a/virtwho/register.py
+++ b/virtwho/register.py
@@ -953,19 +953,22 @@ class Satellite:
         logger.warning(f"Failed to get host info for {host} on satellite webui")
         return None
 
-    def sca(self, sca="disable"):
+    def sca(self, org=None, sca="disable"):
         """
         Enable/disable simple content access.
+        :param org: org lable, default use the Default_Organization.
         :param sca: enable/disable.
         :return: True or raise fail.
         """
+        org = org or self.org
+        org_id = self.organization_id(org=org)
         ret, output = self.ssh.runcmd(
-            f"hammer simple-content-access {sca} --organization-id {self.org_id}"
+            f"hammer simple-content-access {sca} --organization-id {org_id}"
         )
         if ret == 0 and "100%" in output:
-            logger.info(f"Succeeded to {sca} SCA for satellite")
+            logger.info(f"Succeeded to {sca} SCA for satellite:{org}")
             return True
-        raise FailException(f"Failed to {sca} SCA for satellite")
+        raise FailException(f"Failed to {sca} SCA for satellite:{org}")
 
     def facts_get(self, host_id):
         """


### PR DESCRIPTION
- [x] new define provision/virtwho_rhsm.py to setup sca mode for rhsm account.
- [x] new define yield fixture `module_satellite_sca_recover` and `module_rhsm_sca_recover` to recover sca mode after run the subscription test cases.
- [x] update provision/virtwho_satellite.py to support setup sca mode for all the satellite organizations.

**Test Result**
```
% pytest --disable-warnings -v tests/subscription/test_satellite.py -k 'test_vdc_virtual_pool_attach_by_poolId'
========================================================= test session starts =========================================================
platform darwin -- Python 3.11.2, pytest-7.2.2, pluggy-1.0.0 -- /opt/homebrew/opt/python@3.11/bin/python3.11
cachedir: .pytest_cache
rootdir: /Users/yuefliu/workspace/virtwho-test, configfile: pytest.ini
collected 9 items / 8 deselected / 1 selected                                                                                         

tests/subscription/test_satellite.py::TestSatelliteScaDisable::test_vdc_virtual_pool_attach_by_poolId PASSED                    [100%]

======================================== 1 passed, 8 deselected, 1 warning in 96.36s (0:01:36) ========================================
```
```
% pytest --disable-warnings -v tests/subscription/test_rhsm.py -k 'test_vdc_virtual_pool_attach_by_poolId'
========================================================= test session starts =========================================================
platform darwin -- Python 3.11.2, pytest-7.2.2, pluggy-1.0.0 -- /opt/homebrew/opt/python@3.11/bin/python3.11
cachedir: .pytest_cache
rootdir: /Users/yuefliu/workspace/virtwho-test, configfile: pytest.ini
collected 6 items / 5 deselected / 1 selected                                                                                         

tests/subscription/test_rhsm.py::TestRhsmScaDisable::test_vdc_virtual_pool_attach_by_poolId PASSED                              [100%]

======================================= 1 passed, 5 deselected, 2 warnings in 251.54s (0:04:11) ======================================
```