### PR TITLE
Update test case test_associated_info_by_rhsmlog_and_webui

### DIFF
--- a/tests/hypervisor/test_default.py
+++ b/tests/hypervisor/test_default.py
@@ -79,7 +79,13 @@ class TestHypervisorPositive:
 
     @pytest.mark.tier1
     def test_associated_info_by_rhsmlog_and_webui(
-        self, virtwho, function_hypervisor, hypervisor_data, rhsm, satellite, register_data
+        self,
+        virtwho,
+        function_hypervisor,
+        hypervisor_data,
+        rhsm,
+        satellite,
+        register_data,
     ):
         """
         :title: virt-who: hypervisor: check associated info by rhsm.log and webui
@@ -106,7 +112,9 @@ class TestHypervisorPositive:
 
         # check host-to-guest association in rhsm.log
         mappings = result["mappings"]
-        associated_hypervisor_in_mapping = mappings[default_org][guest_uuid]["guest_hypervisor"]
+        associated_hypervisor_in_mapping = mappings[default_org][guest_uuid][
+            "guest_hypervisor"
+        ]
         assert associated_hypervisor_in_mapping == host_name
 
         # check host-to-guest association in webui

--- a/tests/hypervisor/test_default.py
+++ b/tests/hypervisor/test_default.py
@@ -79,7 +79,7 @@ class TestHypervisorPositive:
 
     @pytest.mark.tier1
     def test_associated_info_by_rhsmlog_and_webui(
-        self, virtwho, function_hypervisor, hypervisor_data, rhsm, satellite
+        self, virtwho, function_hypervisor, hypervisor_data, rhsm, satellite, register_data
     ):
         """
         :title: virt-who: hypervisor: check associated info by rhsm.log and webui
@@ -99,12 +99,15 @@ class TestHypervisorPositive:
         host_name = hypervisor_data["hypervisor_hostname"]
         guest_uuid = hypervisor_data["guest_uuid"]
         guest_hostname = hypervisor_data["guest_hostname"]
+        default_org = register_data["default_org"]
 
         result = virtwho.run_service()
         assert result["error"] == 0 and result["send"] == 1 and result["thread"] == 1
 
         # check host-to-guest association in rhsm.log
-        assert guest_uuid in result["log"]
+        mappings = result["mappings"]
+        associated_hypervisor_in_mapping = mappings[default_org][guest_uuid]["guest_hypervisor"]
+        assert associated_hypervisor_in_mapping == host_name
 
         # check host-to-guest association in webui
         if REGISTER == "rhsm":


### PR DESCRIPTION
**Descirption**
Update the step about `check host-to-guest association in rhsm.log`
**Test Result**
```
(env) [hkx303@kuhuang virtwho-test]$ pytest tests/hypervisor/test_default.py -k test_associated_info_by_rhsmlog_and_webui -s
/home/hkx303/Documents/CI/virtwho-test/env/lib/python3.7/site-packages/paramiko/transport.py:216: CryptographyDeprecationWarning: Blowfish has been deprecated
  "class": algorithms.Blowfish,
================================ test session starts =================================
platform linux -- Python 3.7.3, pytest-5.4.3, py-1.11.0, pluggy-0.13.1
rootdir: /home/hkx303/Documents/CI/virtwho-test, inifile: pytest.ini
plugins: services-1.3.1, xdist-1.34.0, mock-1.10.4, forked-1.4.0
collected 6 items / 5 deselected / 1 selected   
=============== 1 passed, 5 deselected, 2 warnings in 77.13s (0:01:17) ===============
```
