### PR TITLE
Fix test cases: test_non_default_org_with and without_rhsm_options

### DIFF
--- a/tests/subscription/test_satellite.py
+++ b/tests/subscription/test_satellite.py
@@ -479,6 +479,7 @@ class TestSatelliteScaDisable:
                 and guest_id in mappings[second_org]
             )
 
+            satellite.sca(org=sm_guest_second_org.org, sca="disable")
             sm_guest_second_org.register()
             vdc_sku_id = sku_data["vdc_physical"]
             vdc_pool_id = sm_guest_second_org.pool_id_get(vdc_sku_id, "Physical")
@@ -553,6 +554,7 @@ class TestSatelliteScaDisable:
                 and guest_id in mappings[second_org]
             )
 
+            satellite.sca(org=sm_guest_second_org.org, sca="disable")
             sm_guest_second_org.register()
             vdc_sku_id = sku_data["vdc_physical"]
             vdc_pool_id = sm_guest_second_org.pool_id_get(vdc_sku_id, "Physical")


### PR DESCRIPTION
**Description**
cases test_non_default_org_with_rhsm_options and test_non_default_org_without_rhsm_options failed due to the error msg:
`TypeError: 'NoneType' object is not subscriptable`
The root cause it the second org is still sca enabled, so failed to attach the subscription

**Test Result**
Test cases passed locally