### PR TITLE
Debug Hypervisor failed test cases in rhel9.3.0 CTC1

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -83,6 +83,18 @@ def class_debug_true(globalconf):
     globalconf.update("global", "debug", "true")
 
 
+@pytest.fixture(scope="function")
+def function_debug_true(globalconf):
+    """Set the debug=True in /etc/virt-who.conf"""
+    globalconf.update("global", "debug", "true")
+
+
+@pytest.fixture(scope="function")
+def function_debug_false(globalconf):
+    """Set the debug=False in /etc/virt-who.conf"""
+    globalconf.update("global", "debug", "false")
+
+
 @pytest.fixture(scope="session")
 def virtwho():
     """Instantication of class VirtwhoRunner()"""

--- a/tests/hypervisor/conftest.py
+++ b/tests/hypervisor/conftest.py
@@ -281,7 +281,9 @@ def libvirt_assertion():
     :return:
     """
     login_error = "fails with error: Cannot recv data"
-    server_disable_error = "Failed to connect socket to '/var/run/libvirt/libvirt-sock-ro'"
+    server_disable_error = (
+        "Failed to connect socket to '/var/run/libvirt/libvirt-sock-ro'"
+    )
     if "RHEL-9" in RHEL_COMPOSE:
         server_disable_error = "Cannot use direct socket mode if no URI is set"
     data = {

--- a/tests/hypervisor/conftest.py
+++ b/tests/hypervisor/conftest.py
@@ -281,6 +281,9 @@ def libvirt_assertion():
     :return:
     """
     login_error = "fails with error: Cannot recv data"
+    server_disable_error = "Failed to connect socket to '/var/run/libvirt/libvirt-sock-ro'"
+    if "RHEL-9" in RHEL_COMPOSE:
+        server_disable_error = "Cannot use direct socket mode if no URI is set"
     data = {
         "type": {
             "invalid": {
@@ -298,7 +301,7 @@ def libvirt_assertion():
                 "红帽€467aa": "internal error: Unable to parse URI qemu+ssh",
                 "": "Cannot recv data: Host key verification failed.",
             },
-            "disable": "Failed to connect socket to '/var/run/libvirt/libvirt-sock-ro'",
+            "disable": server_disable_error,
         },
         "username": {
             "invalid": {

--- a/tests/hypervisor/test_default.py
+++ b/tests/hypervisor/test_default.py
@@ -248,7 +248,7 @@ class TestHypervisorPositive:
         function_hypervisor,
         hypervisor_data,
         register_data,
-        function_debug_false
+        function_debug_false,
     ):
         """
         :title: virt-who: hypervisor: test the virtwho status

--- a/tests/hypervisor/test_default.py
+++ b/tests/hypervisor/test_default.py
@@ -10,6 +10,7 @@ import pytest
 
 from virtwho import REGISTER
 from virtwho import HYPERVISOR
+from virtwho import logger
 
 from virtwho.base import hostname_get
 from virtwho.configure import hypervisor_create
@@ -17,7 +18,7 @@ from virtwho.configure import hypervisor_create
 
 @pytest.mark.usefixtures("function_host_register_for_local_mode")
 @pytest.mark.usefixtures("function_virtwho_d_conf_clean")
-@pytest.mark.usefixtures("class_debug_true")
+@pytest.mark.usefixtures("function_debug_true")
 @pytest.mark.usefixtures("class_globalconf_clean")
 class TestHypervisorPositive:
     @pytest.mark.tier1
@@ -242,7 +243,12 @@ class TestHypervisorPositive:
     @pytest.mark.notRHEL8
     @pytest.mark.notLocal
     def test_virtwho_status(
-        self, virtwho, function_hypervisor, hypervisor_data, register_data
+        self,
+        virtwho,
+        function_hypervisor,
+        hypervisor_data,
+        register_data,
+        function_debug_false
     ):
         """
         :title: virt-who: hypervisor: test the virtwho status
@@ -268,14 +274,14 @@ class TestHypervisorPositive:
         assert result["error"] == 0 and result["send"] == 1 and result["thread"] == 0
 
         # Check '#virt-who --status' with good configuration
-        result = virtwho.run_cli(oneshot=False, status=True)
+        result = virtwho.run_cli(oneshot=False, debug=False, status=True)
         assert (
             "success" in result[function_hypervisor.section]["source_status"]
             and "success" in result[function_hypervisor.section]["destination_status"]
         )
 
         # Check #virt-who --status --json
-        result = virtwho.run_cli(oneshot=False, status=True, jsn=True)
+        result = virtwho.run_cli(oneshot=False, debug=False, status=True, jsn=True)
         if "libvirt" in HYPERVISOR:
             source_connection = f"qemu+ssh://root@{hypervisor_data['hypervisor_server']}/system?no_tty=1"
         elif "esx" in HYPERVISOR:
@@ -308,7 +314,9 @@ class TestHypervisorPositive:
             option = "server"
         function_hypervisor.update(option, "xxx")
         function_hypervisor.update("owner", "xxx")
-        result = virtwho.run_cli(oneshot=False, status=True, jsn=True)
+        result = virtwho.run_cli(oneshot=False, debug=False, status=True, jsn=True)
+        if HYPERVISOR == "ahv":
+            logger.info("=== AHV: failed with bz2177721 ===")
         assert (
             result[function_hypervisor.section]["source"]["status"] == "failure"
             and result[function_hypervisor.section]["destination"]["status"]

--- a/tests/hypervisor/test_esx.py
+++ b/tests/hypervisor/test_esx.py
@@ -1172,7 +1172,7 @@ class TestEsxNegative:
         assert result["error"] == 0 and result["send"] == 1 and result["thread"] == 1
 
     @pytest.mark.tier2
-    @pytest.mark.notStage
+    @pytest.mark.notRHSM
     def test_hypervisors_fqdn(
         self, virtwho, function_hypervisor, hypervisor_data, satellite, ssh_host
     ):

--- a/tests/hypervisor/test_kubevirt.py
+++ b/tests/hypervisor/test_kubevirt.py
@@ -224,19 +224,10 @@ class TestKubevirtNegative:
             and assertion["disable"] in result["error_msg"]
         )
 
-        # type option is disable but another config is ok
+        # type option is null but another config is ok
         hypervisor_create(
             HYPERVISOR, REGISTER, SECOND_HYPERVISOR_FILE, SECOND_HYPERVISOR_SECTION
         )
-        result = virtwho.run_service()
-        assert (
-            result["error"] is not 0
-            and result["send"] == 1
-            and result["thread"] == 1
-            and assertion["disable_multi_configs"] in result["error_msg"]
-        )
-
-        # type option is null but another config is ok
         function_hypervisor.update("type", "")
         result = virtwho.run_service()
         assert result["send"] == 1 and result["thread"] == 1


### PR DESCRIPTION
- [x] `test_virtwho_status`: set debug=false, ahv failed with bz217721
- [x]  `conftest.py`: add function_debug_true and function_debug_false 
- [x]  `test_hypervisors_fqdn`: change mark notRHSM 
- [x] `test_type` for kubevirt mode:  remove the unnecessary step
- [x] `test_libvirt.py: test_server `: log error redefine for rhel9 