### PR TITLE
Add the pytest_runtest_logstart&logfinish functions

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,11 +11,19 @@ from virtwho.configure import hypervisor_create
 
 from virtwho.ssh import SSHConnect
 from virtwho.register import SubscriptionManager, Satellite, RHSM
-from virtwho import HYPERVISOR, REGISTER, RHEL_COMPOSE
+from virtwho import HYPERVISOR, REGISTER, RHEL_COMPOSE, logger
 from virtwho.base import hostname_get
 
 hypervisor_handler = get_hypervisor_handler(HYPERVISOR)
 register_handler = get_register_handler(REGISTER)
+
+
+def pytest_runtest_logstart(nodeid, location):
+    logger.info(f'Started Test: {nodeid}')
+
+
+def pytest_runtest_logfinish(nodeid, location):
+    logger.info(f'Finished Test: {nodeid}')
 
 
 @pytest.fixture(scope="class")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,11 +19,11 @@ register_handler = get_register_handler(REGISTER)
 
 
 def pytest_runtest_logstart(nodeid, location):
-    logger.info(f'Started Test: {nodeid}')
+    logger.info(f"Started Test: {nodeid}")
 
 
 def pytest_runtest_logfinish(nodeid, location):
-    logger.info(f'Finished Test: {nodeid}')
+    logger.info(f"Finished Test: {nodeid}")
 
 
 @pytest.fixture(scope="class")


### PR DESCRIPTION
**Description**
We need to add test log for test cases to identify what is the test case name for the log, so that we could see the failed cases directly

**Test Result**
```
[2023-08-09 15:12:12] - [conftest.py] - INFO: Started Test: tests/subscription/test_rhsm.py::TestRhsmScaDisable::test_vdc_virtual_pool_attach_by_auto

[2023-08-09 15:12:25] - [conftest.py] - INFO: Finished Test: tests/subscription/test_rhsm.py::TestRhsmScaDisable::test_vdc_virtual_pool_attach_by_auto
```
