### PR TITLE
Debug the virt-who smoke testing cases aginst non-released satellite

### DIFF
--- a/tests/hypervisor/test_ahv.py
+++ b/tests/hypervisor/test_ahv.py
@@ -75,7 +75,7 @@ class TestAHVPositive:
 
             hypervisor id shows uuid/hostname in mapping as the setting.
         """
-        hypervisor_ids = ["hostname", "uuid"]
+        hypervisor_ids = ["uuid", "hostname"]
         for hypervisor_id in hypervisor_ids:
             function_hypervisor.update("hypervisor_id", hypervisor_id)
             result = virtwho.run_service()

--- a/tests/hypervisor/test_esx.py
+++ b/tests/hypervisor/test_esx.py
@@ -88,7 +88,7 @@ class TestEsxPositive:
 
             hypervisor id shows uuid/hostname/hwuuid in mapping as the setting.
         """
-        hypervisor_ids = ["hostname", "uuid", "hwuuid"]
+        hypervisor_ids = ["uuid", "hwuuid", "hostname"]
         for hypervisor_id in hypervisor_ids:
             function_hypervisor.update("hypervisor_id", hypervisor_id)
             result = virtwho.run_service()

--- a/tests/hypervisor/test_hyperv.py
+++ b/tests/hypervisor/test_hyperv.py
@@ -78,7 +78,7 @@ class TestHypervPositive:
 
             hypervisor id shows uuid/hostname in mapping as the setting.
         """
-        hypervisor_ids = ["hostname", "uuid"]
+        hypervisor_ids = ["uuid", "hostname"]
         for hypervisor_id in hypervisor_ids:
             function_hypervisor.update("hypervisor_id", hypervisor_id)
             result = virtwho.run_service()

--- a/tests/hypervisor/test_kubevirt.py
+++ b/tests/hypervisor/test_kubevirt.py
@@ -46,7 +46,7 @@ class TestKubevirtPositive:
 
             hypervisor id shows uuid/hostname in mapping as the setting.
         """
-        hypervisor_ids = ["hostname", "uuid"]
+        hypervisor_ids = ["uuid", "hostname"]
         for hypervisor_id in hypervisor_ids:
             function_hypervisor.update("hypervisor_id", hypervisor_id)
             result = virtwho.run_service()

--- a/tests/hypervisor/test_libvirt.py
+++ b/tests/hypervisor/test_libvirt.py
@@ -75,7 +75,7 @@ class TestLibvrtPositive:
 
             hypervisor id shows uuid/hostname in mapping as the setting.
         """
-        hypervisor_ids = ["hostname", "uuid"]
+        hypervisor_ids = ["uuid", "hostname"]
         for hypervisor_id in hypervisor_ids:
             function_hypervisor.update("hypervisor_id", hypervisor_id)
             result = virtwho.run_service()

--- a/tests/hypervisor/test_rhevm.py
+++ b/tests/hypervisor/test_rhevm.py
@@ -76,7 +76,7 @@ class TestRHEVMPositive:
 
             hypervisor id shows uuid/hostname/hwuuid in mapping as the setting.
         """
-        hypervisor_ids = ["hostname", "uuid", "hwuuid"]
+        hypervisor_ids = ["uuid", "hwuuid", "hostname"]
         for hypervisor_id in hypervisor_ids:
             function_hypervisor.update("hypervisor_id", hypervisor_id)
             result = virtwho.run_service()

--- a/tests/hypervisor/test_xen.py
+++ b/tests/hypervisor/test_xen.py
@@ -75,7 +75,7 @@ class TestXenPositive:
 
             hypervisor id shows uuid/hostname in mapping as the setting.
         """
-        hypervisor_ids = ["hostname", "uuid"]
+        hypervisor_ids = ["uuid", "hostname"]
         for hypervisor_id in hypervisor_ids:
             function_hypervisor.update("hypervisor_id", hypervisor_id)
             result = virtwho.run_service()

--- a/tests/subscription/test_satellite.py
+++ b/tests/subscription/test_satellite.py
@@ -184,6 +184,7 @@ class TestSatelliteScaDisable:
         hypervisor_hostname = hypervisor_data["hypervisor_hostname"]
 
         virtwho.stop()
+        virtwho.run_cli()
         satellite.host_delete(host=hypervisor_hostname)
 
         sm_guest.refresh()
@@ -198,7 +199,7 @@ class TestSatelliteScaDisable:
 
         if HYPERVISOR == "local":
             sm_host.register()
-        _ = virtwho.run_cli()
+        virtwho.run_cli()
         satellite.attach(host=hypervisor_hostname, pool=vdc_pool_physical)
 
         sm_guest.refresh()


### PR DESCRIPTION
The case `test_vdc_temporary_pool_by_poolId` failed when second run the smoke testing job, because in this case, there was a step to `satellite.host_delete(host=hypervisor_hostname)`, but in another case `test_hypervisor_id()`, the hostname was changed to uuid or hwuuid, so there was no hostname in the satellite web when run `satellite.host_delete(host=hypervisor_hostname)`, which impacted the next steps to get temporay vdc sku, because the guest could be associated with the `uuid or hwuuid`.
- [x] reorder the `hypervisor_ids` to  `["uuid", "hwuuid", "hostname"]`, put the hostname to the last one, because basically all other cases use the hostname.
- [x]  add `virtwho.run_cli()` step to the failed case `test_vdc_temporary_pool_by_poolId`, which will resend the correct hostname at the begining.