### PR TITLE
design the sca/enable cases around subscription

### DIFF
--- a/tests/subscription/test_rhsm.py
+++ b/tests/subscription/test_rhsm.py
@@ -393,7 +393,7 @@ class TestRhsmScaDisable:
 class TestRhsmScaEnable:
     @pytest.mark.tier1
     def test_hypervisor_entitlement_status(
-            self, virtwho, hypervisor_data, rhsm, vdc_pool_physical
+        self, virtwho, hypervisor_data, rhsm, vdc_pool_physical
     ):
         """Test the hypervisor entitlement status.
 
@@ -429,7 +429,7 @@ class TestRhsmScaEnable:
         function_guest_register,
         hypervisor_data,
         rhsm,
-        vdc_pool_physical
+        vdc_pool_physical,
     ):
         """
 

--- a/tests/subscription/test_rhsm.py
+++ b/tests/subscription/test_rhsm.py
@@ -406,12 +406,11 @@ class TestRhsmScaEnable:
         :steps:
 
             1. run virt-who to report mappings
-            2. try to auto-attach subscription for hypervisor
+            2. try to attach vdc sku for hypervisor
 
         :expectedresults:
 
-            get the 'This host's organization is in Simple Content Access
-                mode. Auto-attach is disabled'
+            failed to attach any sku with sca enabled. bz2017774 exists for rhsm.
         """
         hypervisor_hostname = hypervisor_data["hypervisor_hostname"]
         result = virtwho.run_cli()
@@ -443,15 +442,16 @@ class TestRhsmScaEnable:
 
             1. register guest
             2. check the #subscription-manager status
-            3. try to auto-attach subscription for guest
-            4. try to attach subscription for guest by rhsm web
+            3. try to attach vdc sku for guest by terminal
+            4. try to attach vdc sku for guest by rhsm web
 
         :expectedresults:
 
-            2. get the output with 'Content Access Mode is set to Simple Content
-                Access' by #subscription-manager status
-            3. get the 'This host's organization is in Simple Content Access
-                mode. Auto-attach is disabled'
+            2. get the output with 'Content Access Mode is set to Simple Content Access.
+            This host has access to content, regardless of subscription status'
+            3. get the 'Attaching subscriptions is disabled .* because Simple Content
+            Access .* is enabled.'
+            4. failed to attach any sku with sca enabled. bz2017774 exists for rhsm.
         """
         guest_hostname = hypervisor_data["guest_hostname"]
         virtwho.run_cli()

--- a/tests/subscription/test_rhsm.py
+++ b/tests/subscription/test_rhsm.py
@@ -398,7 +398,7 @@ class TestRhsmScaEnable:
         """Test the hypervisor entitlement status.
 
         :title: virt-who: rhsm: [sca/enable] test hypervisor entitlement status
-        :id:
+        :id: c505edb4-9afa-401f-bc3d-f562d8081955
         :caseimportance: High
         :tags: subscription,rhsm,tier1
         :customerscenario: false
@@ -434,7 +434,7 @@ class TestRhsmScaEnable:
         """
 
         :title: virt-who: rhsm: [sca/enable] test guest entitlement status
-        :id:
+        :id: 20c09b1b-f23e-4691-b927-ed5262c188da
         :caseimportance: High
         :tags: subscription,rhsm,tier1
         :customerscenario: false

--- a/tests/subscription/test_satellite.py
+++ b/tests/subscription/test_satellite.py
@@ -10,7 +10,7 @@ import time
 import pytest
 from virtwho.base import msg_search
 from virtwho.settings import config
-from virtwho import HYPERVISOR, FAKE_CONFIG_FILE, logger
+from virtwho import HYPERVISOR, FAKE_CONFIG_FILE
 from virtwho.configure import hypervisor_create
 from virtwho.configure import get_hypervisor_handler
 from virtwho.register import SubscriptionManager, Satellite

--- a/tests/subscription/test_satellite.py
+++ b/tests/subscription/test_satellite.py
@@ -10,7 +10,7 @@ import time
 import pytest
 from virtwho.base import msg_search
 from virtwho.settings import config
-from virtwho import HYPERVISOR, FAKE_CONFIG_FILE
+from virtwho import HYPERVISOR, FAKE_CONFIG_FILE, logger
 from virtwho.configure import hypervisor_create
 from virtwho.configure import get_hypervisor_handler
 from virtwho.register import SubscriptionManager, Satellite
@@ -41,7 +41,7 @@ class TestSatelliteScaDisable:
     ):
         """Test the guest can get and attach the virtual vdc pool by pool id
 
-        :title: virt-who: satellite: test guest attach virtual vdc pool by pool id
+        :title: virt-who: satellite: [sca/disable] test guest attach virtual vdc pool by pool id
         :id: 38e213ef-70cc-445a-85b2-8f9639064f12
         :caseimportance: High
         :tags: subscription,satellite,tier1
@@ -93,7 +93,7 @@ class TestSatelliteScaDisable:
     ):
         """Test the guest can get and attach the virtual vdc pool by auto
 
-        :title: virt-who: satellite: test guest attach virtual vdc pool by auto
+        :title: virt-who: satellite: [sca/disable] test guest attach virtual vdc pool by auto
         :id: 812aac00-5b4d-4307-bb4e-bdd774330128
         :caseimportance: High
         :tags: subscription,satellite,tier1
@@ -151,7 +151,7 @@ class TestSatelliteScaDisable:
     ):
         """Test the temporary vdc pool in guest
 
-        :title: virt-who: satellite: test temporary vdc pool in guest
+        :title: virt-who: satellite: [sca/disable] test temporary vdc pool in guest
         :id: 733ce7d0-bb51-4d80-87cc-a5ee5fbdf542
         :caseimportance: High
         :tags: subscription,satellite,tier1
@@ -223,8 +223,7 @@ class TestSatelliteScaDisable:
     ):
         """Test the guest can get and attach the virtual vdc pool in fake mode
 
-        :title: virt-who: satellite: test guest attach virtual vdc pool in
-            fake mode
+        :title: virt-who: satellite: [sca/disable] test guest attach virtual vdc pool in fake mode
         :id: 164f2d20-d357-4f25-a0e4-f5260012a266
         :caseimportance: High
         :tags: subscription,satellite,tier1
@@ -291,7 +290,7 @@ class TestSatelliteScaDisable:
     ):
         """Test the guest register by activation_key
 
-        :title: virt-who: satellite: test guest attach rule by activation_key
+        :title: virt-who: satellite: [sca/disable] test guest attach rule by activation_key
         :id: 6d0e169c-74a7-41a0-a97a-81e084f0aabf
         :caseimportance: High
         :tags: subscription,satellite,tier2
@@ -397,8 +396,7 @@ class TestSatelliteScaDisable:
         """Test the guest can auto attach temporary sku when registering with
             activation key
 
-        :title: virt-who: satellite: test guest auto attach temporay sku with
-            activation key
+        :title: virt-who: satellite: [sca/disable] test guest auto attach temporay sku with activation key
         :id: ae58e185-3e78-4c3d-90fb-c5bd1ff01382
         :caseimportance: Medium
         :tags: subscription,satellite,tier2
@@ -461,7 +459,7 @@ class TestSatelliteScaDisable:
     ):
         """
 
-        :title: virt-who: satellite: test non-default org with rhsm options
+        :title: virt-who: satellite: [sca/disable] test non-default org with rhsm options
         :id: c372adf9-645e-4b79-9bcd-af462e5be03a
         :caseimportance: High
         :tags: subscription,satellite,tier2
@@ -533,8 +531,7 @@ class TestSatelliteScaDisable:
     ):
         """
 
-        :title: virt-who: satellite: test the non-default org without
-            rhsm options
+        :title: virt-who: satellite: [sca/disable] test the non-default org without rhsm options
         :id: e6702ccb-d0ad-4215-9503-cf973c14b31c
         :caseimportance: High
         :tags: subscription,satellite,tier2
@@ -600,7 +597,7 @@ class TestSatelliteScaDisable:
     ):
         """Test the virtual vdc content subscriptions on satellite webui
 
-        :title: virt-who: satellite: test vdc virtual subscriptions on webui
+        :title: virt-who: satellite: [sca/disable] test vdc virtual subscriptions on webui
         :id: 5c71d37c-b5e2-4789-87f6-24357a96819b
         :caseimportance: Medium
         :tags: subscription,satellite,tier2
@@ -694,15 +691,83 @@ class TestSatelliteScaDisable:
     #     assert register_by == 'admin'
 
 
-# @pytest.mark.usefixtures("module_satellite_sca_recover")
-# @pytest.mark.usefixtures("class_hypervisor")
-# @pytest.mark.usefixtures("class_virtwho_d_conf_clean")
-# @pytest.mark.usefixtures("class_globalconf_clean")
-# @pytest.mark.usefixtures("function_guest_unattach")
-# @pytest.mark.usefixtures("class_guest_register")
-# @pytest.mark.usefixtures("function_host_register_for_local_mode")
-# @pytest.mark.usefixtures("class_satellite_sca_enable")
-# class TestSatelliteScaEnable:
+@pytest.mark.usefixtures("module_satellite_sca_recover")
+@pytest.mark.usefixtures("class_hypervisor")
+@pytest.mark.usefixtures("class_virtwho_d_conf_clean")
+@pytest.mark.usefixtures("class_globalconf_clean")
+@pytest.mark.usefixtures("function_guest_unattach")
+@pytest.mark.usefixtures("class_guest_register")
+@pytest.mark.usefixtures("function_host_register_for_local_mode")
+@pytest.mark.usefixtures("class_satellite_sca_enable")
+class TestSatelliteScaEnable:
+    @pytest.mark.tier1
+    def test_hypervisor_entitlement_status(self, virtwho, hypervisor_data, satellite, vdc_pool_physical):
+        """Test the hypervisor entitlement status.
+
+        :title: virt-who: satellite: [sca/enable] test hypervisor entitlement status
+        :id:
+        :caseimportance: High
+        :tags: subscription,satellite,tier1
+        :customerscenario: false
+        :upstream: no
+        :steps:
+
+            1. run virt-who to report mappings
+            2. try to auto-attach subscription for hypervisor
+
+        :expectedresults:
+
+            get the 'This host's organization is in Simple Content Access
+                mode. Auto-attach is disabled'
+        """
+        hypervisor_hostname = hypervisor_data["hypervisor_hostname"]
+        result = virtwho.run_cli()
+        assert result["send"] == 1 and result["error"] == 0
+
+        msg ="This host's organization is in Simple Content Access mode. Attaching subscriptions is disabled."
+        result = satellite.attach(host=hypervisor_hostname, pool=vdc_pool_physical)
+        assert msg_search(result, msg)
+
+    @pytest.mark.tier1
+    def test_guest_entitlement_status(
+        self, virtwho, ssh_guest, sm_guest, function_guest_register, hypervisor_data, satellite, vdc_pool_physical
+    ):
+        """
+
+        :title: virt-who: satellite: [sca/enable] test guest entitlement status
+        :id:
+        :caseimportance: High
+        :tags: subscription,rhsm,tier1
+        :customerscenario: false
+        :upstream: no
+        :steps:
+
+            1. register guest
+            2. check the #subscription-manager status
+            3. try to auto-attach subscription for guest
+            4. try to attach subscription for guest by satellite web
+
+        :expectedresults:
+
+            2. get the output with 'Content Access Mode is set to Simple Content
+                Access' by #subscription-manager status
+            3. get the 'This host's organization is in Simple Content Access
+                mode. Auto-attach is disabled'
+        """
+        guest_hostname = hypervisor_data["guest_hostname"]
+        # virtwho.run_cli()
+
+        ret, output = ssh_guest.runcmd("subscription-manager status")
+        msg = "Content Access Mode is set to Simple Content Access"
+        assert msg_search(output, msg)
+
+        output = sm_guest.attach(pool=vdc_pool_physical)
+        msg = "Attaching subscriptions is disabled .* because Simple Content Access .* is enabled."
+        assert msg_search(output, msg)
+
+        msg = "This host's organization is in Simple Content Access mode. Attaching subscriptions is disabled."
+        result = satellite.attach(host=guest_hostname, pool=vdc_pool_physical)
+        assert msg in result
 
 
 @pytest.fixture(scope="class")
@@ -769,6 +834,12 @@ def satellite_second_org():
 def class_satellite_sca_disable(satellite):
     """Disable sca mode for default org"""
     satellite.sca(org=None, sca="disable")
+
+
+@pytest.fixture(scope="class")
+def class_satellite_sca_enable(satellite):
+    """Enable sca mode for default org"""
+    satellite.sca(org=None, sca="enable")
 
 
 @pytest.fixture(scope="module")

--- a/tests/subscription/test_satellite.py
+++ b/tests/subscription/test_satellite.py
@@ -707,7 +707,7 @@ class TestSatelliteScaEnable:
         """Test the hypervisor entitlement status.
 
         :title: virt-who: satellite: [sca/enable] test hypervisor entitlement status
-        :id:
+        :id: bda68020-b17e-4442-bcfd-91537e9499e1
         :caseimportance: High
         :tags: subscription,satellite,tier1
         :customerscenario: false
@@ -744,7 +744,7 @@ class TestSatelliteScaEnable:
         """
 
         :title: virt-who: satellite: [sca/enable] test guest entitlement status
-        :id:
+        :id: fcbb4e43-da1e-49c8-a454-0f0979a7717a
         :caseimportance: High
         :tags: subscription,rhsm,tier1
         :customerscenario: false

--- a/tests/subscription/test_satellite.py
+++ b/tests/subscription/test_satellite.py
@@ -715,12 +715,12 @@ class TestSatelliteScaEnable:
         :steps:
 
             1. run virt-who to report mappings
-            2. try to auto-attach subscription for hypervisor
+            2. try to attach vdc sku for hypervisor
 
         :expectedresults:
 
-            get the 'This host's organization is in Simple Content Access
-                mode. Auto-attach is disabled'
+            get the 'This host's organization is in Simple Content Access mode.
+            Attaching subscriptions is disabled.'
         """
         hypervisor_hostname = hypervisor_data["hypervisor_hostname"]
         result = virtwho.run_cli()
@@ -753,15 +753,16 @@ class TestSatelliteScaEnable:
 
             1. register guest
             2. check the #subscription-manager status
-            3. try to auto-attach subscription for guest
-            4. try to attach subscription for guest by satellite web
+            3. try to attach vdc sku for guest by terminal
+            4. try to attach vdc sku for guest by satellite web
 
         :expectedresults:
 
-            2. get the output with 'Content Access Mode is set to Simple Content
-                Access' by #subscription-manager status
-            3. get the 'This host's organization is in Simple Content Access
-                mode. Auto-attach is disabled'
+            2. get the output with 'Content Access Mode is set to Simple Content Access'
+            3. get the 'Attaching subscriptions is disabled .* because Simple Content
+            Access .* is enabled'
+            4. get the 'This host's organization is in Simple Content Access mode.
+            Attaching subscriptions is disabled.'
         """
         guest_hostname = hypervisor_data["guest_hostname"]
         # virtwho.run_cli()

--- a/tests/subscription/test_satellite.py
+++ b/tests/subscription/test_satellite.py
@@ -701,7 +701,9 @@ class TestSatelliteScaDisable:
 @pytest.mark.usefixtures("class_satellite_sca_enable")
 class TestSatelliteScaEnable:
     @pytest.mark.tier1
-    def test_hypervisor_entitlement_status(self, virtwho, hypervisor_data, satellite, vdc_pool_physical):
+    def test_hypervisor_entitlement_status(
+        self, virtwho, hypervisor_data, satellite, vdc_pool_physical
+    ):
         """Test the hypervisor entitlement status.
 
         :title: virt-who: satellite: [sca/enable] test hypervisor entitlement status
@@ -724,13 +726,20 @@ class TestSatelliteScaEnable:
         result = virtwho.run_cli()
         assert result["send"] == 1 and result["error"] == 0
 
-        msg ="This host's organization is in Simple Content Access mode. Attaching subscriptions is disabled."
+        msg = "This host's organization is in Simple Content Access mode. Attaching subscriptions is disabled."
         result = satellite.attach(host=hypervisor_hostname, pool=vdc_pool_physical)
         assert msg_search(result, msg)
 
     @pytest.mark.tier1
     def test_guest_entitlement_status(
-        self, virtwho, ssh_guest, sm_guest, function_guest_register, hypervisor_data, satellite, vdc_pool_physical
+        self,
+        virtwho,
+        ssh_guest,
+        sm_guest,
+        function_guest_register,
+        hypervisor_data,
+        satellite,
+        vdc_pool_physical,
     ):
         """
 


### PR DESCRIPTION
test_rhsm.py
- [x] test_hypervisor_entitlement_status
- [x] test_guest_entitlement_status

test_satellite.py
- [x] test_hypervisor_entitlement_status
- [x] test_guest_entitlement_status

**rhsm+esx**
```
% pytest --disable-warnings -v tests/subscription/test_rhsm.py -k 'test_hypervisor_entitlement_status or test_guest_entitlement_status'
========================================================= test session starts =========================================================
platform darwin -- Python 3.11.2, pytest-7.2.2, pluggy-1.0.0 -- /opt/homebrew/opt/python@3.11/bin/python3.11
cachedir: .pytest_cache
rootdir: /Users/yuefliu/workspace/virtwho-test, configfile: pytest.ini
collected 8 items / 6 deselected / 2 selected                                                                                         

tests/subscription/test_rhsm.py::TestRhsmScaEnable::test_hypervisor_entitlement_status PASSED                                   [ 50%]
tests/subscription/test_rhsm.py::TestRhsmScaEnable::test_guest_entitlement_status PASSED                                        [100%]

======================================= 2 passed, 6 deselected, 4 warnings in 211.69s (0:03:31) =======================================
```

**satellite+esx**
```
% pytest --disable-warnings -v tests/subscription/test_satellite.py -k 'test_hypervisor_entitlement_status or test_guest_entitlement_status'
========================================================= test session starts =========================================================
platform darwin -- Python 3.11.2, pytest-7.2.2, pluggy-1.0.0 -- /opt/homebrew/opt/python@3.11/bin/python3.11
cachedir: .pytest_cache
rootdir: /Users/yuefliu/workspace/virtwho-test, configfile: pytest.ini
collected 11 items / 9 deselected / 2 selected                                                                                        

tests/subscription/test_satellite.py::TestSatelliteScaEnable::test_hypervisor_entitlement_status PASSED                         [ 50%]
tests/subscription/test_satellite.py::TestSatelliteScaEnable::test_guest_entitlement_status PASSED                              [100%]

======================================== 2 passed, 9 deselected, 1 warning in 70.01s (0:01:10) ========================================
```

**satellite+local**
```
% pytest --disable-warnings -v tests/subscription/test_satellite.py -k 'test_hypervisor_entitlement_status or test_guest_entitlement_status'
========================================================= test session starts =========================================================
platform darwin -- Python 3.11.2, pytest-7.2.2, pluggy-1.0.0 -- /opt/homebrew/opt/python@3.11/bin/python3.11
cachedir: .pytest_cache
rootdir: /Users/yuefliu/workspace/virtwho-test, configfile: pytest.ini
collected 11 items / 9 deselected / 2 selected                                                                                        

tests/subscription/test_satellite.py::TestSatelliteScaEnable::test_hypervisor_entitlement_status PASSED                         [ 50%]
tests/subscription/test_satellite.py::TestSatelliteScaEnable::test_guest_entitlement_status PASSED                              [100%]

======================================= 2 passed, 9 deselected, 1 warning in 105.31s (0:01:45) ========================================
```