### PR TITLE
update test_http_proxy_in_virtwho_conf

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -376,6 +376,7 @@ def owner_data():
     owner["error"] = [
         f"Organization with id {bad_owner} could not be found",
         f"Couldn't find Organization '{bad_owner}'",
+        f"[Owner] with ID(s) {bad_owner} could not be found",
     ]
     # the errors for null are different when virt-who host registered and unreigstered.
     owner["null_error"] = [

--- a/tests/function/test_config.py
+++ b/tests/function/test_config.py
@@ -21,7 +21,7 @@ from virtwho.base import hostname_get
 @pytest.mark.usefixtures("function_globalconf_clean")
 @pytest.mark.usefixtures("class_hypervisor")
 @pytest.mark.usefixtures("class_virtwho_d_conf_clean")
-class TestConfiguration:
+class TestConfigurationPositive:
     @pytest.mark.tier1
     def test_debug_in_virtwho_conf(self, virtwho, globalconf):
         """Test the debug option in /etc/virtwho.conf
@@ -520,22 +520,22 @@ class TestConfiguration:
             globalconf.update("system_environment", proxy, proxy_data[proxy])
             result = virtwho.run_service()
             if HYPERVISOR == "ahv":
-                logger.info("=== AHV: failed with bz1992619 ===")
+                logger.info("=== AHV: failed with RHEL-1309 ===")
             assert (
                 result["error"] == 0
                 and result["send"] == 1
                 and result["thread"] == 1
-                # Skip the below assertion due to open bz1989354
+                # Skip the below assertion due to open rhel13376
                 # and connection_msg in result["log"]
                 # and proxy_msg in result["log"]
             )
-            bz1989354_test = result["log"]
+            rhel13376_test = result["log"]
 
             # run virt-who with unreachable http_proxy/https_proxy setting
             globalconf.update("system_environment", proxy, proxy_data[f"bad_{proxy}"])
             result = virtwho.run_service()
-            if HYPERVISOR in ("kubvirt", "hyperv", "libvirt"):
-                logger.info("=== Kubevirt/Hyperv/Libvirt: failed with bz2175098 ===")
+            if HYPERVISOR in ("kubevirt", "hyperv", "libvirt"):
+                logger.info("=== Kubevirt/Hyperv/Libvirt: failed with RHEL-12391 ===")
             assert result["error"] in (1, 2)
             assert any(
                 error_msg in result["error_msg"] for error_msg in proxy_data["error"]
@@ -550,8 +550,8 @@ class TestConfiguration:
 
             globalconf.delete("system_environment")
 
-        logger.info("=== All Hypervisors: failed with bz1989354 ===")
-        assert connection_msg in bz1989354_test and proxy_msg in bz1989354_test
+        logger.info("=== All Hypervisors: failed with RHEL-13376 ===")
+        assert connection_msg in rhel13376_test and proxy_msg in rhel13376_test
 
 
 @pytest.mark.usefixtures("function_host_register_for_local_mode")

--- a/tests/hypervisor/test_hyperv.py
+++ b/tests/hypervisor/test_hyperv.py
@@ -22,6 +22,7 @@ from virtwho.configure import hypervisor_create
 
 from hypervisor.virt.hyperv.hypervcli import HypervCLI
 
+
 @pytest.mark.usefixtures("function_virtwho_d_conf_clean")
 @pytest.mark.usefixtures("class_debug_true")
 @pytest.mark.usefixtures("class_globalconf_clean")
@@ -636,11 +637,13 @@ class TestHypervNegative:
                 and result["thread"] == 1
                 and hostname not in str(result["mappings"])
             )
-    
+
     @pytest.mark.tier3
-    def test_biosguid_null(self, virtwho, function_hypervisor, hypervisor_data, register_data):
+    def test_biosguid_null(
+        self, virtwho, function_hypervisor, hypervisor_data, register_data
+    ):
         """Test if the biosguid is null, whether virt-who can send the guest info to server.
-        
+
         :title: virt-who: hyperv: test biosguid null
         :id: 4de4fed0-97c2-4146-9540-2223386297c4
         :caseimportance: High
@@ -661,26 +664,24 @@ class TestHypervNegative:
             4. Succeeded to change the biosguid to null.
             5. Succeeded to run the virt-who, cannot find the guest info in the server.
         """
-        
+
         hyperv = HypervCLI(
-            server = hypervisor_data["hypervisor_server"],
-            ssh_user = hypervisor_data["hypervisor_username"],
-            ssh_pwd = hypervisor_data["hypervisor_password"],
+            server=hypervisor_data["hypervisor_server"],
+            ssh_user=hypervisor_data["hypervisor_username"],
+            ssh_pwd=hypervisor_data["hypervisor_password"],
         )
-        
+
         result = virtwho.run_service()
-        assert (
-            result["error"] == 0
-            and result["send"] == 1
-            and result["thread"] == 1
-        )
+        assert result["error"] == 0 and result["send"] == 1 and result["thread"] == 1
         try:
             origin_guid = hyperv.guest_uuid()
             assert origin_guid != ""
 
-            result = hyperv.guest_uuid_change("00000000-0000-0000-0000-000000000000", hypervisor_data['guest_name'])
+            result = hyperv.guest_uuid_change(
+                "00000000-0000-0000-0000-000000000000", hypervisor_data["guest_name"]
+            )
             assert result is True
-            
+
             timeout = 300
             interval = 5
             start_time = time.time()
@@ -689,20 +690,27 @@ class TestHypervNegative:
                 if elapsed_time > timeout:
                     assert False, f"Timeout reached after {timeout} seconds!"
                 time.sleep(interval)
-            
+
             result = virtwho.run_service()
             assert (
                 result["error"] == 0
                 and result["send"] == 1
                 and result["thread"] == 1
-                and len(result["mappings"][register_data["default_org"]][hypervisor_data["hypervisor_hostname"]]["guests"])==0
+                and len(
+                    result["mappings"][register_data["default_org"]][
+                        hypervisor_data["hypervisor_hostname"]
+                    ]["guests"]
+                )
+                == 0
             )
-            
+
             new_guid = hyperv.guest_uuid()
             assert new_guid == ""
         finally:
-            result = hyperv.guest_uuid_change(origin_guid, hypervisor_data['guest_name'])
+            result = hyperv.guest_uuid_change(
+                origin_guid, hypervisor_data["guest_name"]
+            )
             assert result is True
-            
+
             final_guid = hyperv.guest_uuid()
             assert final_guid == origin_guid

--- a/virtwho/base.py
+++ b/virtwho/base.py
@@ -645,6 +645,7 @@ def hypervisors_list():
     """
     return config.job.multi_hypervisors.strip("[").strip("]").split(",")
 
+
 def is_host_responsive(host):
     """
     Check if the host is responsive


### PR DESCRIPTION
- [x] The latest virt-who prints new error message `[Owner] with ID(s) {bad_owner} could not be found`, which is reasonable, so updated the error list.
- [x] Change the issue id to Jira.
- [x] Correct one spelling mistake, `kubvirt` -> `kubevirt`, which help to print log for kubevirt mode.  

