### PR TITLE
Fix test case test_associated_info_by_rhsmlog_and_webui for local mode

### DIFF
--- a/tests/hypervisor/test_default.py
+++ b/tests/hypervisor/test_default.py
@@ -112,10 +112,13 @@ class TestHypervisorPositive:
 
         # check host-to-guest association in rhsm.log
         mappings = result["mappings"]
-        associated_hypervisor_in_mapping = mappings[default_org][guest_uuid][
-            "guest_hypervisor"
-        ]
-        assert associated_hypervisor_in_mapping == host_name
+        if HYPERVISOR == 'local':
+            assert guest_uuid in mappings.keys()
+        else:
+            associated_hypervisor_in_mapping = mappings[default_org][guest_uuid][
+                "guest_hypervisor"
+            ]
+            assert associated_hypervisor_in_mapping == host_name
 
         # check host-to-guest association in webui
         if REGISTER == "rhsm":

--- a/tests/hypervisor/test_default.py
+++ b/tests/hypervisor/test_default.py
@@ -111,10 +111,8 @@ class TestHypervisorPositive:
         assert result["error"] == 0 and result["send"] == 1 and result["thread"] == 1
 
         # check host-to-guest association in rhsm.log
-        mappings = result["mappings"]
-        if HYPERVISOR == 'local':
-            assert guest_uuid in mappings.keys()
-        else:
+        if HYPERVISOR != 'local':
+            mappings = result["mappings"]
             associated_hypervisor_in_mapping = mappings[default_org][guest_uuid][
                 "guest_hypervisor"
             ]

--- a/tests/hypervisor/test_default.py
+++ b/tests/hypervisor/test_default.py
@@ -111,7 +111,7 @@ class TestHypervisorPositive:
         assert result["error"] == 0 and result["send"] == 1 and result["thread"] == 1
 
         # check host-to-guest association in rhsm.log
-        if HYPERVISOR != 'local':
+        if HYPERVISOR != "local":
             mappings = result["mappings"]
             associated_hypervisor_in_mapping = mappings[default_org][guest_uuid][
                 "guest_hypervisor"


### PR DESCRIPTION
**Description**
test case `test_associated_info_by_rhsmlog_and_webui` failed for local mode due to the error msg:
`KeyError: 'Default_Organization'`， the mapping info for local mode is different from other hypervisors, need to update the test case

**Test Result**
```
(env) [hkx303@kuhuang virtwho-test]$ pytest tests/hypervisor/test_default.py -k test_associated_info_by_rhsmlog_and_webui -s
/home/hkx303/Documents/CI/virtwho-test/env/lib/python3.7/site-packages/paramiko/transport.py:216: CryptographyDeprecationWarning: Blowfish has been deprecated
  "class": algorithms.Blowfish,
================================ test session starts =================================
platform linux -- Python 3.7.3, pytest-5.4.3, py-1.11.0, pluggy-0.13.1
rootdir: /home/hkx303/Documents/CI/virtwho-test, inifile: pytest.ini
plugins: services-1.3.1, xdist-1.34.0, mock-1.10.4, forked-1.4.0
collected 6 items / 5 deselected / 1 selected    
=============== 1 passed, 5 deselected, 2 warnings in 75.69s (0:01:15) ===============
```
