### PR TITLE
Fix test case test_interval_in_virtwho_sysconfig

### DIFF
--- a/tests/function/test_config.py
+++ b/tests/function/test_config.py
@@ -659,7 +659,7 @@ class TestSysConfiguration:
         sysconfg_options["VIRTWHO_INTERVAL"] = 60
         function_sysconfig.update(**sysconfg_options)
         result = virtwho.run_service(wait=60)
-        assert result["send"] == 1 and result["error"] == 0 and result["loop"] == 60
+        assert result["send"] == 1 and result["error"] == 0 and result["loop"] in [60, 61]
 
         function_sysconfig.clean()
 

--- a/tests/function/test_config.py
+++ b/tests/function/test_config.py
@@ -659,7 +659,9 @@ class TestSysConfiguration:
         sysconfg_options["VIRTWHO_INTERVAL"] = 60
         function_sysconfig.update(**sysconfg_options)
         result = virtwho.run_service(wait=60)
-        assert result["send"] == 1 and result["error"] == 0 and result["loop"] in [60, 61]
+        assert (
+            result["send"] == 1 and result["error"] == 0 and result["loop"] in [60, 61]
+        )
 
         function_sysconfig.clean()
 


### PR DESCRIPTION
**Description**
test case test_interval_in_virtwho_sysconfig failed due to the error msg:
```
>       assert result["send"] == 1 and result["error"] == 0 and result["loop"] == 60
E       assert (1 == 1
E         +1
E         -1 and 0 == 0
E         +0
E         -0 and 61 == 60
E         +61
E         -60)
```

Need to add the time option for loop time assertion

**Test Result**
test for kubevirt hypervisor
```
[hkx303@kuhuang virtwho-test]$ pytest tests/function/test_config.py -k test_interval_in_virtwho_sysconfig -s
==================== 1 passed, 20 deselected in 150.17s (0:02:30) ====================
```
