### PR TITLE
Expand the time sleep when starting the libvirt guest

### DIFF
--- a/virtwho/provision/virtwho_host.py
+++ b/virtwho/provision/virtwho_host.py
@@ -256,7 +256,7 @@ def local_mode_guest_add(ssh):
         )
     else:
         local.guest_start(guest_name)
-    time.sleep(15)
+    time.sleep(60)
     return local.guest_search(guest_name)
 
 


### PR DESCRIPTION
As subject, to fix the error when starting the guest:
```
Traceback (most recent call last):
  File "/home/jenkins/workspace/regression-el8/REGRESSION-TRIGGER/virtwho-test/virtwho/provision/virtwho_host.py", line 353, in <module>
    provision_virtwho_host(args)
  File "/home/jenkins/workspace/regression-el8/REGRESSION-TRIGGER/virtwho-test/virtwho/provision/virtwho_host.py", line 111, in provision_virtwho_host
    virtwho_ini_props_update(args)
  File "/home/jenkins/workspace/regression-el8/REGRESSION-TRIGGER/virtwho-test/utils/properties_update.py", line 18, in virtwho_ini_props_update
    config.update(args.section, args.option, args.value)
  File "/home/jenkins/workspace/regression-el8/REGRESSION-TRIGGER/virtwho-test/virtwho/settings.py", line 56, in update
    self.config.set(section, option, value)
  File "/usr/lib64/python3.10/configparser.py", line 1204, in set
    self._validate_value_types(option=option, value=value)
  File "/usr/lib64/python3.10/configparser.py", line 1189, in _validate_value_types
    raise TypeError("option values must be strings")
TypeError: option values must be strings
```