### PR TITLE
Fix test case: test_interval_in_virtwho_conf

### DIFF
--- a/tests/function/test_config.py
+++ b/tests/function/test_config.py
@@ -76,7 +76,9 @@ class TestConfiguration:
 
         globalconf.update("global", "interval", "60")
         result = virtwho.run_service(wait=60)
-        assert result["send"] == 1 and result["error"] == 0 and result["loop"] in [60, 61]
+        assert (
+            result["send"] == 1 and result["error"] == 0 and result["loop"] in [60, 61]
+        )
 
     @pytest.mark.tier1
     def test_oneshot_in_virtwho_conf(self, virtwho, globalconf):

--- a/tests/function/test_config.py
+++ b/tests/function/test_config.py
@@ -76,7 +76,7 @@ class TestConfiguration:
 
         globalconf.update("global", "interval", "60")
         result = virtwho.run_service(wait=60)
-        assert result["send"] == 1 and result["error"] == 0 and result["loop"] == 60
+        assert result["send"] == 1 and result["error"] == 0 and result["loop"] in [60, 61]
 
     @pytest.mark.tier1
     def test_oneshot_in_virtwho_conf(self, virtwho, globalconf):


### PR DESCRIPTION
**Description**
Fix test case: test_interval_in_virtwho_conf, the result["loop"] is not always 60s, might also 61s

**Test Result**
```
(env) [hkx303@kuhuang virtwho-test]$ pytest tests/function/test_config.py -k test_interval_in_virtwho_conf -s
/home/hkx303/Documents/CI/virtwho-test/env/lib/python3.7/site-packages/paramiko/transport.py:216: CryptographyDeprecationWarning: Blowfish has been deprecated
  "class": algorithms.Blowfish,
==================================== test session starts =====================================
platform linux -- Python 3.7.3, pytest-5.4.3, py-1.11.0, pluggy-0.13.1
rootdir: /home/hkx303/Documents/CI/virtwho-test, inifile: pytest.ini
plugins: services-1.3.1, xdist-1.34.0, mock-1.10.4, forked-1.4.0
collected 21 items / 20 deselected / 1 selected    
======================== 1 passed, 20 deselected in 150.60s (0:02:30) ========================
```