### PR TITLE
Skip the strict host key checking when ssh access to virt-who server from guest

### DIFF
--- a/tests/function/test_service.py
+++ b/tests/function/test_service.py
@@ -132,17 +132,17 @@ class TestVirtwhoService:
         port = config.virtwho.port
         ssh_access_no_password(ssh_guest, ssh_host, server, port)
         # stop
-        ssh_guest.runcmd(f"ssh {server} -p {port} 'systemctl stop virt-who'")
+        ssh_guest.runcmd(f"ssh -o StrictHostKeyChecking=no {server} -p {port} 'systemctl stop virt-who'")
         _, status = virtwho.operate_service(action="status")
         assert status == "dead"
 
         # start
-        ssh_guest.runcmd(f"ssh {server} -p {port} 'systemctl restart virt-who'")
+        ssh_guest.runcmd(f"ssh -o StrictHostKeyChecking=no {server} -p {port} 'systemctl restart virt-who'")
         _, status = virtwho.operate_service(action="status")
         assert status == "running"
 
         # stop
-        ssh_guest.runcmd(f"ssh {server} -p {port} 'systemctl stop virt-who'")
+        ssh_guest.runcmd(f"ssh -o StrictHostKeyChecking=no {server} -p {port} 'systemctl stop virt-who'")
         _, status = virtwho.operate_service(action="status")
         assert status == "dead"
 

--- a/tests/function/test_service.py
+++ b/tests/function/test_service.py
@@ -132,17 +132,23 @@ class TestVirtwhoService:
         port = config.virtwho.port
         ssh_access_no_password(ssh_guest, ssh_host, server, port)
         # stop
-        ssh_guest.runcmd(f"ssh -o StrictHostKeyChecking=no {server} -p {port} 'systemctl stop virt-who'")
+        ssh_guest.runcmd(
+            f"ssh -o StrictHostKeyChecking=no {server} -p {port} 'systemctl stop virt-who'"
+        )
         _, status = virtwho.operate_service(action="status")
         assert status == "dead"
 
         # start
-        ssh_guest.runcmd(f"ssh -o StrictHostKeyChecking=no {server} -p {port} 'systemctl restart virt-who'")
+        ssh_guest.runcmd(
+            f"ssh -o StrictHostKeyChecking=no {server} -p {port} 'systemctl restart virt-who'"
+        )
         _, status = virtwho.operate_service(action="status")
         assert status == "running"
 
         # stop
-        ssh_guest.runcmd(f"ssh -o StrictHostKeyChecking=no {server} -p {port} 'systemctl stop virt-who'")
+        ssh_guest.runcmd(
+            f"ssh -o StrictHostKeyChecking=no {server} -p {port} 'systemctl stop virt-who'"
+        )
         _, status = virtwho.operate_service(action="status")
         assert status == "dead"
 


### PR DESCRIPTION
**Descirption**
Case [test_virtwho_service_control_by_ssh_connect](https://main-jenkins-csb-virtwhoqe.apps.ocp-c1.prod.psi.redhat.com/job/regression-el8/job/function-runtest/78/testReport/junit/tests.function.test_service/TestVirtwhoService/test_virtwho_service_control_by_ssh_connect/) failed due to the error info:

```
>       assert status == "dead"
E       AssertionError: assert 'running' == 'dead'
E         - dead
E         + running
```
the ssh key from virt-who host is different in hypervisor server, remove ~/.ssh/known_hosts file in hypervisor server, works fine. We can also skip the checking.

**Test Result**
```
[hkx303@kuhuang virtwho-test]$ pytest tests/function/test_service.py -k test_virtwho_service_control_by_ssh_connect -s
================================ test session starts =================================
platform linux -- Python 3.7.3, pytest-5.4.3, py-1.8.0, pluggy-0.13.1
rootdir: /home/hkx303/Documents/CI/virtwho-test, inifile: pytest.ini
plugins: services-1.3.1, mock-1.10.4, forked-1.0.2, ibutsu-1.0.34, cov-2.7.1, xdist-1.34.0
collected 9 items / 8 deselected / 1 selected  
===================== 1 passed, 8 deselected in 64.64s (0:01:04) =====================
```