### PR TITLE
Update testcase importance and subtype

### DIFF
--- a/tests/subscription/test_rhsm.py
+++ b/tests/subscription/test_rhsm.py
@@ -1,7 +1,8 @@
 """Test cases Global fields
 
 :casecomponent: virt-who
-:testtype: functional
+:testtype: nonfunctional
+:subtype1: Interoperability
 :caseautomation: Automated
 :subsystemteam: sst_subscription_virtwho
 :caselevel: Component
@@ -33,7 +34,7 @@ class TestRhsmScaDisable:
 
         :title: virt-who: rhsm: [sca/disable] test guest attach virtual vdc pool by pool id
         :id: 39717357-eadb-4ac7-bf44-2b323cda3717
-        :caseimportance: High
+        :caseimportance: Medium
         :tags: subscription,rhsm,tier1
         :customerscenario: false
         :upstream: no
@@ -85,7 +86,7 @@ class TestRhsmScaDisable:
 
         :title: virt-who: rhsm: [sca/disable] test guest attach virtual vdc pool by auto
         :id: d082e0c1-e925-46ea-8ab1-d65355709f55
-        :caseimportance: High
+        :caseimportance: Medium
         :tags: subscription,rhsm,tier1
         :customerscenario: false
         :upstream: no
@@ -143,7 +144,7 @@ class TestRhsmScaDisable:
 
         :title: virt-who: rhsm: [sca/disable] test temporary vdc pool in guest
         :id: d1c42adf-dee5-42bf-80b6-017948e77baf
-        :caseimportance: High
+        :caseimportance: Medium
         :tags: subscription,rhsm,tier1
         :customerscenario: false
         :upstream: no
@@ -220,7 +221,7 @@ class TestRhsmScaDisable:
 
         :title: virt-who: rhsm: [sca/disable] test physcial vdc pool consumed status in physical host
         :id: cbf0e07b-c51c-4e6d-9c80-07c2c8dd7692
-        :caseimportance: High
+        :caseimportance: Medium
         :tags: subscription,rhsm,tier1
         :customerscenario: false
         :upstream: no
@@ -278,7 +279,7 @@ class TestRhsmScaDisable:
 
         :title: virt-who: rhsm: [sca/disable] test vdc virtual pool consumed status in guest
         :id: 93af0dad-21e6-4732-8a06-2fb2e86a05a3
-        :caseimportance: High
+        :caseimportance: Medium
         :tags: subscription,rhsm,tier2
         :customerscenario: false
         :upstream: no
@@ -332,7 +333,7 @@ class TestRhsmScaDisable:
 
         :title: virt-who: rhsm: [sca/disable] test guest attach virtual vdc pool in fake mode
         :id: f97afcd8-2b23-4754-8c40-a70605009e8f
-        :caseimportance: High
+        :caseimportance: Medium
         :tags: subscription,rhsm,tier2
         :customerscenario: false
         :upstream: no
@@ -401,7 +402,7 @@ class TestRhsmScaEnable:
 
         :title: virt-who: rhsm: [sca/enable] test hypervisor entitlement status
         :id: c505edb4-9afa-401f-bc3d-f562d8081955
-        :caseimportance: High
+        :caseimportance: Medium
         :tags: subscription,rhsm,tier1
         :customerscenario: false
         :upstream: no
@@ -436,7 +437,7 @@ class TestRhsmScaEnable:
 
         :title: virt-who: rhsm: [sca/enable] test guest entitlement status
         :id: 20c09b1b-f23e-4691-b927-ed5262c188da
-        :caseimportance: High
+        :caseimportance: Medium
         :tags: subscription,rhsm,tier1
         :customerscenario: false
         :upstream: no

--- a/tests/subscription/test_satellite.py
+++ b/tests/subscription/test_satellite.py
@@ -1,7 +1,8 @@
 """Test cases Global fields
 
 :casecomponent: virt-who
-:testtype: functional
+:testtype: nonfunctional
+:subtype1: Interoperability
 :caseautomation: Automated
 :subsystemteam: sst_subscription_virtwho
 :caselevel: Component
@@ -44,7 +45,7 @@ class TestSatelliteScaDisable:
 
         :title: virt-who: satellite: [sca/disable] test guest attach virtual vdc pool by pool id
         :id: 38e213ef-70cc-445a-85b2-8f9639064f12
-        :caseimportance: High
+        :caseimportance: Medium
         :tags: subscription,satellite,tier1
         :customerscenario: false
         :upstream: no
@@ -96,7 +97,7 @@ class TestSatelliteScaDisable:
 
         :title: virt-who: satellite: [sca/disable] test guest attach virtual vdc pool by auto
         :id: 812aac00-5b4d-4307-bb4e-bdd774330128
-        :caseimportance: High
+        :caseimportance: Medium
         :tags: subscription,satellite,tier1
         :customerscenario: false
         :upstream: no
@@ -155,7 +156,7 @@ class TestSatelliteScaDisable:
 
         :title: virt-who: satellite: [sca/disable] test temporary vdc pool in guest
         :id: 733ce7d0-bb51-4d80-87cc-a5ee5fbdf542
-        :caseimportance: High
+        :caseimportance: Medium
         :tags: subscription,satellite,tier1
         :customerscenario: false
         :upstream: no
@@ -228,7 +229,7 @@ class TestSatelliteScaDisable:
 
         :title: virt-who: satellite: [sca/disable] test guest attach virtual vdc pool in fake mode
         :id: 164f2d20-d357-4f25-a0e4-f5260012a266
-        :caseimportance: High
+        :caseimportance: Medium
         :tags: subscription,satellite,tier1
         :customerscenario: false
         :upstream: no
@@ -295,7 +296,7 @@ class TestSatelliteScaDisable:
 
         :title: virt-who: satellite: [sca/disable] test guest attach rule by activation_key
         :id: 6d0e169c-74a7-41a0-a97a-81e084f0aabf
-        :caseimportance: High
+        :caseimportance: Medium
         :tags: subscription,satellite,tier2
         :customerscenario: false
         :upstream: no
@@ -464,7 +465,7 @@ class TestSatelliteScaDisable:
 
         :title: virt-who: satellite: [sca/disable] test non-default org with rhsm options
         :id: c372adf9-645e-4b79-9bcd-af462e5be03a
-        :caseimportance: High
+        :caseimportance: Medium
         :tags: subscription,satellite,tier2
         :customerscenario: false
         :upstream: no
@@ -537,7 +538,7 @@ class TestSatelliteScaDisable:
 
         :title: virt-who: satellite: [sca/disable] test the non-default org without rhsm options
         :id: e6702ccb-d0ad-4215-9503-cf973c14b31c
-        :caseimportance: High
+        :caseimportance: Medium
         :tags: subscription,satellite,tier2
         :customerscenario: false
         :upstream: no
@@ -717,7 +718,7 @@ class TestSatelliteScaEnable:
 
         :title: virt-who: satellite: [sca/enable] test hypervisor entitlement status
         :id: bda68020-b17e-4442-bcfd-91537e9499e1
-        :caseimportance: High
+        :caseimportance: Medium
         :tags: subscription,satellite,tier1
         :customerscenario: false
         :upstream: no
@@ -755,7 +756,7 @@ class TestSatelliteScaEnable:
 
         :title: virt-who: satellite: [sca/enable] test guest entitlement status
         :id: fcbb4e43-da1e-49c8-a454-0f0979a7717a
-        :caseimportance: High
+        :caseimportance: Medium
         :tags: subscription,rhsm,tier1
         :customerscenario: false
         :upstream: no


### PR DESCRIPTION
Cases under test_rhsm.py and test_satellite.py: 

- `nonfunctional:Interoperability`
- `importance:Medium` 
Because those cases are not directly testing the virt-who function, but to test the integration with entitlement server.