### PR TITLE
Fix test one shot cases for kubevirt, hyperv and rhevm hypervisors

### DIFF
--- a/tests/function/test_cli.py
+++ b/tests/function/test_cli.py
@@ -9,6 +9,8 @@
 import threading
 import time
 import pytest
+
+from virtwho import HYPERVISOR
 from virtwho import HYPERVISOR_FILE, config
 from virtwho.base import encrypt_password
 
@@ -73,14 +75,21 @@ class TestCli:
             and result["oneshot"] is False
         )
 
+        # BZ1448821: No log notice for hyperv rhevm and kubevirt for oneshot function.
+        if HYPERVISOR not in ["rhevm", "hyperv", "kubevirt"]:
+            assert result["oneshot"] is False
+
         result = virtwho.run_cli(oneshot=True)
         assert (
             result["send"] == 1
             and result["error"] == 0
             and result["thread"] == 0
             and result["terminate"] == 1
-            and result["oneshot"] is True
         )
+
+        # BZ1448821: No log notice for hyperv rhevm and kubevirt for oneshot function.
+        if HYPERVISOR not in ["rhevm", "hyperv", "kubevirt"]:
+            assert result["oneshot"] is True
 
     @pytest.mark.tier1
     def test_interval(self, virtwho):

--- a/tests/function/test_config.py
+++ b/tests/function/test_config.py
@@ -107,8 +107,11 @@ class TestConfiguration:
             result["send"] == 1
             and result["error"] == 0
             and result["terminate"] == 1
-            and result["oneshot"] is True
         )
+
+        # BZ1448821: No log notice for hyperv rhevm and kubevirt for oneshot function.
+        if HYPERVISOR not in ["rhevm", "hyperv", "kubevirt"]:
+            assert result["oneshot"] is True
 
         globalconf.update("global", "oneshot", "False")
         result = virtwho.run_service()
@@ -116,8 +119,11 @@ class TestConfiguration:
             result["send"] == 1
             and result["error"] == 0
             and result["terminate"] == 0
-            and result["oneshot"] is False
         )
+
+        # BZ1448821: No log notice for hyperv rhevm and kubevirt for oneshot function.
+        if HYPERVISOR not in ["rhevm", "hyperv", "kubevirt"]:
+            assert result["oneshot"] is True
 
     @pytest.mark.tier1
     def test_print_in_virtwho_conf(
@@ -597,8 +603,11 @@ class TestSysConfiguration:
             result["send"] == 1
             and result["error"] == 0
             and result["terminate"] == 1
-            and result["oneshot"] is True
         )
+
+        # BZ1448821: No log notice for hyperv rhevm and kubevirt for oneshot function.
+        if HYPERVISOR not in ["rhevm", "hyperv", "kubevirt"]:
+            assert result["oneshot"] is True
 
         sysconfg_options["VIRTWHO_ONE_SHOT"] = 0
         function_sysconfig.update(**sysconfg_options)
@@ -607,8 +616,11 @@ class TestSysConfiguration:
             result["send"] == 1
             and result["error"] == 0
             and result["terminate"] == 0
-            and result["oneshot"] is False
         )
+
+        # BZ1448821: No log notice for hyperv rhevm and kubevirt for oneshot function.
+        if HYPERVISOR not in ["rhevm", "hyperv", "kubevirt"]:
+            assert result["oneshot"] is False
 
         function_sysconfig.clean()
 

--- a/tests/function/test_config.py
+++ b/tests/function/test_config.py
@@ -103,11 +103,7 @@ class TestConfiguration:
         globalconf.update("global", "debug", "True")
         globalconf.update("global", "oneshot", "True")
         result = virtwho.run_service()
-        assert (
-            result["send"] == 1
-            and result["error"] == 0
-            and result["terminate"] == 1
-        )
+        assert result["send"] == 1 and result["error"] == 0 and result["terminate"] == 1
 
         # BZ1448821: No log notice for hyperv rhevm and kubevirt for oneshot function.
         if HYPERVISOR not in ["rhevm", "hyperv", "kubevirt"]:
@@ -115,11 +111,7 @@ class TestConfiguration:
 
         globalconf.update("global", "oneshot", "False")
         result = virtwho.run_service()
-        assert (
-            result["send"] == 1
-            and result["error"] == 0
-            and result["terminate"] == 0
-        )
+        assert result["send"] == 1 and result["error"] == 0 and result["terminate"] == 0
 
         # BZ1448821: No log notice for hyperv rhevm and kubevirt for oneshot function.
         if HYPERVISOR not in ["rhevm", "hyperv", "kubevirt"]:
@@ -599,11 +591,7 @@ class TestSysConfiguration:
         sysconfg_options = {"VIRTWHO_DEBUG": "1", "VIRTWHO_ONE_SHOT": "1"}
         function_sysconfig.update(**sysconfg_options)
         result = virtwho.run_service()
-        assert (
-            result["send"] == 1
-            and result["error"] == 0
-            and result["terminate"] == 1
-        )
+        assert result["send"] == 1 and result["error"] == 0 and result["terminate"] == 1
 
         # BZ1448821: No log notice for hyperv rhevm and kubevirt for oneshot function.
         if HYPERVISOR not in ["rhevm", "hyperv", "kubevirt"]:
@@ -612,11 +600,7 @@ class TestSysConfiguration:
         sysconfg_options["VIRTWHO_ONE_SHOT"] = 0
         function_sysconfig.update(**sysconfg_options)
         result = virtwho.run_service()
-        assert (
-            result["send"] == 1
-            and result["error"] == 0
-            and result["terminate"] == 0
-        )
+        assert result["send"] == 1 and result["error"] == 0 and result["terminate"] == 0
 
         # BZ1448821: No log notice for hyperv rhevm and kubevirt for oneshot function.
         if HYPERVISOR not in ["rhevm", "hyperv", "kubevirt"]:


### PR DESCRIPTION
**Description**
As per [BZ1448821](https://bugzilla.redhat.com/show_bug.cgi?id=1448821), we don't have related notice log for kubevirt, hyperv and rhevm hypervisors, need to skip the assertion for these hypervisors
Need to add the steps to the following 3 cases:

- [x] tests/function/test_config.py::TestSysConfiguration::test_oneshot_in_virtwho_sysconfig 
- [x] tests/function/test_config.py::TestConfiguration::test_oneshot_in_virtwho_conf
- [x] tests/function/test_cli.py::TestCli::test_oneshot 


**Test Result**
All test cases passed locally