### PR TITLE
Update test cases for test_rhsm_option file

### DIFF
--- a/tests/subscription/test_rhsm_option.py
+++ b/tests/subscription/test_rhsm_option.py
@@ -56,7 +56,7 @@ class TestSubscriptionPositive:
         assert (
             result["send"] == 0
             and result["error"] != 0
-            and msg_search(result["error_msg"], register_assertion["unregister_host"])
+            and msg_search(result["log"], register_assertion["unregister_host"])
         )
 
     @pytest.mark.tier1
@@ -265,7 +265,7 @@ class TestSubscriptionNegative:
                 result["error"] is not 0
                 and result["send"] == 0
                 and result["thread"] == 1
-                and msg_search(result["error_msg"], value)
+                and msg_search(result["log"], value)
             )
 
         # disable
@@ -318,7 +318,7 @@ class TestSubscriptionNegative:
                 result["error"] is not 0
                 and result["send"] == 0
                 and result["thread"] == 1
-                and msg_search(result["error_msg"], value)
+                and msg_search(result["log"], value)
             )
 
         # null, will use the default 443
@@ -445,7 +445,7 @@ class TestSubscriptionNegative:
                 result["error"] is not 0
                 and result["send"] == 0
                 and result["thread"] == 1
-                and msg_search(result["error_msg"], value)
+                and msg_search(result["log"], value)
             )
 
         # disable
@@ -455,7 +455,7 @@ class TestSubscriptionNegative:
             result["error"] is not 0
             and result["send"] == 0
             and result["thread"] == 1
-            and msg_search(result["error_msg"], assertion["disable"])
+            and msg_search(result["log"], assertion["disable"])
         )
 
     @pytest.mark.tier2
@@ -492,7 +492,7 @@ class TestSubscriptionNegative:
                 result["error"] is not 0
                 and result["send"] == 0
                 and result["thread"] == 1
-                and msg_search(result["error_msg"], value)
+                and msg_search(result["log"], value)
             )
 
         # disable
@@ -502,7 +502,7 @@ class TestSubscriptionNegative:
             result["error"] is not 0
             and result["send"] == 0
             and result["thread"] == 1
-            and msg_search(result["error_msg"], assertion["disable"])
+            and msg_search(result["log"], assertion["disable"])
         )
 
     @pytest.mark.tier2


### PR DESCRIPTION
**Description**
Cases failed as cannot get the expected error info from `result["error_msg"]`:
```
[2023-05-31 17:35:44] - [ssh.py] - INFO: >>> grep '\[.*ERROR.*\]' /var/log/rhsm/rhsm.log |sort
[2023-05-31 17:35:44] - [ssh.py] - INFO: <<< stdout
2023-05-31 05:35:15,294 [virtwho.destination_-3953841796083599115 ERROR] MainProcess(955685):Thread-3 @virt.py:run:421 - Thread 'destination_-3953841796083599115' fails with exception:
```
Need to change to `result["log"]` for the following cases:
- [x] test_no_rhsm_options
- [x] test_rhsm_hostname
- [x] test_rhsm_port
- [x] test_rhsm_username
- [x] test_rhsm_password

Test Result
All test cases passed locally
