### PR TITLE
Add param log_print=True to function runcmd()

### DIFF
--- a/virtwho/runner.py
+++ b/virtwho/runner.py
@@ -209,7 +209,7 @@ class VirtwhoRunner:
         """
         if cli:
             logger.info(f"Start to run virt-who by cli: {cli}")
-            _, output = self.ssh.runcmd(cli)
+            _, output = self.ssh.runcmd(cli, log_print=False)
         else:
             logger.info("Start to run virt-who by service")
             _, output = self.operate_service()

--- a/virtwho/ssh.py
+++ b/virtwho/ssh.py
@@ -71,10 +71,11 @@ class SSHConnect:
         sftp = paramiko.SFTPClient.from_transport(transport)
         return sftp, transport
 
-    def runcmd(self, cmd, if_stdout=False):
+    def runcmd(self, cmd, if_stdout=False, log_print=True):
         """Executes SSH command on remote hostname.
         :param str cmd: The command to run
         :param str if_stdout: default to return to stderr
+        :param str log_print: default to print the output
         """
         ssh = self._connect()
         logger.info(f"[{self.host}:{self.port}] >>> {cmd}")
@@ -83,10 +84,12 @@ class SSHConnect:
         stdout, stderr = stdout.read(), stderr.read()
         ssh.close()
         if if_stdout or not stderr:
-            logger.info("<<< stdout\n{}".format(stdout.decode()))
+            if log_print:
+                logger.info("<<< stdout\n{}".format(stdout.decode()))
             return code, stdout.decode()
         else:
-            logger.info("<<< stderr\n{}".format(stderr.decode()))
+            if log_print:
+                logger.info("<<< stderr\n{}".format(stderr.decode()))
             return code, stderr.decode()
 
     def get_file(self, remote_file, local_file):


### PR DESCRIPTION
We always got much log messages in the jenkins job, most of the logs are the output after run virt-who by cli, which logs were always printed twice, one is the output of the virt-who, the other is from cat log file, so this pr added a new parameter `log_print=True` to provide us selection if the output need to be printed.
The default is also to print the log when call runcmd(), we may only need to ignore the log print after run virt-who cli, because we can see the same log in the following #cat /var/log/rhsm/rhsm.log.