### PR TITLE
Interval cases: update for ahv due to bz1996923 won't fix

### DIFF
--- a/tests/function/test_cli.py
+++ b/tests/function/test_cli.py
@@ -10,7 +10,7 @@ import threading
 import time
 import pytest
 
-from virtwho import HYPERVISOR
+from virtwho import HYPERVISOR, RHEL_COMPOSE
 from virtwho import HYPERVISOR_FILE, config
 from virtwho.base import encrypt_password
 
@@ -124,7 +124,7 @@ class TestCli:
         result = virtwho.run_cli(oneshot=False, interval=60, wait=60)
         assert (result["send"] == 1 and result["interval"] == 60)
         # Nutanix bug bz1996923 won't fix
-        if HYPERVISOR == "ahv":
+        if HYPERVISOR == "ahv" and "RHEL-8" in RHEL_COMPOSE:
             rhsm_log = virtwho.rhsm_log_get()
             assert "No data to send, waiting for next interval" in rhsm_log
         else:

--- a/tests/function/test_cli.py
+++ b/tests/function/test_cli.py
@@ -122,11 +122,13 @@ class TestCli:
         assert result["send"] == 1 and result["interval"] == 3600
 
         result = virtwho.run_cli(oneshot=False, interval=60, wait=60)
-        assert (
-            result["send"] == 1
-            and result["interval"] == 60
-            and (result["loop"] == 60 or result["loop"] == 61)
-        )
+        assert (result["send"] == 1 and result["interval"] == 60)
+        # Nutanix bug bz1996923 won't fix
+        if HYPERVISOR == "ahv":
+            rhsm_log = virtwho.rhsm_log_get()
+            assert "No data to send, waiting for next interval" in rhsm_log
+        else:
+            assert (result["loop"] == 60 or result["loop"] == 61)
 
     @pytest.mark.tier1
     def test_print(self, virtwho, hypervisor_data):

--- a/tests/function/test_cli.py
+++ b/tests/function/test_cli.py
@@ -122,13 +122,13 @@ class TestCli:
         assert result["send"] == 1 and result["interval"] == 3600
 
         result = virtwho.run_cli(oneshot=False, interval=60, wait=60)
-        assert (result["send"] == 1 and result["interval"] == 60)
+        assert result["send"] == 1 and result["interval"] == 60
         # Nutanix bug bz1996923 won't fix
         if HYPERVISOR == "ahv" and "RHEL-8" in RHEL_COMPOSE:
             rhsm_log = virtwho.rhsm_log_get()
             assert "No data to send, waiting for next interval" in rhsm_log
         else:
-            assert (result["loop"] == 60 or result["loop"] == 61)
+            assert result["loop"] == 60 or result["loop"] == 61
 
     @pytest.mark.tier1
     def test_print(self, virtwho, hypervisor_data):

--- a/tests/function/test_config.py
+++ b/tests/function/test_config.py
@@ -8,7 +8,7 @@
 """
 import pytest
 
-from virtwho import HYPERVISOR
+from virtwho import HYPERVISOR, RHEL_COMPOSE
 from virtwho import HYPERVISOR_FILE
 from virtwho import REGISTER
 from virtwho import SYSCONFIG_FILE
@@ -82,7 +82,7 @@ class TestConfigurationPositive:
         result = virtwho.run_service(wait=60)
         assert (result["send"] == 1 and result["error"] == 0)
         # Nutanix bug bz1996923 won't fix
-        if HYPERVISOR == "ahv":
+        if HYPERVISOR == "ahv" and "RHEL-8" in RHEL_COMPOSE:
             rhsm_log = virtwho.rhsm_log_get()
             assert "No data to send, waiting for next interval" in rhsm_log
         else:
@@ -665,7 +665,7 @@ class TestSysConfiguration:
         result = virtwho.run_service(wait=60)
         assert (result["send"] == 1 and result["error"] == 0)
         # Nutanix bug bz1996923 won't fix
-        if HYPERVISOR == "ahv":
+        if HYPERVISOR == "ahv" and "RHEL-8" in RHEL_COMPOSE:
             rhsm_log = virtwho.rhsm_log_get()
             assert "No data to send, waiting for next interval" in rhsm_log
         else:

--- a/tests/function/test_config.py
+++ b/tests/function/test_config.py
@@ -80,7 +80,7 @@ class TestConfigurationPositive:
 
         globalconf.update("global", "interval", "60")
         result = virtwho.run_service(wait=60)
-        assert (result["send"] == 1 and result["error"] == 0)
+        assert result["send"] == 1 and result["error"] == 0
         # Nutanix bug bz1996923 won't fix
         if HYPERVISOR == "ahv" and "RHEL-8" in RHEL_COMPOSE:
             rhsm_log = virtwho.rhsm_log_get()
@@ -663,7 +663,7 @@ class TestSysConfiguration:
         sysconfg_options["VIRTWHO_INTERVAL"] = 60
         function_sysconfig.update(**sysconfg_options)
         result = virtwho.run_service(wait=60)
-        assert (result["send"] == 1 and result["error"] == 0)
+        assert result["send"] == 1 and result["error"] == 0
         # Nutanix bug bz1996923 won't fix
         if HYPERVISOR == "ahv" and "RHEL-8" in RHEL_COMPOSE:
             rhsm_log = virtwho.rhsm_log_get()

--- a/tests/function/test_config.py
+++ b/tests/function/test_config.py
@@ -80,9 +80,13 @@ class TestConfigurationPositive:
 
         globalconf.update("global", "interval", "60")
         result = virtwho.run_service(wait=60)
-        assert (
-            result["send"] == 1 and result["error"] == 0 and result["loop"] in [60, 61]
-        )
+        assert (result["send"] == 1 and result["error"] == 0)
+        # Nutanix bug bz1996923 won't fix
+        if HYPERVISOR == "ahv":
+            rhsm_log = virtwho.rhsm_log_get()
+            assert "No data to send, waiting for next interval" in rhsm_log
+        else:
+            assert result["loop"] in [60, 61]
 
     @pytest.mark.tier1
     def test_oneshot_in_virtwho_conf(self, virtwho, globalconf):
@@ -659,9 +663,13 @@ class TestSysConfiguration:
         sysconfg_options["VIRTWHO_INTERVAL"] = 60
         function_sysconfig.update(**sysconfg_options)
         result = virtwho.run_service(wait=60)
-        assert (
-            result["send"] == 1 and result["error"] == 0 and result["loop"] in [60, 61]
-        )
+        assert (result["send"] == 1 and result["error"] == 0)
+        # Nutanix bug bz1996923 won't fix
+        if HYPERVISOR == "ahv":
+            rhsm_log = virtwho.rhsm_log_get()
+            assert "No data to send, waiting for next interval" in rhsm_log
+        else:
+            assert result["loop"] in [60, 61]
 
         function_sysconfig.clean()
 


### PR DESCRIPTION
The https://bugzilla.redhat.com/show_bug.cgi?id=1996923 has been closed as won't fix, so now update the code for ahv to ignore checking the loop time around interval testing, but adding step to check another key words to make sure the virt-who can rerun after 60 seconds.


**Test Result**
```
% python3 -m pytest --disable-warnings -v tests/function -k 'test_interval'
========================================================= test session starts =========================================================
platform darwin -- Python 3.11.2, pytest-7.2.2, pluggy-1.0.0 -- /opt/homebrew/opt/python@3.11/bin/python3.11
cachedir: .pytest_cache
rootdir: /Users/yuefliu/workspace/virtwho-test, configfile: pytest.ini
collected 38 items / 35 deselected / 3 selected                                                                                       

tests/function/test_cli.py::TestCli::test_interval PASSED                                                                       [ 33%]
tests/function/test_config.py::TestConfigurationPositive::test_interval_in_virtwho_conf PASSED                                  [ 66%]
tests/function/test_config.py::TestSysConfiguration::test_interval_in_virtwho_sysconfig PASSED                                  [100%]

====================================== 3 passed, 35 deselected, 7 warnings in 474.56s (0:07:54) =======================================
```