### PR TITLE
Debug network issue of case test_vdc_virtual_subscription_on_webui

### DIFF
--- a/tests/subscription/test_satellite.py
+++ b/tests/subscription/test_satellite.py
@@ -607,9 +607,9 @@ class TestSatelliteScaDisable:
 
             1. Register guest to entitlement server
             2. Attach physical vdc pool to hypervisor
-            3. Check the virtual vdc subscription
-            4. Attach virtual vdc pool to sm
-            5. Check the virtual vdc subscription again
+            3. Check the virtual vdc subscription on webui
+            4. Attach virtual vdc pool to the guest
+            5. Check the virtual vdc subscription on webui again
 
         :expectedresults:
 
@@ -630,6 +630,9 @@ class TestSatelliteScaDisable:
             satellite.host_delete(host=hypervisor_hostname)
         _ = virtwho.run_cli()
         satellite.attach(host=hypervisor_hostname, pool=vdc_pool_physical)
+
+        time.sleep(5)
+        sm_guest.refresh()
         vdc_virt_data = sm_guest.available(vdc_virtual_sku, "Virtual")
         vdc_virt_pool = vdc_virt_data["pool_id"]
         subscription = satellite.subscription_on_webui(vdc_virt_pool)
@@ -647,7 +650,6 @@ class TestSatelliteScaDisable:
         )
 
         # check the subscription with virtual vdc pool attached for guest
-        sm_guest.refresh()
         sm_guest.attach(pool=vdc_virt_pool)
         for i in range(3):
             time.sleep(30)


### PR DESCRIPTION
The testcase `test_vdc_virtual_subscription_on_webui` always failed in the automation workflow, but could be passed in the local debug, so guess it should be the network issue.
Add 5 seconds wait and run the sub-man refresh before checking the subscription.

**Test Result**
```
% python3 -m pytest -v tests/subscription/test_satellite.py -k 'test_vdc_virtual_subscription_on_webui'
========================================================= test session starts =========================================================
platform darwin -- Python 3.11.2, pytest-7.2.2, pluggy-1.0.0 -- /opt/homebrew/opt/python@3.11/bin/python3.11
cachedir: .pytest_cache
rootdir: /Users/yuefliu/workspace/virtwho-test, configfile: pytest.ini
collected 11 items / 10 deselected / 1 selected                                                                                       

tests/subscription/test_satellite.py::TestSatelliteScaDisable::test_vdc_virtual_subscription_on_webui PASSED                    [100%]

====================================== 1 passed, 10 deselected, 2 warnings in 176.86s (0:02:56) =======================================
[2024-01-26 14:58:52] - [conftest.py] - INFO: Finished Test: tests/subscription/test_satellite.py::TestSatelliteScaDisable::test_vdc_virtual_subscription_on_webui
```