### PR TITLE
Fix test case: test_hypervisor_id

### DIFF
--- a/tests/hypervisor/test_rhevm.py
+++ b/tests/hypervisor/test_rhevm.py
@@ -88,7 +88,7 @@ class TestRHEVMPositive:
             )
             if REGISTER == "rhsm":
                 assert rhsm.consumers(hypervisor_data["hypervisor_hostname"])
-                rhsm.delete(hypervisor_data["hypervisor_hostname"])
+                rhsm.host_delete(hypervisor_data["hypervisor_hostname"])
             else:
                 if hypervisor_id == "hostname":
                     assert satellite.host_id(hypervisor_data["hypervisor_hostname"])


### PR DESCRIPTION
**Description**
Test case failed due to the error msg:
`AttributeError: 'RHSM' object has no attribute 'delete'`, need to update the case

**Test Result**
Passed locally