### PR TITLE
Extented to wait for 30s after adding vm for local mode

### DIFF
--- a/virtwho/provision/virtwho_host.py
+++ b/virtwho/provision/virtwho_host.py
@@ -253,7 +253,7 @@ def local_mode_guest_add():
         )
     else:
         local.guest_start(guest_name)
-    time.sleep(15)
+    time.sleep(30)
     return local.guest_search(guest_name)
 
 


### PR DESCRIPTION
15s is not enough for the guest starting in local mode, so change to 30s.