### PR TITLE
Automation support the fips enable mode cases

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -5,7 +5,7 @@ markers =
     tier3: Tier 2 cases for virt-who extra functions
 
     satelliteSmoke: cases for smoke testing against development satellite
-    fipsEnable: cases to run in fils enabled mode
+    fipsEnable: cases to run in fips enabled mode
 
     notSatellite: cases not for satellite
     notRHSM: cases not for candlepin

--- a/pytest.ini
+++ b/pytest.ini
@@ -5,6 +5,7 @@ markers =
     tier3: Tier 2 cases for virt-who extra functions
 
     satelliteSmoke: cases for smoke testing against development satellite
+    fipsEnable: cases to run in fils enabled mode
 
     notSatellite: cases not for satellite
     notRHSM: cases not for candlepin

--- a/tests/function/test_cli.py
+++ b/tests/function/test_cli.py
@@ -20,6 +20,7 @@ from virtwho.base import encrypt_password
 @pytest.mark.usefixtures("class_hypervisor")
 class TestCli:
     @pytest.mark.tier1
+    @pytest.mark.fipsEnable
     def test_debug(self, virtwho):
         """Test the '-d' option in virt-who command line
 
@@ -47,6 +48,7 @@ class TestCli:
         assert result["send"] == 1 and result["error"] == 0 and result["debug"] is True
 
     @pytest.mark.tier1
+    @pytest.mark.fipsEnable
     def test_oneshot(self, virtwho):
         """Test the '-o' option in virt-who command line
 
@@ -93,6 +95,7 @@ class TestCli:
             assert result["oneshot"] is True
 
     @pytest.mark.tier1
+    @pytest.mark.fipsEnable
     def test_interval(self, virtwho):
         """Test the '-i' option in virt-who command line
 

--- a/tests/function/test_config.py
+++ b/tests/function/test_config.py
@@ -488,6 +488,7 @@ class TestConfigurationPositive:
 
     @pytest.mark.tier1
     @pytest.mark.notLocal
+    @pytest.mark.fipsEnable
     def test_http_proxy_in_virtwho_conf(self, virtwho, globalconf, proxy_data):
         """Test the http_proxy, https_proxy and no_proxy options in /etc/virtwho.conf
 

--- a/tests/function/test_service.py
+++ b/tests/function/test_service.py
@@ -23,6 +23,7 @@ from virtwho.ssh import SSHConnect
 @pytest.mark.usefixtures("class_virtwho_d_conf_clean")
 class TestVirtwhoService:
     @pytest.mark.tier1
+    @pytest.mark.fipsEnable
     def test_virtwho_service_start_and_stop(self, virtwho):
         """
 
@@ -51,6 +52,7 @@ class TestVirtwhoService:
         assert output is "dead"
 
     @pytest.mark.tier1
+    @pytest.mark.fipsEnable
     def test_virtwho_service_restart(self, virtwho):
         """
 
@@ -108,6 +110,7 @@ class TestVirtwhoService:
         assert output is "running"
 
     @pytest.mark.tier1
+    @pytest.mark.fipsEnable
     def test_virtwho_service_control_by_ssh_connect(self, virtwho, ssh_guest, ssh_host):
         """
 

--- a/tests/function/test_service.py
+++ b/tests/function/test_service.py
@@ -23,7 +23,6 @@ from virtwho.ssh import SSHConnect
 @pytest.mark.usefixtures("class_virtwho_d_conf_clean")
 class TestVirtwhoService:
     @pytest.mark.tier1
-    @pytest.mark.fipsEnable
     def test_virtwho_service_start_and_stop(self, virtwho):
         """
 
@@ -52,7 +51,6 @@ class TestVirtwhoService:
         assert output is "dead"
 
     @pytest.mark.tier1
-    @pytest.mark.fipsEnable
     def test_virtwho_service_restart(self, virtwho):
         """
 

--- a/tests/hypervisor/test_default.py
+++ b/tests/hypervisor/test_default.py
@@ -79,6 +79,7 @@ class TestHypervisorPositive:
 
     @pytest.mark.tier1
     @pytest.mark.satelliteSmoke
+    @pytest.mark.fipsEnable
     def test_associated_info_by_rhsmlog_and_webui(
         self,
         virtwho,

--- a/tests/hypervisor/test_esx.py
+++ b/tests/hypervisor/test_esx.py
@@ -11,7 +11,6 @@ import random
 import string
 import json
 import uuid
-import time
 import pytest
 
 from virtwho import logger
@@ -25,7 +24,6 @@ from virtwho import SECOND_HYPERVISOR_SECTION
 
 from virtwho.base import encrypt_password
 from virtwho.base import get_host_domain_id
-from virtwho.base import is_host_responsive
 from virtwho.configure import hypervisor_create
 from virtwho.settings import TEMP_DIR
 

--- a/tests/hypervisor/test_esx.py
+++ b/tests/hypervisor/test_esx.py
@@ -1436,68 +1436,6 @@ class TestEsxNegative:
             logger.warning("Failed to post json to satellite")
             logger.warning(output)
 
-    @pytest.mark.tier3
-    def test_run_in_FIPS_mode(self, function_hypervisor, virtwho, ssh_host):
-        """
-        :title: virt-who: esx: test run virt-who in FIPS mode
-        :id: 2a05a366-6b92-456a-89ca-c7576491c0bb
-        :caseimportance: High
-        :tags: hypervisor,esx,tier3
-        :customerscenario: false
-        :upstream: no
-        :steps:
-            1. Enable FIPS mode on the host
-            2. Reboot the host
-            3. Run virt-who service
-            4. Check the virt-who service status
-            5. Disable FIPS mode on the host
-            6. Reboot the host
-
-        :expectedresults:
-            1. Succeeded to enable FIPS mode on the host
-        """
-        timeout = 300
-        interval = 5
-        try:
-            ssh_host.runcmd("fips-mode-setup --enable")
-            ssh_host.runcmd("sudo reboot")
-            start_time = time.time()
-            # Waiting for server to reboot
-            time.sleep(interval)
-            while not is_host_responsive(ssh_host.host):
-                elapsed_time = time.time() - start_time
-                if elapsed_time > timeout:
-                    assert False, f"Timeout reached after {timeout} seconds!"
-                logger.info(
-                    f"Waiting for server to come back online... Elapsed time: {int(elapsed_time)} seconds."
-                )
-                time.sleep(interval)
-
-            _, stdout = ssh_host.runcmd("cat /proc/sys/crypto/fips_enabled")
-            assert "1" in stdout
-
-            result = virtwho.run_service()
-            assert (
-                result["error"] == 0 and result["send"] == 1 and result["thread"] == 1
-            )
-        finally:
-            ssh_host.runcmd("fips-mode-setup --disable")
-            ssh_host.runcmd("sudo reboot")
-            start_time = time.time()
-            # Waiting for server to reboot
-            time.sleep(interval)
-            while not is_host_responsive(ssh_host.host):
-                elapsed_time = time.time() - start_time
-                if elapsed_time > timeout:
-                    assert False, f"Timeout reached after {timeout} seconds!"
-                logger.info(
-                    f"Waiting for server to come back online... Elapsed time: {int(elapsed_time)} seconds."
-                )
-                time.sleep(interval)
-
-            _, stdout = ssh_host.runcmd("cat /proc/sys/crypto/fips_enabled")
-            assert "0" in stdout
-
 
 def json_data_create(hypervisors_num, guests_num):
     """

--- a/tests/subscription/test_rhsm_option.py
+++ b/tests/subscription/test_rhsm_option.py
@@ -90,6 +90,7 @@ class TestSubscriptionPositive:
 
     @pytest.mark.tier1
     @pytest.mark.satelliteSmoke
+    @pytest.mark.fipsEnable
     def test_rhsm_proxy(self, virtwho, function_hypervisor, rhsmconf, proxy_data):
         """
 

--- a/utils/fips_set.py
+++ b/utils/fips_set.py
@@ -43,20 +43,28 @@ def arguments_parser():
     """
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        "--server", default=config.virtwho.server, required=False,
-        help="RHEL host IP address/hostname, default to use the virtwho.ini:virtwho:server"
+        "--server",
+        default=config.virtwho.server,
+        required=False,
+        help="RHEL host IP address/hostname, default to use the virtwho.ini:virtwho:server",
     )
     parser.add_argument(
-        "--username", default=config.virtwho.username, required=False,
-        help="RHEL host access username, default to use the virtwho.ini:virtwho:username."
+        "--username",
+        default=config.virtwho.username,
+        required=False,
+        help="RHEL host access username, default to use the virtwho.ini:virtwho:username.",
     )
     parser.add_argument(
-        "--password", default=config.virtwho.password, required=False,
-        help="RHEL host access password, default to use the virtwho.ini:virtwho:password."
+        "--password",
+        default=config.virtwho.password,
+        required=False,
+        help="RHEL host access password, default to use the virtwho.ini:virtwho:password.",
     )
     parser.add_argument(
-        "--mode", default="enable", required=False,
-        help="enable/disable fips mode, default is enable"
+        "--mode",
+        default="enable",
+        required=False,
+        help="enable/disable fips mode, default is enable",
     )
     return parser.parse_args()
 

--- a/utils/fips_set.py
+++ b/utils/fips_set.py
@@ -30,7 +30,7 @@ def fips_set_for_rhel_host(args):
         system_reboot(ssh_host)
         _, stdout = ssh_host.runcmd(fips_check)
         if fips in stdout:
-            logger.info(f"The host was set to Fips/{args.mode} mode.")
+            logger.info(f"Succeeded to set host to Fips/{args.mode} mode.")
             return True
         raise FailException(f"Failed to set the Fips/{args.mode} mode")
 

--- a/utils/fips_set.py
+++ b/utils/fips_set.py
@@ -1,0 +1,66 @@
+import os
+import argparse
+import sys
+
+curPath = os.path.abspath(os.path.dirname(__file__))
+rootPath = os.path.split(curPath)[0]
+sys.path.append(rootPath)
+
+from virtwho.ssh import SSHConnect
+from virtwho import config, logger
+from virtwho.base import system_reboot
+from virtwho import FailException
+
+
+def fips_set_for_rhel_host(args):
+    """
+    Disable/Enable the fips mode for RHEL (>=RHEL8) host
+    """
+    fips = "1"
+    if args.mode == "disable":
+        fips = "0"
+    fips_check = "cat /proc/sys/crypto/fips_enabled"
+    ssh_host = SSHConnect(host=args.server, user=args.username, pwd=args.password)
+    _, stdout = ssh_host.runcmd(fips_check)
+    if fips in stdout:
+        logger.info(f"The host has been in the Fips/{args.mode} mode.")
+        return True
+    else:
+        ssh_host.runcmd(f"fips-mode-setup --{args.mode}")
+        system_reboot(ssh_host)
+        _, stdout = ssh_host.runcmd(fips_check)
+        if fips in stdout:
+            logger.info(f"The host was set to Fips/{args.mode} mode.")
+            return True
+        raise FailException(f"Failed to set the Fips/{args.mode} mode")
+
+
+def arguments_parser():
+    """
+    Parse and convert the arguments from command line to parameters
+    for function using, and generate help and usage messages for
+    each arguments.
+    """
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--server", default=config.virtwho.server, required=False,
+        help="RHEL host IP address/hostname, default to use the virtwho.ini:virtwho:server"
+    )
+    parser.add_argument(
+        "--username", default=config.virtwho.username, required=False,
+        help="RHEL host access username, default to use the virtwho.ini:virtwho:username."
+    )
+    parser.add_argument(
+        "--password", default=config.virtwho.password, required=False,
+        help="RHEL host access password, default to use the virtwho.ini:virtwho:password."
+    )
+    parser.add_argument(
+        "--mode", default="enable", required=False,
+        help="enable/disable fips mode, default is enable"
+    )
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    args = arguments_parser()
+    fips_set_for_rhel_host(args)

--- a/virtwho/base.py
+++ b/virtwho/base.py
@@ -618,9 +618,10 @@ def system_reboot(ssh):
     :return: True or raise fail.
     """
     ssh.runcmd("sync;sync;sync;sync;reboot")
-    time.sleep(120)
-    if ssh_connect(ssh):
-        return True
+    for i in range(5):
+        time.sleep(120)
+        if ssh_connect(ssh):
+            return True
     raise FailException("Failed to reboot system")
 
 


### PR DESCRIPTION
- [x] new design util tool `fips_set.py`, the usage is `% python3 utils/fips_set.py --server= --username=--password= --mode=[enable/disable]` 
- [x] choose test cases with `fipsEnable` mark
- test_debug
- test_interval
- test_oneshot
- test_http_proxy_in_virtwho_conf
- test_virtwho_service_control_by_ssh_connect
- test_associated_info_by_rhsmlog_and_webui
- test_rhsm_proxy
- [x] remove esx case `test_run_in_FIPS_mode`, which should be tested for each hypervisor