### PR TITLE
[Automation] RHEL-137166 - Run virt-who in FIPS mode

### DIFF
--- a/tests/hypervisor/test_esx.py
+++ b/tests/hypervisor/test_esx.py
@@ -1499,10 +1499,6 @@ class TestEsxNegative:
             and result["send"] == 1
             and result["thread"] == 1
         )
-            
-            
-            
-
 
 def json_data_create(hypervisors_num, guests_num):
     """

--- a/tests/hypervisor/test_esx.py
+++ b/tests/hypervisor/test_esx.py
@@ -1441,7 +1441,7 @@ class TestEsxNegative:
         :title: virt-who: esx: test run virt-who in FIPS mode
         :id: 2a05a366-6b92-456a-89ca-c7576491c0bb
         :caseimportance: High
-        :tags: hypervisor,esx,tier2
+        :tags: hypervisor,esx,tier3
         :customerscenario: false
         :upstream: no
         :steps:
@@ -1459,7 +1459,7 @@ class TestEsxNegative:
         ssh_host.runcmd("fips-mode-setup --enable")
         ssh_host.runcmd("sudo reboot")
         start_time = time.time()
-        # 等待几秒，以便服务器开始重启过程
+        # Waiting for server to reboot
         time.sleep(interval)
         while not is_host_responsive(ssh_host.host):
             elapsed_time = time.time() - start_time
@@ -1472,7 +1472,6 @@ class TestEsxNegative:
         assert("1" in stdout)
         
         result = virtwho.run_service()
-        print(result)
         assert (
             result["error"] == 0
             and result["send"] == 1
@@ -1481,6 +1480,28 @@ class TestEsxNegative:
         
         ssh_host.runcmd("fips-mode-setup --disable")
         ssh_host.runcmd("sudo reboot")
+        start_time = time.time()
+        # Waiting for server to reboot
+        time.sleep(interval)
+        while not is_host_responsive(ssh_host.host):
+            elapsed_time = time.time() - start_time
+            if elapsed_time > timeout:
+                assert False, f"Timeout reached after {timeout} seconds!"
+            print(f"Waiting for server to come back online... Elapsed time: {int(elapsed_time)} seconds.")
+            time.sleep(interval)
+        
+        _, stdout = ssh_host.runcmd("cat /proc/sys/crypto/fips_enabled")
+        assert("0" in stdout)
+        
+        result = virtwho.run_service()
+        assert (
+            result["error"] == 0
+            and result["send"] == 1
+            and result["thread"] == 1
+        )
+            
+            
+            
 
 
 def json_data_create(hypervisors_num, guests_num):

--- a/tests/hypervisor/test_esx.py
+++ b/tests/hypervisor/test_esx.py
@@ -1436,7 +1436,23 @@ class TestEsxNegative:
     
     @pytest.mark.tier2
     @pytest.mark.notStage
-    def test_run_in_FIPS_mode(self, virtwho, ssh_host):
+    def test_run_in_FIPS_mode(self, function_hypervisor, virtwho, ssh_host):
+        """
+        :title: virt-who: esx: test run virt-who in FIPS mode
+        :id: 2a05a366-6b92-456a-89ca-c7576491c0bb
+        :caseimportance: High
+        :tags: hypervisor,esx,tier2
+        :customerscenario: false
+        :upstream: no
+        :steps:
+            1. Enable FIPS mode on the host
+            2. Reboot the host
+            3. Run virt-who service
+            4. Check the virt-who service status
+            5. Disable FIPS mode on the host
+        :expectedresults:
+            1. Succeeded to enable FIPS mode on the host
+        """
         timeout = 300
         interval = 5
         
@@ -1463,6 +1479,8 @@ class TestEsxNegative:
             and result["thread"] == 1
         )
         
+        ssh_host.runcmd("fips-mode-setup --disable")
+        ssh_host.runcmd("sudo reboot")
 
 
 def json_data_create(hypervisors_num, guests_num):

--- a/tests/hypervisor/test_esx.py
+++ b/tests/hypervisor/test_esx.py
@@ -1455,50 +1455,50 @@ class TestEsxNegative:
         """
         timeout = 300
         interval = 5
-        
-        ssh_host.runcmd("fips-mode-setup --enable")
-        ssh_host.runcmd("sudo reboot")
-        start_time = time.time()
-        # Waiting for server to reboot
-        time.sleep(interval)
-        while not is_host_responsive(ssh_host.host):
-            elapsed_time = time.time() - start_time
-            if elapsed_time > timeout:
-                assert False, f"Timeout reached after {timeout} seconds!"
-            print(f"Waiting for server to come back online... Elapsed time: {int(elapsed_time)} seconds.")
+        try:
+            ssh_host.runcmd("fips-mode-setup --enable")
+            ssh_host.runcmd("sudo reboot")
+            start_time = time.time()
+            # Waiting for server to reboot
             time.sleep(interval)
-        
-        _, stdout = ssh_host.runcmd("cat /proc/sys/crypto/fips_enabled")
-        assert("1" in stdout)
-        
-        result = virtwho.run_service()
-        assert (
-            result["error"] == 0
-            and result["send"] == 1
-            and result["thread"] == 1
-        )
-        
-        ssh_host.runcmd("fips-mode-setup --disable")
-        ssh_host.runcmd("sudo reboot")
-        start_time = time.time()
-        # Waiting for server to reboot
-        time.sleep(interval)
-        while not is_host_responsive(ssh_host.host):
-            elapsed_time = time.time() - start_time
-            if elapsed_time > timeout:
-                assert False, f"Timeout reached after {timeout} seconds!"
-            print(f"Waiting for server to come back online... Elapsed time: {int(elapsed_time)} seconds.")
+            while not is_host_responsive(ssh_host.host):
+                elapsed_time = time.time() - start_time
+                if elapsed_time > timeout:
+                    assert False, f"Timeout reached after {timeout} seconds!"
+                print(f"Waiting for server to come back online... Elapsed time: {int(elapsed_time)} seconds.")
+                time.sleep(interval)
+            
+            _, stdout = ssh_host.runcmd("cat /proc/sys/crypto/fips_enabled")
+            assert("1" in stdout)
+            
+            result = virtwho.run_service()
+            assert (
+                result["error"] == 0
+                and result["send"] == 1
+                and result["thread"] == 1
+            )
+        finally:
+            ssh_host.runcmd("fips-mode-setup --disable")
+            ssh_host.runcmd("sudo reboot")
+            start_time = time.time()
+            # Waiting for server to reboot
             time.sleep(interval)
-        
-        _, stdout = ssh_host.runcmd("cat /proc/sys/crypto/fips_enabled")
-        assert("0" in stdout)
-        
-        result = virtwho.run_service()
-        assert (
-            result["error"] == 0
-            and result["send"] == 1
-            and result["thread"] == 1
-        )
+            while not is_host_responsive(ssh_host.host):
+                elapsed_time = time.time() - start_time
+                if elapsed_time > timeout:
+                    assert False, f"Timeout reached after {timeout} seconds!"
+                print(f"Waiting for server to come back online... Elapsed time: {int(elapsed_time)} seconds.")
+                time.sleep(interval)
+            
+            _, stdout = ssh_host.runcmd("cat /proc/sys/crypto/fips_enabled")
+            assert("0" in stdout)
+            
+            result = virtwho.run_service()
+            assert (
+                result["error"] == 0
+                and result["send"] == 1
+                and result["thread"] == 1
+            )
 
 def json_data_create(hypervisors_num, guests_num):
     """

--- a/tests/hypervisor/test_esx.py
+++ b/tests/hypervisor/test_esx.py
@@ -1450,6 +1450,8 @@ class TestEsxNegative:
             3. Run virt-who service
             4. Check the virt-who service status
             5. Disable FIPS mode on the host
+            6. Reboot the host
+            
         :expectedresults:
             1. Succeeded to enable FIPS mode on the host
         """
@@ -1492,13 +1494,6 @@ class TestEsxNegative:
             
             _, stdout = ssh_host.runcmd("cat /proc/sys/crypto/fips_enabled")
             assert("0" in stdout)
-            
-            result = virtwho.run_service()
-            assert (
-                result["error"] == 0
-                and result["send"] == 1
-                and result["thread"] == 1
-            )
 
 def json_data_create(hypervisors_num, guests_num):
     """
@@ -1527,6 +1522,5 @@ def is_host_responsive(host):
     :param host: host ip address
     :return: True or False
     """
-    print(host)
     cmd = f"ping -c 1 {host}"
     return os.system(cmd) == 0

--- a/tests/hypervisor/test_esx.py
+++ b/tests/hypervisor/test_esx.py
@@ -1434,8 +1434,7 @@ class TestEsxNegative:
             logger.warning("Failed to post json to satellite")
             logger.warning(output)
     
-    @pytest.mark.tier2
-    @pytest.mark.notStage
+    @pytest.mark.tier3
     def test_run_in_FIPS_mode(self, function_hypervisor, virtwho, ssh_host):
         """
         :title: virt-who: esx: test run virt-who in FIPS mode

--- a/tests/hypervisor/test_esx.py
+++ b/tests/hypervisor/test_esx.py
@@ -1465,7 +1465,7 @@ class TestEsxNegative:
                 elapsed_time = time.time() - start_time
                 if elapsed_time > timeout:
                     assert False, f"Timeout reached after {timeout} seconds!"
-                print(f"Waiting for server to come back online... Elapsed time: {int(elapsed_time)} seconds.")
+                logger.info(f"Waiting for server to come back online... Elapsed time: {int(elapsed_time)} seconds.")
                 time.sleep(interval)
             
             _, stdout = ssh_host.runcmd("cat /proc/sys/crypto/fips_enabled")
@@ -1487,7 +1487,7 @@ class TestEsxNegative:
                 elapsed_time = time.time() - start_time
                 if elapsed_time > timeout:
                     assert False, f"Timeout reached after {timeout} seconds!"
-                print(f"Waiting for server to come back online... Elapsed time: {int(elapsed_time)} seconds.")
+                logger.info(f"Waiting for server to come back online... Elapsed time: {int(elapsed_time)} seconds.")
                 time.sleep(interval)
             
             _, stdout = ssh_host.runcmd("cat /proc/sys/crypto/fips_enabled")


### PR DESCRIPTION
**Description**
Add a automation test case to test ESXi available in FIPS mode.

**Test Result**
```
================================================================== test session starts ==================================================================
platform linux -- Python 3.9.13, pytest-6.2.5, py-1.11.0, pluggy-0.13.1
rootdir: /home/jzhang/文档/test_repos/virtwho-test, configfile: pytest.ini
plugins: anyio-3.5.0, services-1.3.1, mock-1.10.4, forked-1.6.0, xdist-1.34.0
collected 30 items / 29 deselected / 1 selected                                                                                                         

tests/hypervisor/test_esx.py .                                                                                                                    [100%]

=================================================================== warnings summary ====================================================================
../../../anaconda3/lib/python3.9/site-packages/paramiko/transport.py:216
  /home/jzhang/anaconda3/lib/python3.9/site-packages/paramiko/transport.py:216: CryptographyDeprecationWarning: Blowfish has been deprecated
    "class": algorithms.Blowfish,

tests/hypervisor/test_esx.py:1394
  /home/jzhang/文档/test_repos/virtwho-test/tests/hypervisor/test_esx.py:1394: PytestUnknownMarkWarning: Unknown pytest.mark.notStage - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/mark.html
    @pytest.mark.notStage

tests/hypervisor/test_esx.py:1438
  /home/jzhang/文档/test_repos/virtwho-test/tests/hypervisor/test_esx.py:1438: PytestUnknownMarkWarning: Unknown pytest.mark.notStage - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/mark.html
    @pytest.mark.notStage

-- Docs: https://docs.pytest.org/en/stable/warnings.html
=============================================== 1 passed, 29 deselected, 3 warnings in 219.69s (0:03:39) ================================================
[2023-10-25 10:51:06] - [conftest.py] - INFO: Finished Test: tests/hypervisor/test_esx.py::TestEsxNegative::test_run_in_FIPS_mode
```