### PR TITLE
Fix test case test_guest_entitlement_status

### DIFF
--- a/tests/subscription/test_rhsm.py
+++ b/tests/subscription/test_rhsm.py
@@ -457,8 +457,10 @@ class TestRhsmScaEnable:
         virtwho.run_cli()
 
         ret, output = ssh_guest.runcmd("subscription-manager status")
-        msg = "Content Access Mode is set to Simple Content Access. " \
-              "This host has access to content, regardless of subscription status."
+        msg = (
+            "Content Access Mode is set to Simple Content Access. "
+            "This host has access to content, regardless of subscription status."
+        )
         assert msg_search(output, msg)
 
         output = sm_guest.attach(pool=vdc_pool_physical)
@@ -469,7 +471,7 @@ class TestRhsmScaEnable:
                 "Ignoring request to attach. "
                 "It is disabled for org .* because of the content access mode setting.",  # esx
                 "Ignoring the request to attach. Attaching subscriptions is disabled "
-                "for organization .* because Simple Content Access .* is enabled",       # kubevirt
+                "for organization .* because Simple Content Access .* is enabled",  # kubevirt
             ]
 
         assert msg_search(output, msg)

--- a/tests/subscription/test_rhsm.py
+++ b/tests/subscription/test_rhsm.py
@@ -461,10 +461,16 @@ class TestRhsmScaEnable:
         assert msg_search(output, msg)
 
         output = sm_guest.attach(pool=vdc_pool_physical)
+
         msg = "Attaching subscriptions is disabled .* because Simple Content Access .* is enabled."
         if "RHEL-8" in RHEL_COMPOSE:
-            msg = "Ignoring request to attach. " \
-                  "It is disabled for org .* because of the content access mode setting."
+            msg = [
+                "Ignoring request to attach. "
+                "It is disabled for org .* because of the content access mode setting.",  # esx
+                "Ignoring the request to attach. Attaching subscriptions is disabled "
+                "for organization .* because Simple Content Access .* is enabled",       # kubevirt
+            ]
+
         assert msg_search(output, msg)
 
         logger.info("=== RHSM has bz2017774, skip the checking tempoparily ===")

--- a/tests/subscription/test_rhsm.py
+++ b/tests/subscription/test_rhsm.py
@@ -9,7 +9,7 @@
 import pytest
 from virtwho.base import msg_search
 from virtwho.settings import config
-from virtwho import HYPERVISOR, FAKE_CONFIG_FILE, logger
+from virtwho import HYPERVISOR, FAKE_CONFIG_FILE, RHEL_COMPOSE, logger
 from virtwho.configure import hypervisor_create
 
 vdc_physical_sku = config.sku.vdc
@@ -462,6 +462,9 @@ class TestRhsmScaEnable:
 
         output = sm_guest.attach(pool=vdc_pool_physical)
         msg = "Attaching subscriptions is disabled .* because Simple Content Access .* is enabled."
+        if "RHEL-8" in RHEL_COMPOSE:
+            msg = "Ignoring request to attach. " \
+                  "It is disabled for org .* because of the content access mode setting."
         assert msg_search(output, msg)
 
         logger.info("=== RHSM has bz2017774, skip the checking tempoparily ===")

--- a/tests/subscription/test_rhsm.py
+++ b/tests/subscription/test_rhsm.py
@@ -457,7 +457,8 @@ class TestRhsmScaEnable:
         virtwho.run_cli()
 
         ret, output = ssh_guest.runcmd("subscription-manager status")
-        msg = "Content Access Mode is set to Simple Content Access. This host has access to content, regardless of subscription status."
+        msg = "Content Access Mode is set to Simple Content Access. " \
+              "This host has access to content, regardless of subscription status."
         assert msg_search(output, msg)
 
         output = sm_guest.attach(pool=vdc_pool_physical)

--- a/tests/subscription/test_satellite.py
+++ b/tests/subscription/test_satellite.py
@@ -772,10 +772,16 @@ class TestSatelliteScaEnable:
         assert msg_search(output, msg)
 
         output = sm_guest.attach(pool=vdc_pool_physical)
-        msg = "Attaching subscriptions is disabled .* because Simple Content Access .* is enabled."
+        msg = [
+            "Attaching subscriptions is disabled .* "
+            "because Simple Content Access .* is enabled.",
+            "Ignoring request to attach. It is disabled for org .* "
+            "because of the content access mode setting.",
+        ]
         assert msg_search(output, msg)
 
-        msg = "This host's organization is in Simple Content Access mode. Attaching subscriptions is disabled."
+        msg = "This host's organization is in Simple Content Access mode. " \
+              "Attaching subscriptions is disabled."
         result = satellite.attach(host=guest_hostname, pool=vdc_pool_physical)
         assert msg in result
 

--- a/tests/subscription/test_satellite.py
+++ b/tests/subscription/test_satellite.py
@@ -780,8 +780,10 @@ class TestSatelliteScaEnable:
         ]
         assert msg_search(output, msg)
 
-        msg = "This host's organization is in Simple Content Access mode. " \
-              "Attaching subscriptions is disabled."
+        msg = (
+            "This host's organization is in Simple Content Access mode. "
+            "Attaching subscriptions is disabled."
+        )
         result = satellite.attach(host=guest_hostname, pool=vdc_pool_physical)
         assert msg in result
 


### PR DESCRIPTION
**Description**
The test case test_guest_entitlement_status failed due to the error msg:
https://main-jenkins-csb-virtwhoqe.apps.ocp-c1.prod.psi.redhat.com/job/regression-el8/job/subscription-runtest/15/testReport/junit/tests.subscription.test_rhsm/TestRhsmScaEnable/test_guest_entitlement_status/
```
AssertionError: assert False
 +  where False = msg_search('+-------------------------------------------+\n   System Status Details\n+-------------------------------------------...nRed Hat Enterprise Linux for x86_64:\n- Not supported by a valid subscription.\n\nSystem Purpose Status: Disabled\n\n', 'Content Access Mode is set to Simple Content Access. This host has access to content, regardless of subscription status.')
```


**Test Result**
```
[hkx303@kuhuang virtwho-test]$ pytest tests/subscription/test_rhsm.py -k test_guest_entitlement_status -s
============== 1 passed, 7 deselected, 6 warnings in 113.01s (0:01:53) ===============
```

