### PR TITLE
Polarion testrun: add fips and logs custom fields

### DIFF
--- a/utils/polarion_testrun_import.py
+++ b/utils/polarion_testrun_import.py
@@ -40,6 +40,7 @@ def betelgeuse_xml_file_transform(xml_file, output_xml_file):
         f'--custom-fields component="{args.component}" '
         f'--custom-fields build="{args.build}" '
         f'--custom-fields jenkinsjobs="{args.jenkinsjobs}" '
+        f'--custom-fields logs="{args.jenkinsjobs}artifact/virtwho-test/logs/" '
         f'--custom-fields notes="{args.notes}" '
         f'--test-run-template-id="{args.template_id}" '
         f'--test-run-title="{args.title}" '

--- a/utils/polarion_testrun_import.py
+++ b/utils/polarion_testrun_import.py
@@ -42,6 +42,7 @@ def betelgeuse_xml_file_transform(xml_file, output_xml_file):
         f'--custom-fields jenkinsjobs="{args.jenkinsjobs}" '
         f'--custom-fields logs="{args.jenkinsjobs}artifact/virtwho-test/logs/" '
         f'--custom-fields notes="{args.notes}" '
+        f'--custom-fields fips="{args.fips}" '
         f'--test-run-template-id="{args.template_id}" '
         f'--test-run-title="{args.title}" '
         f'--status="finished" '
@@ -159,6 +160,7 @@ def arguments_parser():
         "--plannedin", required=False, default="", help="The plans of polarion project"
     )
     parser.add_argument("--notes", required=False, default="", help="The custom notes")
+    parser.add_argument("--fips", required=False, default="", help="Yes/No")
     parser.add_argument(
         "--xml-file",
         required=False,


### PR DESCRIPTION
Following the Polarion Evidence Traceability, define the logs and fips for test run.
Have passed the test locally, the new custom fields could be uploaded successfully.