### PR TITLE
Update the send_number function for satellite

### DIFF
--- a/virtwho/runner.py
+++ b/virtwho/runner.py
@@ -323,8 +323,16 @@ class VirtwhoRunner:
             if "satellite" in self.register_type:
                 if self.mode == "local":
                     msg = r'Response: status=200, request="PUT /rhsm/consumers'
+                    return len(re.findall(msg, rhsm_log, re.I))
                 else:
+                    # mode is other hypervisor but also have local mode on virt-who host
+                    msg = r'Response: status=200, request="PUT /rhsm/consumers'
+                    if re.findall(msg, rhsm_log, re.I):
+                        return len(re.findall(msg, rhsm_log, re.I))
+                    # mode is other hypervisor but don't have local mode on virt-who host
                     msg = r'Response: status=200, request="POST /rhsm/hypervisors'
+                    if re.findall(msg, rhsm_log, re.I):
+                        return len(re.findall(msg, rhsm_log, re.I))
             if "rhsm" in self.register_type:
                 if self.mode == "local":
                     msg = (


### PR DESCRIPTION
**Description**
Test case `test_extension_file_name` for satellite [failed](https://main-jenkins-csb-virtwhoqe.apps.ocp-c1.prod.psi.redhat.com/job/regression-el8/job/hypervisor-runtest/25/testReport/junit/tests.hypervisor.test_esx/TestEsxNegative/test_extension_file_name/) due the error msg:
```
>       assert (
            result["error"] is not 0
            and result["send"] == 0
            and result["thread"] == 1
            and error_msg in result["error_msg"]
            and warning_msg in result["warning_msg"]
        )
E       assert (0 is not 0)
```
Need to update the send_number function for satellite to fix this issue


**Test Result**

```
[hkx303@kuhuang virtwho-test]$ pytest tests/hypervisor/test_esx.py -k test_extension_file_name -s
================================ test session starts =================================
platform linux -- Python 3.7.3, pytest-5.4.3, py-1.8.0, pluggy-0.13.1
rootdir: /home/hkx303/Documents/CI/virtwho-test, inifile: pytest.ini
plugins: services-1.3.1, mock-1.10.4, forked-1.0.2, ibutsu-1.0.34, cov-2.7.1, xdist-1.34.0
collected 29 items / 28 deselected / 1 selected   
==================== 1 passed, 28 deselected, 1 warning in 55.93s ====================
```