### PR TITLE
register virt-who host when run for local mode

### DIFF
--- a/tests/function/test_cli.py
+++ b/tests/function/test_cli.py
@@ -15,6 +15,7 @@ from virtwho import HYPERVISOR_FILE, config
 from virtwho.base import encrypt_password
 
 
+@pytest.mark.usefixtures("function_host_register_for_local_mode")
 @pytest.mark.usefixtures("class_globalconf_clean")
 @pytest.mark.usefixtures("class_hypervisor")
 class TestCli:

--- a/tests/function/test_config.py
+++ b/tests/function/test_config.py
@@ -16,6 +16,7 @@ from virtwho import SYSCONFIG_FILE
 from virtwho.base import hostname_get
 
 
+@pytest.mark.usefixtures("function_host_register_for_local_mode")
 @pytest.mark.usefixtures("function_globalconf_clean")
 @pytest.mark.usefixtures("class_hypervisor")
 @pytest.mark.usefixtures("class_virtwho_d_conf_clean")

--- a/tests/function/test_service.py
+++ b/tests/function/test_service.py
@@ -15,6 +15,7 @@ from virtwho import HYPERVISOR, REGISTER
 from virtwho.ssh import SSHConnect
 
 
+@pytest.mark.usefixtures("function_host_register_for_local_mode")
 @pytest.mark.usefixtures("class_hypervisor")
 @pytest.mark.usefixtures("class_virtwho_d_conf_clean")
 @pytest.mark.usefixtures("class_globalconf_clean")

--- a/tests/hypervisor/test_default.py
+++ b/tests/hypervisor/test_default.py
@@ -15,6 +15,7 @@ from virtwho.base import hostname_get
 from virtwho.configure import hypervisor_create
 
 
+@pytest.mark.usefixtures("function_host_register_for_local_mode")
 @pytest.mark.usefixtures("function_virtwho_d_conf_clean")
 @pytest.mark.usefixtures("class_debug_true")
 @pytest.mark.usefixtures("class_globalconf_clean")

--- a/tests/hypervisor/test_local.py
+++ b/tests/hypervisor/test_local.py
@@ -12,6 +12,7 @@ import time
 from hypervisor import logger
 
 
+@pytest.mark.usefixtures("function_host_register_for_local_mode")
 @pytest.mark.usefixtures("function_virtwho_d_conf_clean")
 @pytest.mark.usefixtures("class_debug_true")
 @pytest.mark.usefixtures("class_globalconf_clean")

--- a/tests/package/test_upgrade_downgrade.py
+++ b/tests/package/test_upgrade_downgrade.py
@@ -26,6 +26,7 @@ if "RHEL-8" in RHEL_COMPOSE:
 @pytest.mark.usefixtures("function_globalconf_clean")
 @pytest.mark.usefixtures("class_hypervisor")
 @pytest.mark.usefixtures("class_virtwho_d_conf_clean")
+@pytest.mark.usefixtures("function_host_register_for_local_mode")
 class TestUpgradeDowngrade:
     @pytest.mark.tier1
     def test_upgrade_downgrade_by_yum(self, ssh_host, virtwho, globalconf):


### PR DESCRIPTION
local mode doesn't support the rhsm_x options, so need to register virt-who host.