### PR TITLE
Fix the case test_extension_file_name

### DIFF
--- a/tests/hypervisor/test_esx.py
+++ b/tests/hypervisor/test_esx.py
@@ -1026,16 +1026,19 @@ class TestEsxNegative:
         ssh_host.runcmd(cmd)
 
         warning_msg = esx_assertion["extension_file_name"]["warining_msg"]
-        error_msg = esx_assertion["extension_file_name"]["error_msg"]
+        # error_msg = esx_assertion["extension_file_name"]["error_msg"]
 
         result = virtwho.run_service()
-        assert (
-            result["error"] is not 0
-            and result["send"] == 0
-            and result["thread"] == 1
-            and error_msg in result["error_msg"]
-            and warning_msg in result["warning_msg"]
-        )
+        assert warning_msg in result["warning_msg"]
+
+        # Now we have the libvirt local mode on host, so just assert the warning msg
+        # assert (
+        #     result["error"] is not 0
+        #     and result["send"] == 0
+        #     and result["thread"] == 1
+        #     and error_msg in result["error_msg"]
+        #     and warning_msg in result["warning_msg"]
+        # )
 
     @pytest.mark.tier2
     def test_quoted_options(self, virtwho, function_hypervisor, ssh_host):

--- a/tests/hypervisor/test_esx.py
+++ b/tests/hypervisor/test_esx.py
@@ -1026,19 +1026,18 @@ class TestEsxNegative:
         ssh_host.runcmd(cmd)
 
         warning_msg = esx_assertion["extension_file_name"]["warining_msg"]
-        # error_msg = esx_assertion["extension_file_name"]["error_msg"]
-
+        error_msg = esx_assertion["extension_file_name"]["error_msg"]
         result = virtwho.run_service()
-        assert warning_msg in result["warning_msg"]
-
-        # Now we have the libvirt local mode on host, so just assert the warning msg
-        # assert (
-        #     result["error"] is not 0
-        #     and result["send"] == 0
-        #     and result["thread"] == 1
-        #     and error_msg in result["error_msg"]
-        #     and warning_msg in result["warning_msg"]
-        # )
+        if result["error"]:
+            assert (
+                result["send"] == 0
+                and result["thread"] == 1
+                and error_msg in result["error_msg"]
+                and warning_msg in result["warning_msg"]
+            )
+        else:
+            # Now we also have the libvirt local mode on host, so just assert the warning msg
+            assert warning_msg in result["warning_msg"]
 
     @pytest.mark.tier2
     def test_quoted_options(self, virtwho, function_hypervisor, ssh_host):

--- a/virtwho/runner.py
+++ b/virtwho/runner.py
@@ -326,10 +326,27 @@ class VirtwhoRunner:
                 else:
                     msg = r'Response: status=200, request="POST /rhsm/hypervisors'
             if "rhsm" in self.register_type:
-                msg = (
-                    r"Response: status=20.*requestUuid.*request="
-                    r'"PUT /subscription/.*'
-                )
+                if self.mode == "local":
+                    msg = (
+                        r"Response: status=20.*requestUuid.*request="
+                        r'"PUT /subscription/consumers'
+                    )
+                    return len(re.findall(msg, rhsm_log, re.I))
+                else:
+                    # mode is other hypervisor but also have local mode on virt-who host
+                    msg = (
+                        r"Response: status=20.*requestUuid.*request="
+                        r'"PUT /subscription/consumers'
+                    )
+                    if re.findall(msg, rhsm_log, re.I):
+                        return len(re.findall(msg, rhsm_log, re.I))
+                    # mode is other hypervisor but don't have local mode on virt-who host
+                    msg = (
+                        r"Response: status=20.*requestUuid.*request="
+                        r'"POST /subscription/hypervisors'
+                    )
+                    if re.findall(msg, rhsm_log, re.I):
+                        return len(re.findall(msg, rhsm_log, re.I))
         else:
             if self.mode == "local":
                 msg = r"Sending update in guests lists for config"

--- a/virtwho/runner.py
+++ b/virtwho/runner.py
@@ -326,16 +326,10 @@ class VirtwhoRunner:
                 else:
                     msg = r'Response: status=200, request="POST /rhsm/hypervisors'
             if "rhsm" in self.register_type:
-                if self.mode == "local":
-                    msg = (
-                        r"Response: status=20.*requestUuid.*request="
-                        r'"PUT /subscription/consumers'
-                    )
-                else:
-                    msg = (
-                        r"Response: status=20.*requestUuid.*request="
-                        r'"POST /subscription/hypervisors'
-                    )
+                msg = (
+                    r"Response: status=20.*requestUuid.*request="
+                    r'"PUT /subscription/.*'
+                )
         else:
             if self.mode == "local":
                 msg = r"Sending update in guests lists for config"


### PR DESCRIPTION
**Description**
The test case `test_extension_file_name` [failed](https://main-jenkins-csb-virtwhoqe.apps.ocp-c1.prod.psi.redhat.com/job/regression-el8/job/hypervisor-runtest/17/testReport/junit/tests.hypervisor.test_esx/TestEsxNegative/test_extension_file_name/) due to:
```
>       assert (
            result["error"] is not 0
            and result["send"] == 0
            and result["thread"] == 1
            and error_msg in result["error_msg"]
            and warning_msg in result["warning_msg"]
        )
E       assert (0 is not 0)

tests/hypervisor/test_esx.py:1032: AssertionError
```
It is because we are now also have the libvirt mode on host, need to update the test case.

**Test Result**
```
[hkx303@kuhuang virtwho-test]$ pytest tests/hypervisor/test_esx.py -k test_extension_file_name -s
==================== 1 passed, 28 deselected, 1 warning in 56.85s ====================
```