### PR TITLE
Debug Libvirt local failed test cases in rhel9.3.0 CTC1

### DIFF
--- a/tests/function/test_config.py
+++ b/tests/function/test_config.py
@@ -202,6 +202,7 @@ class TestConfiguration:
         )
 
     @pytest.mark.tier1
+    @pytest.mark.notLocal
     def test_log_per_config_in_virtwho_conf(
         self, virtwho, globalconf, hypervisor_data, ssh_host
     ):
@@ -355,6 +356,7 @@ class TestConfiguration:
         )
 
     @pytest.mark.tier1
+    @pytest.mark.notLocal
     def test_owner_in_virtwho_conf(
         self,
         virtwho,
@@ -407,6 +409,7 @@ class TestConfiguration:
         )
 
     @pytest.mark.tier1
+    @pytest.mark.notLocal
     def test_hypervisor_id_in_virtwho_conf(
         self,
         virtwho,
@@ -479,6 +482,7 @@ class TestConfiguration:
                     assert not satellite.host_id(hypervisor_data["hypervisor_uuid"])
 
     @pytest.mark.tier1
+    @pytest.mark.notLocal
     def test_http_proxy_in_virtwho_conf(self, virtwho, globalconf, proxy_data):
         """Test the http_proxy, https_proxy and no_proxy options in /etc/virtwho.conf
 
@@ -540,6 +544,7 @@ class TestConfiguration:
             globalconf.delete("system_environment")
 
 
+@pytest.mark.usefixtures("function_host_register_for_local_mode")
 @pytest.mark.usefixtures("function_globalconf_clean")
 @pytest.mark.usefixtures("class_hypervisor")
 @pytest.mark.usefixtures("class_virtwho_d_conf_clean")
@@ -686,6 +691,7 @@ class TestSysConfiguration:
         )
 
 
+@pytest.mark.usefixtures("function_host_register_for_local_mode")
 @pytest.mark.usefixtures("function_globalconf_clean")
 @pytest.mark.usefixtures("class_hypervisor")
 @pytest.mark.usefixtures("class_virtwho_d_conf_clean")

--- a/tests/hypervisor/test_default.py
+++ b/tests/hypervisor/test_default.py
@@ -112,6 +112,7 @@ class TestHypervisorPositive:
             assert satellite.associate_on_webui(host_name, guest_hostname)
 
     @pytest.mark.tier1
+    @pytest.mark.notLocal
     def test_mapping_info(
         self,
         virtwho,
@@ -379,7 +380,7 @@ class TestHypervisorPositive:
         assert result["error"] == 0 and result["send"] == 1 and result["thread"] == 1
 
         # delete hypervisor from webui
-        if HYPERVISOR is not "local":
+        if HYPERVISOR != "local":
             if REGISTER == "rhsm":
                 rhsm.host_delete(host_name)
             else:

--- a/tests/hypervisor/test_default.py
+++ b/tests/hypervisor/test_default.py
@@ -370,7 +370,7 @@ class TestHypervisorPositive:
             result["error"] is not 0
             and result["send"] == 0
             and result["thread"] == 1
-            and error_msg in result["error_msg"]
+            and error_msg in result["log"]
         )
 
         # re-register host and run virt-who

--- a/tests/subscription/test_satellite.py
+++ b/tests/subscription/test_satellite.py
@@ -194,6 +194,8 @@ class TestSatelliteScaDisable:
             and consumed_data["temporary"] is True
         )
 
+        if HYPERVISOR == "local":
+            sm_host.register()
         _ = virtwho.run_cli()
         satellite.attach(host=hypervisor_hostname, pool=vdc_pool_physical)
 
@@ -384,7 +386,7 @@ class TestSatelliteScaDisable:
 
     @pytest.mark.tier2
     def test_guest_auto_attach_temporary_pool_by_activation_key(
-        self, virtwho, sm_guest_ack, satellite, hypervisor_data
+        self, virtwho, sm_guest_ack, satellite, hypervisor_data, sm_host
     ):
         """Test the guest can auto attach temporary sku when registering with
             activation key
@@ -424,12 +426,15 @@ class TestSatelliteScaDisable:
         consumed_data = sm_guest_ack.consumed(vdc_virtual_sku)
         assert consumed_data["temporary"] is True
 
+        if HYPERVISOR == "local":
+            sm_host.register()
         _ = virtwho.run_cli()
         sm_guest_ack.refresh()
         consumed_data = sm_guest_ack.consumed(vdc_virtual_sku)
         assert consumed_data["temporary"] is False
 
     @pytest.mark.tier2
+    @pytest.mark.notLocal
     def test_non_default_org_with_rhsm_options(
         self,
         virtwho,
@@ -500,6 +505,7 @@ class TestSatelliteScaDisable:
             satellite_second_org.host_delete(host=hypervisor_hostname)
 
     @pytest.mark.tier2
+    @pytest.mark.notLocal
     def test_non_default_org_without_rhsm_options(
         self,
         virtwho,
@@ -609,7 +615,8 @@ class TestSatelliteScaDisable:
             hypervisor_name = [key, key.lower()]
 
         # check the subscription without virtual vdc pool attached for guest
-        satellite.host_delete(host=hypervisor_hostname)
+        if HYPERVISOR != "local":
+            satellite.host_delete(host=hypervisor_hostname)
         _ = virtwho.run_cli()
         satellite.attach(host=hypervisor_hostname, pool=vdc_pool_physical)
         vdc_virt_data = sm_guest.available(vdc_virtual_sku, "Virtual")
@@ -628,7 +635,7 @@ class TestSatelliteScaDisable:
             and subscription["consumed"] == 0
         )
 
-        # check the subscription without virtual vdc pool attached for guest
+        # check the subscription with virtual vdc pool attached for guest
         sm_guest.refresh()
         sm_guest.attach(pool=vdc_virt_pool)
         for i in range(3):

--- a/virtwho/configure.py
+++ b/virtwho/configure.py
@@ -71,7 +71,7 @@ class VirtwhoHypervisorConfig:
                 self.update("username", self.hypervisor.username)
                 self.update("password", self.hypervisor.password)
             self.update("owner", self.register.default_org)
-        if rhsm is True:
+        if rhsm is True and HYPERVISOR != "local":
             self.update("rhsm_hostname", self.register.server)
             self.update("rhsm_username", self.register.username)
             self.update("rhsm_password", self.register.password)

--- a/virtwho/register.py
+++ b/virtwho/register.py
@@ -634,7 +634,7 @@ class Satellite:
         output = json.loads(output)
         if ret == 0 and len(output) >= 1:
             for item in output:
-                if host or host.lower() in item["Name"]:
+                if host in item["Name"] or host.lower() in item["Name"]:
                     host_id = item["Id"]
                     logger.info(f"Succeeded to get the host id, {host}:{host_id}")
                     return host_id


### PR DESCRIPTION
- [x] test_config.py: update to support local mode 
- [x] test_delete_host_hypervisor
- [x] test_vdc_virtual_pool_attach_by_poolId 
- [x] test_vdc_virtual_pool_attach_by_auto
- [x] test_vdc_temporary_pool_by_poolId
- [x] test_vdc_virtual_pool_attach_in_fake_mode
- [x] test_guest_auto_attach_rule_by_activation_key
- [x] test_guest_auto_attach_temporary_pool_by_activation_key
- [x] test_non_default_org_with_rhsm_options
- [x] test_non_default_org_without_rhsm_options
- [x] test_vdc_virtual_subscription_on_webui

All the cases were rerun pass locally.