### PR TITLE
virtwho_host: configure to start firewall and enable selinux

### DIFF
--- a/virtwho/base.py
+++ b/virtwho/base.py
@@ -29,8 +29,8 @@ def system_init(ssh, keyword):
         host_name = f"{keyword}-{random_str}.redhat.com"
     hostname_set(ssh, host_name)
     etc_hosts_set(ssh, f"{host_ip} {host_name}")
-    firewall_stop(ssh)
-    selinux_disable(ssh)
+    # firewall_stop(ssh)
+    # selinux_disable(ssh)
     logger.info(f"Finished to init system {host_name}")
 
 


### PR DESCRIPTION
As the discussion by meeting, we can try to test virt-who with the selinux enabled and firewall started, which should be closer to customers environments.

- Succeeded to install all the necessary packages for virt-who hosts with the new configuration.