### PR TITLE
Fix test case: test_hypervisor_id_in_virtwho_conf

### DIFF
--- a/virtwho/register.py
+++ b/virtwho/register.py
@@ -634,7 +634,7 @@ class Satellite:
         output = json.loads(output)
         if ret == 0 and len(output) >= 1:
             for item in output:
-                if host in item["Name"]:
+                if host or host.lower() in item["Name"]:
                     host_id = item["Id"]
                     logger.info(f"Succeeded to get the host id, {host}:{host_id}")
                     return host_id


### PR DESCRIPTION
**Description**
case test_hypervisor_id_in_virtwho_conf failed for the Nutanix hypervisor due to the error info:
```
>                   assert satellite.host_id(hypervisor_data["hypervisor_hostname"])
E                   AssertionError: assert None
E                    +  where None = <bound method Satellite.host_id of <virtwho.register.Satellite object at 0x7f05f9c83b80>>('NTNX-089019a9-A')
E                    +    where <bound method Satellite.host_id of <virtwho.register.Satellite object at 0x7f05f9c83b80>> = <virtwho.register.Satellite object at 0x7f05f9c83b80>.host_id
```
the root cause is the hostname of Nutanix is capital,  cannot match the name from the hammer command output, need to transfer it


**Test Result**
```
(env) [hkx303@kuhuang virtwho-test]$ pytest tests/function/test_config.py::TestConfiguration::test_hypervisor_id_in_virtwho_conf -s
/home/hkx303/Documents/CI/virtwho-test/env/lib/python3.7/site-packages/paramiko/transport.py:216: CryptographyDeprecationWarning: Blowfish has been deprecated
  "class": algorithms.Blowfish,
==================================== test session starts =====================================
platform linux -- Python 3.7.3, pytest-5.4.3, py-1.11.0, pluggy-0.13.1
rootdir: /home/hkx303/Documents/CI/virtwho-test, inifile: pytest.ini
plugins: services-1.3.1, xdist-1.34.0, mock-1.10.4, forked-1.4.0
collected 1 item 
=============================== 1 passed in 137.91s (0:02:17) ================================
```
