### PR TITLE
Fix the teat case test_multi_hypervisors_report_together

### DIFF
--- a/tests/hypervisor/test_multi_hypervisors.py
+++ b/tests/hypervisor/test_multi_hypervisors.py
@@ -32,7 +32,7 @@ class TestMultiHypervisors:
         :expectedresults:
             1. Succeed to run the virt-who, no error messages in the rhsm.log
         """
-        for mode in hypervisors_list:
+        for mode in hypervisors_list():
             hypervisor_create(mode)
         result = virtwho.run_service()
         assert result["error"] == 0 and result["send"] == 1 and result["thread"] == 1


### PR DESCRIPTION
**Description**
Test case failed due to the error info:
```
self = <tests.hypervisor.test_multi_hypervisors.TestMultiHypervisors object at 0x7f4f32d3b490>
virtwho = <virtwho.runner.VirtwhoRunner object at 0x7f4f32d3b790>

    def test_multi_hypervisors_report_together(self, virtwho):
        """Test virt-who can report multi hypervisors together
    
        :title: virt-who: multiHypervisors: test multi hypervisors report together
        :id: 9fb6694e-7535-4d9f-9ac0-75e6cbe3066d
        :caseimportance: High
        :tags: hypervisor,multiHypervisor
        :customerscenario: false
        :upstream: no
        :steps:
            1. Create the virt-who config files for the multi hypervisors list
            2. Run the virt-who service
    
        :expectedresults:
            1. Succeed to run the virt-who, no error messages in the rhsm.log
        """
>       for mode in hypervisors_list:
E       TypeError: 'function' object is not iterable

tests/hypervisor/test_multi_hypervisors.py:35: TypeError 
```

**Test Result**
```
[hkx303@kuhuang virtwho-test]$ pytest tests/hypervisor/test_multi_hypervisors.py -s
================================ test session starts =================================
platform linux -- Python 3.7.3, pytest-5.4.3, py-1.8.0, pluggy-0.13.1
rootdir: /home/hkx303/Documents/CI/virtwho-test, inifile: pytest.ini
plugins: services-1.3.1, mock-1.10.4, forked-1.0.2, ibutsu-1.0.34, cov-2.7.1, xdist-1.34.0
collected 1 item  

=========================== 1 passed in 123.23s (0:02:03) ============================
```