### PR TITLE
polarion_testrun_import: change to use the default testrun id

### DIFF
--- a/utils/polarion_testrun_import.py
+++ b/utils/polarion_testrun_import.py
@@ -65,7 +65,7 @@ def xml_file_testrun_id_remove(xml_file):
         contents = f.read()
         res = re.findall(
             r'<property name="polarion-testrun-id" value="test-run-\d{10,}" />',
-            contents
+            contents,
         )
         contents = contents.replace(res[0], "")
         f.seek(0)
@@ -127,10 +127,7 @@ def arguments_parser():
         help="The project id, such as 'RHELSS'",
     )
     parser.add_argument(
-        "--template-id",
-        required=False,
-        default="",
-        help="The testrun template id"
+        "--template-id", required=False, default="", help="The testrun template id"
     )
     parser.add_argument("--title", required=True, help="The testrun title")
     parser.add_argument(

--- a/utils/polarion_testrun_import.py
+++ b/utils/polarion_testrun_import.py
@@ -26,7 +26,6 @@ def polarion_test_run_upload(args):
 def betelgeuse_xml_file_transform(xml_file, output_xml_file):
     """
     Transform the original xml file by betelgeuse to match the polarion request.
-    # :param testrun_id: polarion testrun id
     :param xml_file: the original xml file
     :param output_xml_file: the new xml file to match the polarion format
     """
@@ -78,7 +77,6 @@ def xml_file_testrun_id_remove(xml_file):
 def polarion_xml_file_import(polarion_xml_file):
     """
     Import the xml file to Polarion to create testrun.
-    # :param testrun_id: polarion testrun id
     :param polarion_xml_file: the polarion xml file that match the polarion format
     """
     import_url = f"{args.url}/import/xunit"
@@ -95,17 +93,6 @@ def polarion_xml_file_import(polarion_xml_file):
         logger.info(f"Successed to import xml to polarion")
     else:
         raise FailException("Failed to import xml to polarion")
-
-
-def polarion_testrun_id_get():
-    """
-    Get the testrun id in Polarion
-    """
-    testrun_url = f"{args.url}/#/project/{args.project}"
-    cmd = (
-        f"curl -k -u {args.username}:{args.password} -X GET -F "
-        f""
-    )
 
 
 def arguments_parser():

--- a/utils/polarion_testrun_import.py
+++ b/utils/polarion_testrun_import.py
@@ -1,5 +1,6 @@
 import os
 import argparse
+import re
 import subprocess
 import sys
 
@@ -8,7 +9,6 @@ rootPath = os.path.split(curPath)[0]
 sys.path.append(rootPath)
 
 from virtwho import logger, config, FailException
-from datetime import datetime
 
 
 def polarion_test_run_upload(args):
@@ -16,26 +16,17 @@ def polarion_test_run_upload(args):
     Upload the test results to Polarion.
     Requires curl and betelgeuse pypi package installed
     """
-    testrun_id = testrun_id_generate()
     results_xml = f"{args.directory}/results.xml"
     polarion_xml = f"{args.directory}/polarion_testrun.xml"
-    betelgeuse_xml_file_transform(testrun_id, results_xml, polarion_xml)
-    polarion_xml_file_import(testrun_id, polarion_xml)
+    betelgeuse_xml_file_transform(results_xml, polarion_xml)
+    xml_file_testrun_id_remove(polarion_xml)
+    polarion_xml_file_import(polarion_xml)
 
 
-def testrun_id_generate():
-    """
-    Generate the polarion testrun id, eg: RHSS_2023-05-30_14-16-49
-    """
-    create_time = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
-    testrun_id = f"{args.id}_{create_time}"
-    return testrun_id
-
-
-def betelgeuse_xml_file_transform(testrun_id, xml_file, output_xml_file):
+def betelgeuse_xml_file_transform(xml_file, output_xml_file):
     """
     Transform the original xml file by betelgeuse to match the polarion request.
-    :param testrun_id: polarion testrun id
+    # :param testrun_id: polarion testrun id
     :param xml_file: the original xml file
     :param output_xml_file: the new xml file to match the polarion format
     """
@@ -49,11 +40,9 @@ def betelgeuse_xml_file_transform(testrun_id, xml_file, output_xml_file):
         f'--custom-fields assignee="{args.assignee}" '
         f'--custom-fields component="{args.component}" '
         f'--custom-fields build="{args.build}" '
-        f'--custom-fields subsystemteam="{args.subsystemteam}" '
-        f'--custom-fields type="{args.type}" '
         f'--custom-fields jenkinsjobs="{args.jenkinsjobs}" '
         f'--custom-fields notes="{args.notes}" '
-        f'--test-run-id="{testrun_id}" '
+        f'--test-run-template-id="{args.template_id}" '
         f'--test-run-title="{args.title}" '
         f'--status="finished" '
         f'"{xml_file}" '
@@ -69,14 +58,31 @@ def betelgeuse_xml_file_transform(testrun_id, xml_file, output_xml_file):
         raise FailException("\nThe betelgause failed to transform the xml file.")
 
 
-def polarion_xml_file_import(testrun_id, polarion_xml_file):
+def xml_file_testrun_id_remove(xml_file):
+    """
+    Remove the testrun id property to use the default id of Polarion
+    """
+    with open(xml_file, "r+") as f:
+        contents = f.read()
+        res = re.findall(
+            r'<property name="polarion-testrun-id" value="test-run-\d{10,}" />',
+            contents
+        )
+        contents = contents.replace(res[0], "")
+        f.seek(0)
+        f.write(contents)
+        f.truncate()
+        f.close()
+
+
+def polarion_xml_file_import(polarion_xml_file):
     """
     Import the xml file to Polarion to create testrun.
-    :param testrun_id: polarion testrun id
+    # :param testrun_id: polarion testrun id
     :param polarion_xml_file: the polarion xml file that match the polarion format
     """
     import_url = f"{args.url}/import/xunit"
-    testrun_url = f"{args.url}/#/project/{args.project}"
+    # testrun_url = f"{args.url}/#/project/{args.project}"
     cmd = (
         f"curl -k -u {args.username}:{args.password} -X POST -F "
         f"file=@{polarion_xml_file} {import_url}"
@@ -85,10 +91,21 @@ def polarion_xml_file_import(testrun_id, polarion_xml_file):
     logger.info(f"\n{cmd}")
     logger.info(output)
     if "error-message" not in output:
-        testrun = f"{testrun_url}/testrun?id={testrun_id}"
-        logger.info(f"Successed to import xml to polarion with link:\n{testrun}")
+        # testrun = f"{testrun_url}/testrun?id={testrun_id}"
+        logger.info(f"Successed to import xml to polarion")
     else:
         raise FailException("Failed to import xml to polarion")
+
+
+def polarion_testrun_id_get():
+    """
+    Get the testrun id in Polarion
+    """
+    testrun_url = f"{args.url}/#/project/{args.project}"
+    cmd = (
+        f"curl -k -u {args.username}:{args.password} -X GET -F "
+        f""
+    )
 
 
 def arguments_parser():
@@ -123,7 +140,10 @@ def arguments_parser():
         help="The project id, such as 'RHELSS'",
     )
     parser.add_argument(
-        "--id", required=False, default="", help="The testrun id, such as: RHSS"
+        "--template-id",
+        required=False,
+        default="",
+        help="The testrun template id"
     )
     parser.add_argument("--title", required=True, help="The testrun title")
     parser.add_argument(
@@ -153,14 +173,6 @@ def arguments_parser():
     parser.add_argument(
         "--plannedin", required=False, default="", help="The plans of polarion project"
     )
-
-    parser.add_argument(
-        "--subsystemteam",
-        required=False,
-        default="",
-        help="Subsystem Team, such as: sst_subscription_virtwho",
-    )
-    parser.add_argument("--type", required=False, default="regression", help="")
     parser.add_argument("--notes", required=False, default="", help="The custom notes")
     parser.add_argument(
         "--xml-file",


### PR DESCRIPTION
- [x] deleted the testrun id property from xml file, that created by betelgeues.
- [x] add new param `testrun-template-id`, which is useful to do some specified and stable setting.
- [x]  remove the `subsystemteam` and `type`, it seems they didn't take effect now and have set them in the testrun template.

**Local test result**
```
[2023-06-06 16:58:14] - [polarion_testrun_import.py] - INFO: {
  "files" : {
    "polarion_testrun.xml" : {
      "job-ids" : [ 3440071 ]
    }
  }
}

[2023-06-06 16:58:14] - [polarion_testrun_import.py] - INFO: Successed to import xml to polarion
```