### PR TITLE
Fix the ahv_assersion function for ahv test cases

### DIFF
--- a/tests/hypervisor/conftest.py
+++ b/tests/hypervisor/conftest.py
@@ -225,11 +225,6 @@ def ahv_assertion():
     :return:
     """
     login_error = "HTTP Auth Failed get"
-
-    username_password_non_ascii_error = "internal error: Unable to parse URI qemu+ssh"
-    if "RHEL-9" in RHEL_COMPOSE:
-        username_password_non_ascii_error = login_error
-
     data = {
         "type": {
             "invalid": {
@@ -254,7 +249,7 @@ def ahv_assertion():
         "username": {
             "invalid": {
                 "xxx": login_error,
-                "红帽€467aa": username_password_non_ascii_error,
+                "红帽€467aa": login_error,
                 "": login_error,
             },
             "disable": 'Required option: "username" not set',
@@ -262,16 +257,17 @@ def ahv_assertion():
         "password": {
             "invalid": {
                 "xxx": login_error,
-                "红帽€467aa": username_password_non_ascii_error,
+                "红帽€467aa": login_error,
                 "": login_error,
             },
             "disable": 'Required option: "password" not set',
         },
         "encrypted_password": {
             "invalid": {
-                "xxx": "",
-                "": "",
+                "xxx": 'Required option: "password" not set',
+                "": 'Required option: "password" not set',
             },
+            "valid_multi_configs": 'Required option: "password" not set',
         },
     }
 

--- a/tests/hypervisor/test_ahv.py
+++ b/tests/hypervisor/test_ahv.py
@@ -476,7 +476,7 @@ class TestAHVNegative:
 
     @pytest.mark.tier2
     def test_encrypted_password(
-        self, virtwho, function_hypervisor, hyperv_assertion, hypervisor_data, ssh_host
+        self, virtwho, function_hypervisor, ahv_assertion, hypervisor_data, ssh_host
     ):
         """Test the encrypted_password= option in /etc/virt-who.d/test_ahv.conf
 
@@ -497,7 +497,7 @@ class TestAHVNegative:
         """
         # encrypted_password option is invalid value
         function_hypervisor.delete("password")
-        assertion = hyperv_assertion["encrypted_password"]
+        assertion = ahv_assertion["encrypted_password"]
         assertion_invalid_list = list(assertion["invalid"].keys())
         for value in assertion_invalid_list:
             function_hypervisor.update("encrypted_password", value)


### PR DESCRIPTION
**Description**

- [x] tests.hypervisor.test_ahv.TestAHVNegative.test_username
- [x] tests.hypervisor.test_ahv.TestAHVNegative.test_password

Ahv cases for rhel8 failed due to the error msg:
` -1 and 'internal error: Unable to parse URI qemu+ssh' in "2023-06-08 22:05:41,318 [virtwho.main ERROR] MainProcess(311267):Thread-2 @virt.py:run:416 - Thread 'virtwho-ahv' fails with error: HTTP Auth Failed get https://10.73.131.191:9440/api/nutanix/v2.0/clusters. \n")`
The assersion info for rhel8 is not correct, need to update

**Test Result**
All passed locally