### PR TITLE
Fix test_vdc_virtual_subscription_on_webui issue

### DIFF
--- a/tests/subscription/test_satellite.py
+++ b/tests/subscription/test_satellite.py
@@ -31,7 +31,7 @@ hypervisor_handler = get_hypervisor_handler(HYPERVISOR)
 @pytest.mark.usefixtures("class_virtwho_d_conf_clean")
 @pytest.mark.usefixtures("class_globalconf_clean")
 @pytest.mark.usefixtures("function_guest_unattach")
-@pytest.mark.usefixtures("class_guest_register")
+@pytest.mark.usefixtures("function_guest_register")
 @pytest.mark.usefixtures("function_host_register_for_local_mode")
 @pytest.mark.usefixtures("class_satellite_sca_disable")
 class TestSatelliteScaDisable:
@@ -515,6 +515,7 @@ class TestSatelliteScaDisable:
         finally:
             class_hypervisor.update("owner", default_org)
             satellite_second_org.host_delete(host=hypervisor_hostname)
+            sm_guest_second_org.unregister()
 
     @pytest.mark.tier2
     @pytest.mark.notLocal
@@ -590,6 +591,7 @@ class TestSatelliteScaDisable:
         finally:
             function_hypervisor.create(rhsm=True)
             satellite_second_org.host_delete(host=hypervisor_hostname)
+            sm_guest_second_org.unregister()
 
     @pytest.mark.tier2
     def test_vdc_virtual_subscription_on_webui(


### PR DESCRIPTION
Satellite case `test_vdc_virtual_subscription_on_webui ` always failed in the Jenkins job but could be run pass locally, which is because the guest was registered to another org in case `test_non_default_org_without_rhsm_options` and `test_non_default_org_with_rhsm_options`. 
The fix methods are

- Change to use fixture `function_guest_register`.
- Unregister guest at the final step of  `test_non_default_org_without_rhsm_options` and `test_non_default_org_with_rhsm_options`.

**Test Result**
```
% python3 -m pytest tests/subscription/test_satellite.py -m 'tier2' -v
========================================================= test session starts =========================================================
platform darwin -- Python 3.11.2, pytest-7.2.2, pluggy-1.0.0 -- /opt/homebrew/opt/python@3.11/bin/python3.11
cachedir: .pytest_cache
rootdir: /Users/yuefliu/workspace/virtwho-test, configfile: pytest.ini
collected 11 items / 6 deselected / 5 selected                                                                                        

tests/subscription/test_satellite.py::TestSatelliteScaDisable::test_guest_auto_attach_rule_by_activation_key PASSED             [ 20%]
tests/subscription/test_satellite.py::TestSatelliteScaDisable::test_guest_auto_attach_temporary_pool_by_activation_key PASSED   [ 40%]
tests/subscription/test_satellite.py::TestSatelliteScaDisable::test_non_default_org_with_rhsm_options PASSED                    [ 60%]
tests/subscription/test_satellite.py::TestSatelliteScaDisable::test_non_default_org_without_rhsm_options PASSED                 [ 80%]
tests/subscription/test_satellite.py::TestSatelliteScaDisable::test_vdc_virtual_subscription_on_webui PASSED                    [100%]

========================================================== warnings summary =======================================================
```