### PR TITLE
Fix test case: test_upgrade_downgrade_by_yum for libvirt-local mode

### DIFF
--- a/tests/package/test_upgrade_downgrade.py
+++ b/tests/package/test_upgrade_downgrade.py
@@ -29,7 +29,7 @@ if "RHEL-8" in RHEL_COMPOSE:
 @pytest.mark.usefixtures("function_host_register_for_local_mode")
 class TestUpgradeDowngrade:
     @pytest.mark.tier1
-    def test_upgrade_downgrade_by_yum(self, ssh_host, virtwho, globalconf):
+    def test_upgrade_downgrade_by_yum(self, ssh_host, virtwho, globalconf, rhsm):
         """Test virt-who upgrade/downgrade by yum
 
         :title: virt-who: package: upgrade/downgrade by yum
@@ -63,6 +63,7 @@ class TestUpgradeDowngrade:
                 compose_path=old_compose_path,
             )
             # downgrade virt-who to check the configurations not change.
+            rhsm.sca(sca="disable")
             package_downgrade(ssh_host, "virt-who")
             result = virtwho.run_service()
             assert (

--- a/tests/package/test_upgrade_downgrade.py
+++ b/tests/package/test_upgrade_downgrade.py
@@ -29,7 +29,8 @@ if "RHEL-8" in RHEL_COMPOSE:
 @pytest.mark.usefixtures("function_host_register_for_local_mode")
 class TestUpgradeDowngrade:
     @pytest.mark.tier1
-    def test_upgrade_downgrade_by_yum(self, ssh_host, virtwho, globalconf, rhsm):
+    @pytest.mark.notLocal
+    def test_upgrade_downgrade_by_yum(self, ssh_host, virtwho, globalconf):
         """Test virt-who upgrade/downgrade by yum
 
         :title: virt-who: package: upgrade/downgrade by yum
@@ -63,7 +64,6 @@ class TestUpgradeDowngrade:
                 compose_path=old_compose_path,
             )
             # downgrade virt-who to check the configurations not change.
-            rhsm.sca(sca="disable")
             package_downgrade(ssh_host, "virt-who")
             result = virtwho.run_service()
             assert (


### PR DESCRIPTION
**Description**
test case test_upgrade_downgrade_by_yum failed when downgrade the virt-who package with the error msg:
```
Errors during downloading metadata for repository 'rhel-8-for-x86_64-baseos-beta-rpms':
  - Curl error (60): Peer certificate cannot be authenticated with given CA certificates for https://cdn.redhat.com/content/beta/rhel8/8/x86_64/baseos/os/repodata/repomd.xml [SSL certificate problem: self signed certificate in certificate chain]
Error: Failed to download metadata for repo 'rhel-8-for-x86_64-baseos-beta-rpms': Cannot download repomd.xml: Cannot download repodata/repomd.xml: All mirrors were tried
```
we added the step: `function_host_register_for_local_mode`, but need to disable the sca mode to install the package

**Test Result**
```
(env) [hkx303@kuhuang virtwho-test]$ pytest tests/package/test_upgrade_downgrade.py -k test_upgrade_downgrade_by_yum -s
/home/hkx303/Documents/CI/virtwho-test/env/lib/python3.7/site-packages/paramiko/transport.py:216: CryptographyDeprecationWarning: Blowfish has been deprecated
  "class": algorithms.Blowfish,
================================ test session starts =================================
platform linux -- Python 3.7.3, pytest-5.4.3, py-1.11.0, pluggy-0.13.1
rootdir: /home/hkx303/Documents/CI/virtwho-test, inifile: pytest.ini
plugins: services-1.3.1, xdist-1.34.0, mock-1.10.4, forked-1.4.0
collected 3 items / 2 deselected / 1 selected  
=============== 1 passed, 2 deselected, 1 warning in 315.93s (0:05:15) ===============
```
