### PR TITLE
Add test case to test_multi_hypervisors.py

### DIFF
--- a/tests/hypervisor/test_multi_hypervisors.py
+++ b/tests/hypervisor/test_multi_hypervisors.py
@@ -6,11 +6,17 @@
 :subsystemteam: sst_subscription_virtwho
 :caselevel: Component
 """
-from virtwho import logger
+import pytest
+
+from virtwho.settings import config
+from virtwho.configure import hypervisor_create
 
 
+@pytest.mark.usefixtures("function_virtwho_d_conf_clean")
+@pytest.mark.usefixtures("class_debug_true")
+@pytest.mark.usefixtures("class_globalconf_clean")
 class TestMultiHypervisors:
-    def test_multi_hypervisors_report_together(self):
+    def test_multi_hypervisors_report_together(self, virtwho):
         """Test virt-who can report multi hypervisors together
 
         :title: virt-who: multiHypervisors: test multi hypervisors report together
@@ -20,9 +26,13 @@ class TestMultiHypervisors:
         :customerscenario: false
         :upstream: no
         :steps:
-            1. demo
+            1. Create the virt-who config files for the multi hypervisors list
+            2. Run the virt-who service
+
         :expectedresults:
-            1. demo
+            1. Succeed to run the virt-who, no error messages in the rhsm.log
         """
-        logger.info("Succeeded to run the 'test_multi_hypervisors_report'")
-        assert True
+        for mode in config.job.multi_hypervisors.strip('[').strip(']').split(','):
+            hypervisor_create(mode)
+        result = virtwho.run_service()
+        assert result["error"] == 0 and result["send"] == 1 and result["thread"] == 1

--- a/tests/hypervisor/test_multi_hypervisors.py
+++ b/tests/hypervisor/test_multi_hypervisors.py
@@ -8,7 +8,7 @@
 """
 import pytest
 
-from virtwho.settings import config
+from virtwho.base import hypervisors_list
 from virtwho.configure import hypervisor_create
 
 
@@ -32,7 +32,7 @@ class TestMultiHypervisors:
         :expectedresults:
             1. Succeed to run the virt-who, no error messages in the rhsm.log
         """
-        for mode in config.job.multi_hypervisors.strip('[').strip(']').split(','):
+        for mode in hypervisors_list:
             hypervisor_create(mode)
         result = virtwho.run_service()
         assert result["error"] == 0 and result["send"] == 1 and result["thread"] == 1

--- a/virtwho/base.py
+++ b/virtwho/base.py
@@ -636,3 +636,11 @@ def virtwho_package_url(pkg, rhel_compose_id, rhel_compose_path=""):
     _, compose_url_extra = rhel_compose_url(rhel_compose_id, rhel_compose_path)
     pkg_url = compose_url_extra + "/Packages/" + pkg + ".rpm"
     return pkg_url
+
+
+def hypervisors_list():
+    """
+    Get the hypervisors list from virtwho.ini file
+    :return: hypervisors_list
+    """
+    return config.job.multi_hypervisors.strip('[').strip(']').split(',')

--- a/virtwho/base.py
+++ b/virtwho/base.py
@@ -643,4 +643,4 @@ def hypervisors_list():
     Get the hypervisors list from virtwho.ini file
     :return: hypervisors_list
     """
-    return config.job.multi_hypervisors.strip('[').strip(']').split(',')
+    return config.job.multi_hypervisors.strip("[").strip("]").split(",")


### PR DESCRIPTION
**Descirption**
Add test case to test_multi_hypervisors.py

Test Result
```
(env) [hkx303@kuhuang virtwho-test]$ pytest tests/hypervisor/test_multi_hypervisors.py -s
/home/hkx303/Documents/CI/virtwho-test/env/lib/python3.7/site-packages/paramiko/transport.py:216: CryptographyDeprecationWarning: Blowfish has been deprecated
  "class": algorithms.Blowfish,
================================ test session starts =================================
platform linux -- Python 3.7.3, pytest-5.4.3, py-1.11.0, pluggy-0.13.1
rootdir: /home/hkx303/Documents/CI/virtwho-test, inifile: pytest.ini
plugins: services-1.3.1, xdist-1.34.0, mock-1.10.4, forked-1.4.0
collected 1 item   
=========================== 1 passed in 298.74s (0:04:58) ============================
```
