### PR TITLE
Fix case test_threads_number_after_reconfig_libvirt for libvirt-lcoal on rhel9

### DIFF
--- a/tests/hypervisor/test_local.py
+++ b/tests/hypervisor/test_local.py
@@ -10,6 +10,7 @@ import pytest
 import time
 
 from hypervisor import logger
+from virtwho import RHEL_COMPOSE
 
 
 @pytest.mark.usefixtures("function_host_register_for_local_mode")
@@ -55,8 +56,10 @@ class TestLocalPositive:
             operate_option("enable", "tcp_port", libvirt_conf, ssh_host)
 
             run_service(ssh_host, "libvirtd", "restart")
-            _, output = run_service(ssh_host, "libvirtd", "status")
-            assert "is running" in output or "Active: active (running)" in output
+            if "RHEL-8" in RHEL_COMPOSE:
+                # for RHEL-9, the libvirt service will not alwayws active
+                _, output = run_service(ssh_host, "libvirtd", "status")
+                assert "is running" in output or "Active: active (running)" in output
 
             # check virt-who thread_num is changed or not
             thread_after = virtwho.thread_number()
@@ -70,8 +73,10 @@ class TestLocalPositive:
             operate_option("disable", "tcp_port", libvirt_conf, ssh_host)
 
             run_service(ssh_host, "libvirtd", "restart")
-            _, output = run_service(ssh_host, "libvirtd", "status")
-            assert "is running" in output or "Active: active (running)" in output
+            if "RHEL-8" in RHEL_COMPOSE:
+                # for RHEL-9, the libvirt service will not alwayws active
+                _, output = run_service(ssh_host, "libvirtd", "status")
+                assert "is running" in output or "Active: active (running)" in output
 
 
 def operate_option(action, option, file, ssh_host):


### PR DESCRIPTION
**Description**
Test case tests.hypervisor.test_local.TestLocalPositive.test_threads_number_after_reconfig_libvirt failed for rhel9 as cannot start the libvird service as the following msg:

```
[root@hp-z220-05 ~]# service libvirtd status 
Redirecting to /bin/systemctl status libvirtd.service 
○ libvirtd.service - Virtualization daemon 
     Loaded: loaded (/usr/lib/systemd/system/libvirtd.service; enabled; preset: disabled) 
     Active: inactive (dead) since Fri 2023-07-28 10:10:03 EDT; 2min 56s ago 
   Duration: 525ms 
TriggeredBy: ● libvirtd-admin.socket 
             ● libvirtd-ro.socket 
             ● libvirtd.socket 
             ○ libvirtd-tls.socket 
             ○ libvirtd-tcp.socket 
       Docs: man:libvirtd(8) 
             https://libvirt.org 
    Process: 3753 ExecStart=/usr/sbin/libvirtd $LIBVIRTD_ARGS (code=exited, status=0/SUCCESS) 
   Main PID: 3753 (code=exited, status=0/SUCCESS) 
      Tasks: 2 (limit: 32768) 
     Memory: 22.2M 
        CPU: 294ms 
     CGroup: /system.slice/libvirtd.service 
             ├─1612 /usr/sbin/dnsmasq --conf-file=/var/lib/libvirt/dnsmasq/default.conf --leasefile-ro --dhcp-script=/usr/libexec/libvirt_leaseshelper 
             └─1613 /usr/sbin/dnsmasq --conf-file=/var/lib/libvirt/dnsmasq/default.conf --leasefile-ro --dhcp-script=/usr/libexec/libvirt_leaseshelper 

Jul 28 10:10:02 hp-z220-05.qe.lab.eng.nay.redhat.com systemd[1]: Starting Virtualization daemon... 
Jul 28 10:10:02 hp-z220-05.qe.lab.eng.nay.redhat.com systemd[1]: Started Virtualization daemon. 
Jul 28 10:10:03 hp-z220-05.qe.lab.eng.nay.redhat.com dnsmasq[1612]: read /etc/hosts - 3 addresses 
Jul 28 10:10:03 hp-z220-05.qe.lab.eng.nay.redhat.com dnsmasq[1612]: read /var/lib/libvirt/dnsmasq/default.addnhosts - 0 addresses 
Jul 28 10:10:03 hp-z220-05.qe.lab.eng.nay.redhat.com dnsmasq-dhcp[1612]: read /var/lib/libvirt/dnsmasq/default.hostsfile 
Jul 28 10:10:03 hp-z220-05.qe.lab.eng.nay.redhat.com systemd[1]: Stopping Virtualization daemon... 
Jul 28 10:10:03 hp-z220-05.qe.lab.eng.nay.redhat.com systemd[1]: libvirtd.service: Deactivated successfully. 
Jul 28 10:10:03 hp-z220-05.qe.lab.eng.nay.redhat.com systemd[1]: libvirtd.service: Unit process 1612 (dnsmasq) remains running after unit stopped. 
Jul 28 10:10:03 hp-z220-05.qe.lab.eng.nay.redhat.com systemd[1]: libvirtd.service: Unit process 1613 (dnsmasq) remains running after unit stopped. 
Jul 28 10:10:03 hp-z220-05.qe.lab.eng.nay.redhat.com systemd[1]: Stopped Virtualization daemon.
```

for RHEL-9, the libvirt service will not alwayws active, so skip the status check for rhel9
**Test Result**
```
[hkx303@kuhuang virtwho-test]$ pytest tests/hypervisor/test_local.py -k test_threads_number_after_reconfig_libvirt -s

============================================================================ test session starts ============================================================================

platform linux -- Python 3.7.3, pytest-5.4.3, py-1.8.0, pluggy-0.13.1

rootdir: /home/hkx303/Documents/CI/virtwho-test, inifile: pytest.ini

plugins: services-1.3.1, mock-1.10.4, forked-1.0.2, ibutsu-1.0.34, cov-2.7.1, xdist-1.34.0

collected 1 item  
======================================================================= 1 passed in 72.48s (0:01:12) ========================================================================
```