### PR TITLE
is_register(): add step to check if the correct satellite server

### DIFF
--- a/virtwho/register.py
+++ b/virtwho/register.py
@@ -96,6 +96,13 @@ class SubscriptionManager:
         """
         ret, output = self.ssh.runcmd("subscription-manager identity")
         if ret == 0 and self.org in output:
+            if self.register_type == "satellite":
+                _, output = self.ssh.runcmd(f"cat {self.rhsm_conf}", log_print=False)
+                if f"hostname = {self.server}" not in output:
+                    logger.warning(
+                        f"The ({self.host}) is not registering in the testing Satellite"
+                    )
+                    return False
             return True
         return False
 


### PR DESCRIPTION
The testing failed when run virt-who cases against a new Satellite, because the code was able to check if the host was registering, but not able to check if it was the correct Satellite. So now perfect to code with the checking step.