### PR TITLE
Fix the test case: test_print_in_virtwho_conf

### DIFF
--- a/tests/function/test_config.py
+++ b/tests/function/test_config.py
@@ -132,16 +132,20 @@ class TestConfiguration:
         :steps:
 
             1. Run virt-who with "print_=True" in /etc/virt-who.conf
-            2. Run virt-who with "print_=False" in /etc/virt-who.conf
+            2. Run virt-who with "print_=True" and "debug=True" in /etc/virt-who.conf
+            3. Run virt-who with "print_=True" and "debug=False" in /etc/virt-who.conf
 
         :expectedresults:
 
-            1. the mappings send number and alive thread number of the virt-who is 0
-            2. the mappings send number and alive thread number of the virt-who is 1
+            1. the mappings send number and alive thread number of the virt-who is 1
+            2. Succeed to send the mapping info in rhsm.log
+            3. Succeed to send the mapping info in rhsm.log
         """
         globalconf.update("global", "print_", "False")
         result = virtwho.run_service()
         assert result["error"] == 0 and result["send"] == 1 and result["thread"] == 1
+
+        virtwho.stop()
 
         guest_id = hypervisor_data["guest_uuid"]
         globalconf.update("global", "print_", "True")


### PR DESCRIPTION
**Description**
The case failed due to the error info:
`AssertionError: assert '09a33b42-d988-8179-3ae7-ac341efae918' in ''`
the root cause is the `virt-who` command cannot be run successfully when the virt-who thread starts

**Test Result**
```
(env) [hkx303@kuhuang virtwho-test]$ pytest tests/function/test_config.py -k test_print_in_virtwho_conf -s
/home/hkx303/Documents/CI/virtwho-test/env/lib/python3.7/site-packages/paramiko/transport.py:216: CryptographyDeprecationWarning: Blowfish has been deprecated
  "class": algorithms.Blowfish,
==================================== test session starts =====================================
platform linux -- Python 3.7.3, pytest-5.4.3, py-1.11.0, pluggy-0.13.1
rootdir: /home/hkx303/Documents/CI/virtwho-test, inifile: pytest.ini
plugins: services-1.3.1, xdist-1.34.0, mock-1.10.4, forked-1.4.0
collected 21 items / 20 deselected / 1 selected    
======================== 1 passed, 20 deselected in 74.84s (0:01:14) =========================
```

