### PR TITLE
docstring: add subtype1 for nonfunctional cases

### DIFF
--- a/tests/others/test_hypervisors_state.py
+++ b/tests/others/test_hypervisors_state.py
@@ -2,6 +2,7 @@
 
 :casecomponent: virt-who
 :testtype: nonfunctional
+:subtype1: documentation
 :caseautomation: Automated
 :subsystemteam: sst_subscription_virtwho
 :caselevel: Component

--- a/tests/others/test_hypervisors_state.py
+++ b/tests/others/test_hypervisors_state.py
@@ -1,12 +1,13 @@
 """Test cases Global fields
 
 :casecomponent: virt-who
-:testtype: nonfunctional
-:subtype1: documentation
+:testtype: functional
 :caseautomation: Automated
 :subsystemteam: sst_subscription_virtwho
 :caselevel: Component
 """
+# All the test cases have been uploaded to Polarion with Inactive status
+# because the cases are just used to test the test environments.
 
 from virtwho.provision.virtwho_hypervisor import hyperv_monitor
 from virtwho.provision.virtwho_hypervisor import esx_monitor

--- a/tests/others/test_hypervisors_sw.py
+++ b/tests/others/test_hypervisors_sw.py
@@ -6,6 +6,8 @@
 :subsystemteam: sst_subscription_virtwho
 :caselevel: Component
 """
+# The test case has been uploaded to Polarion with Inactive status because
+# the case is just used to test the environments to support Subscription Watch team.
 
 import pytest
 from virtwho.configure import config, hypervisor_create

--- a/tests/others/test_hypervisors_sw.py
+++ b/tests/others/test_hypervisors_sw.py
@@ -1,7 +1,7 @@
 """Test cases Global fields
 
 :casecomponent: virt-who
-:testtype: nonfunctional
+:testtype: functional
 :caseautomation: Automated
 :subsystemteam: sst_subscription_virtwho
 :caselevel: Component

--- a/tests/package/test_info.py
+++ b/tests/package/test_info.py
@@ -1,7 +1,8 @@
 """Test cases Global fields
 
 :casecomponent: virt-who
-:testtype: functional
+:testtype: nonfunctional
+:subtype1: documentation
 :caseautomation: Automated
 :subsystemteam: sst_subscription_virtwho
 :caselevel: Component

--- a/tests/package/test_install_uninstall.py
+++ b/tests/package/test_install_uninstall.py
@@ -2,6 +2,7 @@
 
 :casecomponent: virt-who
 :testtype: nonfunctional
+:subtype1: installability
 :caseautomation: Automated
 :subsystemteam: sst_subscription_virtwho
 :caselevel: Component

--- a/tests/package/test_upgrade_downgrade.py
+++ b/tests/package/test_upgrade_downgrade.py
@@ -2,6 +2,7 @@
 
 :casecomponent: virt-who
 :testtype: nonfunctional
+:subtype1: scalability
 :caseautomation: Automated
 :subsystemteam: sst_subscription_virtwho
 :caselevel: Component

--- a/tests/upgrade/test_upgrade.py
+++ b/tests/upgrade/test_upgrade.py
@@ -1,7 +1,8 @@
 """Test cases Global fields
 
 :casecomponent: virt-who
-:testtype: functional
+:testtype: nonfunctional
+:subtype1: scalability
 :caseautomation: Automated
 :subsystemteam: sst_subscription_virtwho
 :caselevel: Component


### PR DESCRIPTION
As the requirement for test type of Polarion cases, updated the below docstring based on https://source.redhat.com/groups/public/quality_community/quality_engineering_wiki/test_types_levels_and_importance_rev_10

- test_install_uninstall cases

        :testtype: nonfunctional
        :subtype1: installability

- test_upgrade_downgrade cases

        :testtype: nonfunctional
        :subtype1: scalability

-  test_info cases

        :testtype: nonfunctional
        :subtype1: documentation

- All cases in others/ have been changed to `Inactive` status because those cases are just used to test the hypervisor environments and will not be used in any test run.