### PR TITLE
Perfect the ssh_connect() to support the hypervisor monitor

### DIFF
--- a/virtwho/base.py
+++ b/virtwho/base.py
@@ -127,10 +127,11 @@ def ssh_connect(ssh):
     Test if the host is running and can be accessed by ssh.
     :param ssh: ssh access of host
     """
-    ret, output = ssh.runcmd("rpm -qa filesystem")
-    if ret == 0 and "filesystem" in output:
-        logger.info(f"Suceeded to ssh connect the host")
-        return True
+    if ssh.pwd_connect():
+        ret, output = ssh.runcmd("rpm -qa filesystem")
+        if ret == 0 and "filesystem" in output:
+            logger.info(f"Suceeded to ssh connect the host.")
+            return True
     return False
 
 

--- a/virtwho/provision/virtwho_hypervisor.py
+++ b/virtwho/provision/virtwho_hypervisor.py
@@ -87,15 +87,13 @@ def esx_monitor():
                     f"please install one."
                 )
             else:
-                if esx_data["guest_state"] == 1 and host_ping(
-                    host=esx_data["guest_ip"]
-                ):
+                ssh_guest = SSHConnect(
+                    host=esx_data["guest_ip"],
+                    user=config.esx.guest_username,
+                    pwd=config.esx.guest_password,
+                )
+                if esx_data["guest_state"] == 1 and ssh_connect(ssh_guest):
                     logger.info(f"The rhel guest({guest_name}) is running well.")
-                    ssh_guest = SSHConnect(
-                        host=esx_data["guest_ip"],
-                        user=config.esx.guest_username,
-                        pwd=config.esx.guest_password,
-                    )
                     esx_data["guest_uuid"] = rhel_host_uuid_get(ssh_guest)
                 else:
                     esx_state, guest_ip = (state_guest_bad, guest_down)
@@ -189,15 +187,13 @@ def hyperv_monitor():
                     f"please install one."
                 )
             else:
-                if hyperv_data["guest_state"] == 2 and host_ping(
-                    host=hyperv_data["guest_ip"]
-                ):
+                ssh_guest = SSHConnect(
+                    host=hyperv_data["guest_ip"],
+                    user=config.esx.guest_username,
+                    pwd=config.esx.guest_password,
+                )
+                if hyperv_data["guest_state"] == 2 and ssh_connect(ssh_guest):
                     logger.info(f"The rhel guest({guest_name}) is running well.")
-                    ssh_guest = SSHConnect(
-                        host=hyperv_data["guest_ip"],
-                        user=config.esx.guest_username,
-                        pwd=config.esx.guest_password,
-                    )
                     hyperv_data["guest_uuid"] = rhel_host_uuid_get(ssh_guest).upper()
                 else:
                     hyperv_state, guest_ip = (state_guest_bad, guest_down)
@@ -271,10 +267,6 @@ def kubevirt_monitor():
                 logger.error(
                     f"Did not find the guest({guest_name}), please install one."
                 )
-            elif not host_ping(host=guest_ip):
-                logger.warning(
-                    f"The rhel guest({guest_name}) is down, please repair it."
-                )
             else:
                 ssh_guest = SSHConnect(
                     host=kubevirt_data["hostname"],
@@ -315,7 +307,7 @@ def kubevirt_monitor():
                     else:
                         kubevirt_state, guest_ip_sw = (state_guest_bad, guest_down)
                         logger.warning(
-                            f"The guest({guest_name}) is unavailable, please repair it."
+                            f"The guest({guest_name_sw}) is unavailable, please repair it."
                         )
 
     finally:
@@ -547,9 +539,12 @@ def libvirt_monitor():
                     f"please install one."
                 )
             else:
-                if libvirt_data["guest_state"] == "running" and host_ping(
-                    host=libvirt_data["guest_ip"]
-                ):
+                ssh_guest = SSHConnect(
+                    host=libvirt_data["guest_ip"],
+                    user=config.libvirt.guest_username,
+                    pwd=config.libvirt.guest_password,
+                )
+                if ssh_connect(ssh_guest):
                     logger.info(f"The rhel guest({guest_name}) is running well.")
                 else:
                     libvirt_state, guest_ip = (state_guest_bad, guest_down)

--- a/virtwho/ssh.py
+++ b/virtwho/ssh.py
@@ -43,10 +43,18 @@ class SSHConnect:
 
     def pwd_connect(self):
         """SSH command execution connection by password"""
-        ssh = paramiko.SSHClient()
-        ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
-        ssh.connect(self.host, self.port, self.user, self.pwd, timeout=self.timeout)
-        return ssh
+        ssh = ""
+        connect = False
+        try:
+            ssh = paramiko.SSHClient()
+            ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+            ssh.connect(self.host, self.port, self.user, self.pwd, timeout=self.timeout)
+            connect = True
+        finally:
+            if connect:
+                return ssh
+            logger.error(f"Failed to ssh connect the {self.host}.")
+            return False
 
     def rsa_connect(self):
         """SSH command execution connection by key file"""


### PR DESCRIPTION
There was a bug when we try to check a host status by ssh_connect(), that was when the host really down, the code will directly jumped out of the ssh_connect() without returning True/False because of the line `ssh.connect(self.host, self.port, self.user, self.pwd, timeout=self.timeout)` failed in function `pwd_connect()`, which would not result step failure and told us the host was good.
The fix is to perfect the `pwd_connect(self)` to return False if the connect fail.

**Test Result**
```
% pytest --disable-warnings -v tests/others/test_hypervisors_state.py                               
======================================================== test session starts =========================================================
platform darwin -- Python 3.11.2, pytest-7.2.2, pluggy-1.0.0 -- /opt/homebrew/opt/python@3.11/bin/python3.11
cachedir: .pytest_cache
rootdir: /Users/yuefliu/workspace/virtwho-test, configfile: pytest.ini
collected 5 items                                                                                                                    

tests/others/test_hypervisors_state.py::TestHypervisorsState::test_state_esx PASSED                                            [ 20%]
tests/others/test_hypervisors_state.py::TestHypervisorsState::test_state_hyperv PASSED                                         [ 40%]
tests/others/test_hypervisors_state.py::TestHypervisorsState::test_state_kubevirt PASSED                                       [ 60%]
tests/others/test_hypervisors_state.py::TestHypervisorsState::test_state_ahv PASSED                                            [ 80%]
tests/others/test_hypervisors_state.py::TestHypervisorsState::test_state_libvirt PASSED                                        [100%]

============================================= 5 passed, 3 warnings in 161.07s (0:02:41) ==============================================
[2024-02-21 17:38:32] - [conftest.py] - INFO: Finished Test: tests/others/test_hypervisors_state.py::TestHypervisorsState::test_state_libvirt
```