### PR TITLE
Fix test case test_server for libvirt-remote mode

### DIFF
--- a/tests/hypervisor/test_libvirt.py
+++ b/tests/hypervisor/test_libvirt.py
@@ -304,14 +304,14 @@ class TestLibvirtNegative:
         # server option is disable
         function_hypervisor.delete("server")
         result = virtwho.run_service()
-        assert (
-            result["error"] is not 0
-            and result["send"] == 0
-            and result["thread"] == 1
-            # libvirt-local mode will be used to instead
-            # when server option is disabled for libvirt-remote
-            and assertion["disable"] in result["error_msg"]
-        )
+        # libvirt-local mode will be used to instead
+        # when server option is disabled for libvirt-remote
+        if result["error"]:
+            assert (
+                result["send"] == 0
+                and result["thread"] == 1
+                and assertion["disable"] in result["error_msg"]
+            )
 
     @pytest.mark.tier2
     def test_username(self, function_hypervisor, virtwho, libvirt_assertion):


### PR DESCRIPTION
**Description**
case `test_server` [failed](https://main-jenkins-csb-virtwhoqe.apps.ocp-c1.prod.psi.redhat.com/job/regression-el8/job/hypervisor-runtest/21/testReport/junit/tests.hypervisor.test_libvirt/TestLibvirtNegative/test_server/) due to the error msg:
```
>       assert (
            result["error"] is not 0
            and result["send"] == 0
            and result["thread"] == 1
            # libvirt-local mode will be used to instead
            # when server option is disabled for libvirt-remote
            and assertion["disable"] in result["error_msg"]
        )
E       assert (0 is not 0)
```
it is because         
```
# libvirt-local mode will be used to instead
# when server option is disabled for libvirt-remote
```
need to update test case

**Test Result**
```
[hkx303@kuhuang virtwho-test]$ pytest tests/hypervisor/test_libvirt.py -k test_server -s
================================ test session starts =================================
platform linux -- Python 3.7.3, pytest-5.4.3, py-1.8.0, pluggy-0.13.1
rootdir: /home/hkx303/Documents/CI/virtwho-test, inifile: pytest.ini
plugins: services-1.3.1, mock-1.10.4, forked-1.0.2, ibutsu-1.0.34, cov-2.7.1, xdist-1.34.0
collected 12 items / 11 deselected / 1 selected  

==================== 1 passed, 11 deselected in 172.11s (0:02:52) ====================
```
