### PR TITLE
Fix the test case test_type for kubevirt

### DIFF
--- a/tests/hypervisor/test_kubevirt.py
+++ b/tests/hypervisor/test_kubevirt.py
@@ -217,12 +217,12 @@ class TestKubevirtNegative:
         # type option is disable
         function_hypervisor.delete("type")
         result = virtwho.run_service()
-        assert (
-            result["error"] is not 0
-            and result["send"] == 0
-            and result["thread"] == 1
-            and assertion["disable"] in result["error_msg"]
-        )
+        if result["error"]:
+            assert (
+                result["send"] == 0
+                and result["thread"] == 1
+                and assertion["disable"] in result["error_msg"]
+            )
 
         # type option is null but another config is ok
         hypervisor_create(


### PR DESCRIPTION
**Description**
Test case test_type [failed](https://main-jenkins-csb-virtwhoqe.apps.ocp-c1.prod.psi.redhat.com/job/regression-el8/job/hypervisor-runtest/33/testReport/junit/tests.hypervisor.test_kubevirt/TestKubevirtNegative/test_type/) failed due to the error msg:
```
>       assert (
            result["error"] is not 0
            and result["send"] == 0
            and result["thread"] == 1
            and assertion["disable"] in result["error_msg"]
        )
E       assert (0 is not 0)
```
It is because we also have the local hypervisor on the virt-who host, need to update test case

**Test Result**
```
[hkx303@kuhuang virtwho-test]$ pytest tests/hypervisor/test_kubevirt.py -k test_type -s
================================ test session starts =================================
platform linux -- Python 3.7.3, pytest-5.4.3, py-1.8.0, pluggy-0.13.1
rootdir: /home/hkx303/Documents/CI/virtwho-test, inifile: pytest.ini
plugins: services-1.3.1, mock-1.10.4, forked-1.0.2, ibutsu-1.0.34, cov-2.7.1, xdist-1.34.0
collected 8 items / 7 deselected / 1 selected 
==================== 1 passed, 7 deselected in 208.62s (0:03:28) =====================
```