### PR TITLE
Support satelite6.14 for smoke testing

### DIFF
--- a/virtwho/provision/virtwho_satellite.py
+++ b/virtwho/provision/virtwho_satellite.py
@@ -218,9 +218,7 @@ def virtwho_satellite_arguments_parser():
         help="SCA mode, disable/enable",
     )
     parser.add_argument(
-        "--snap",
-        required=False,
-        help="Satellite snap version, such as '5.0', '6.0'"
+        "--snap", required=False, help="Satellite snap version, such as '5.0', '6.0'"
     )
     return parser.parse_args()
 

--- a/virtwho/provision/virtwho_satellite.py
+++ b/virtwho/provision/virtwho_satellite.py
@@ -217,6 +217,11 @@ def virtwho_satellite_arguments_parser():
         required=False,
         help="SCA mode, disable/enable",
     )
+    parser.add_argument(
+        "--snap",
+        required=False,
+        help="Satellite snap version, such as '5.0', '6.0'"
+    )
     return parser.parse_args()
 
 


### PR DESCRIPTION
**Description**
Support satelite6.14 for smoke testing, now deploy the satellite y stream need the value `snap version`, need to update the satellite deploy function


**Test Result**
```
[2023-06-27 20:44:54] - [register.py] - INFO: Succeeded to create activation key:Virtwho_AK
[2023-06-27 20:44:54] - [virtwho_satellite.py] - INFO: +++ Succeeded to deploy the Satellite 6.14-repo-rhel8/dell-per740-69-vm-01.lab.eng.pek2.redhat.com +++
```
