### PR TITLE
Fix the test case test_fake_type

### DIFF
--- a/tests/hypervisor/test_ahv.py
+++ b/tests/hypervisor/test_ahv.py
@@ -203,9 +203,10 @@ class TestAHVPositive:
         virtwho.run_cli(prt=True, oneshot=False)
         function_hypervisor.destroy()
 
-        fake_config = hypervisor_create("fake", REGISTER, rhsm=False)
+        fake_config = hypervisor_create("fake", REGISTER, rhsm=True)
         fake_config.update("file", PRINT_JSON_FILE)
         fake_config.update("is_hypervisor", "True")
+        sm_host.register()
         result = virtwho.run_service()
         assert (
             result["error"] == 0

--- a/tests/hypervisor/test_ahv.py
+++ b/tests/hypervisor/test_ahv.py
@@ -206,7 +206,6 @@ class TestAHVPositive:
         fake_config = hypervisor_create("fake", REGISTER, rhsm=True)
         fake_config.update("file", PRINT_JSON_FILE)
         fake_config.update("is_hypervisor", "True")
-        sm_host.register()
         result = virtwho.run_service()
         assert (
             result["error"] == 0

--- a/tests/hypervisor/test_esx.py
+++ b/tests/hypervisor/test_esx.py
@@ -1433,7 +1433,7 @@ class TestEsxNegative:
         else:
             logger.warning("Failed to post json to satellite")
             logger.warning(output)
-    
+
     @pytest.mark.tier3
     def test_run_in_FIPS_mode(self, function_hypervisor, virtwho, ssh_host):
         """
@@ -1450,7 +1450,7 @@ class TestEsxNegative:
             4. Check the virt-who service status
             5. Disable FIPS mode on the host
             6. Reboot the host
-            
+
         :expectedresults:
             1. Succeeded to enable FIPS mode on the host
         """
@@ -1466,17 +1466,17 @@ class TestEsxNegative:
                 elapsed_time = time.time() - start_time
                 if elapsed_time > timeout:
                     assert False, f"Timeout reached after {timeout} seconds!"
-                logger.info(f"Waiting for server to come back online... Elapsed time: {int(elapsed_time)} seconds.")
+                logger.info(
+                    f"Waiting for server to come back online... Elapsed time: {int(elapsed_time)} seconds."
+                )
                 time.sleep(interval)
-            
+
             _, stdout = ssh_host.runcmd("cat /proc/sys/crypto/fips_enabled")
-            assert("1" in stdout)
-            
+            assert "1" in stdout
+
             result = virtwho.run_service()
             assert (
-                result["error"] == 0
-                and result["send"] == 1
-                and result["thread"] == 1
+                result["error"] == 0 and result["send"] == 1 and result["thread"] == 1
             )
         finally:
             ssh_host.runcmd("fips-mode-setup --disable")
@@ -1488,11 +1488,14 @@ class TestEsxNegative:
                 elapsed_time = time.time() - start_time
                 if elapsed_time > timeout:
                     assert False, f"Timeout reached after {timeout} seconds!"
-                logger.info(f"Waiting for server to come back online... Elapsed time: {int(elapsed_time)} seconds.")
+                logger.info(
+                    f"Waiting for server to come back online... Elapsed time: {int(elapsed_time)} seconds."
+                )
                 time.sleep(interval)
-            
+
             _, stdout = ssh_host.runcmd("cat /proc/sys/crypto/fips_enabled")
-            assert("0" in stdout)
+            assert "0" in stdout
+
 
 def json_data_create(hypervisors_num, guests_num):
     """
@@ -1514,6 +1517,7 @@ def json_data_create(hypervisors_num, guests_num):
             )
         virtwho[str(uuid.uuid4()).replace("-", ".")] = guest_list
     return virtwho
+
 
 def is_host_responsive(host):
     """

--- a/tests/hypervisor/test_esx.py
+++ b/tests/hypervisor/test_esx.py
@@ -312,7 +312,7 @@ class TestEsxPositive:
         virtwho.run_cli(prt=True, oneshot=False)
         function_hypervisor.destroy()
 
-        fake_config = hypervisor_create("fake", REGISTER, rhsm=False)
+        fake_config = hypervisor_create("fake", REGISTER, rhsm=True)
         fake_config.update("file", PRINT_JSON_FILE)
         fake_config.update("is_hypervisor", "True")
         result = virtwho.run_service()

--- a/tests/hypervisor/test_hyperv.py
+++ b/tests/hypervisor/test_hyperv.py
@@ -188,7 +188,7 @@ class TestHypervPositive:
         virtwho.run_cli(prt=True, oneshot=False)
         function_hypervisor.destroy()
 
-        fake_config = hypervisor_create("fake", REGISTER, rhsm=False)
+        fake_config = hypervisor_create("fake", REGISTER, rhsm=True)
         fake_config.update("file", PRINT_JSON_FILE)
         fake_config.update("is_hypervisor", "True")
         result = virtwho.run_service()

--- a/tests/hypervisor/test_kubevirt.py
+++ b/tests/hypervisor/test_kubevirt.py
@@ -157,7 +157,7 @@ class TestKubevirtPositive:
         virtwho.run_cli(prt=True, oneshot=False)
         function_hypervisor.destroy()
 
-        fake_config = hypervisor_create("fake", REGISTER, rhsm=False)
+        fake_config = hypervisor_create("fake", REGISTER, rhsm=True)
         fake_config.update("file", PRINT_JSON_FILE)
         fake_config.update("is_hypervisor", "True")
         result = virtwho.run_service()

--- a/tests/hypervisor/test_libvirt.py
+++ b/tests/hypervisor/test_libvirt.py
@@ -186,7 +186,7 @@ class TestLibvrtPositive:
         virtwho.run_cli(prt=True, oneshot=False)
         function_hypervisor.destroy()
 
-        fake_config = hypervisor_create("fake", REGISTER, rhsm=False)
+        fake_config = hypervisor_create("fake", REGISTER, rhsm=True)
         fake_config.update("file", PRINT_JSON_FILE)
         fake_config.update("is_hypervisor", "True")
         result = virtwho.run_service()

--- a/tests/hypervisor/test_rhevm.py
+++ b/tests/hypervisor/test_rhevm.py
@@ -196,7 +196,7 @@ class TestRHEVMPositive:
         virtwho.run_cli(prt=True, oneshot=False)
         function_hypervisor.destroy()
 
-        fake_config = hypervisor_create("fake", REGISTER, rhsm=False)
+        fake_config = hypervisor_create("fake", REGISTER, rhsm=True)
         fake_config.update("file", PRINT_JSON_FILE)
         fake_config.update("is_hypervisor", "True")
         result = virtwho.run_service()

--- a/tests/hypervisor/test_xen.py
+++ b/tests/hypervisor/test_xen.py
@@ -188,7 +188,7 @@ class TestXenPositive:
         virtwho.run_cli(prt=True, oneshot=False)
         function_hypervisor.destroy()
 
-        fake_config = hypervisor_create("fake", REGISTER, rhsm=False)
+        fake_config = hypervisor_create("fake", REGISTER, rhsm=True)
         fake_config.update("file", PRINT_JSON_FILE)
         fake_config.update("is_hypervisor", "True")
         result = virtwho.run_service()


### PR DESCRIPTION
**Description**
test case `test_fake_type` failed due to the error info:
```
E       assert (2 == 0
E         +2
E         -0)

tests/hypervisor/test_esx.py:318: AssertionError
```
it is because the virt-who host doesn't register to the expected platform, need to fix this issue.

**Test Result**
```
[hkx303@kuhuang virtwho-test]$ pytest tests/hypervisor/test_libvirt.py -k test_fake_type -s
================================ test session starts =================================
platform linux -- Python 3.7.3, pytest-5.4.3, py-1.8.0, pluggy-0.13.1
rootdir: /home/hkx303/Documents/CI/virtwho-test, inifile: pytest.ini
plugins: services-1.3.1, mock-1.10.4, forked-1.0.2, ibutsu-1.0.34, cov-2.7.1, xdist-1.34.0
collected 12 items / 11 deselected / 1 selected 
==================== 1 passed, 11 deselected in 122.58s (0:02:02) ====================
```
