### PR TITLE
polarion_testcase_upload: add to ignote test path(s)

### DIFF
--- a/utils/polarion_testcase_upload.py
+++ b/utils/polarion_testcase_upload.py
@@ -212,7 +212,7 @@ def arguments_parser():
         "--ignore-path",
         required=False,
         default="",
-        help="Ignore path during test collection, separated by | for multi paths, such as: 'tests/others/test_hypervisors_state.py|tests/others/test_hypervisors_sw.py'",
+        help="Ignore path during test collection, separated by | for multi paths, such as: 'tests/others|tests/subscription/test_rhsm.py'",
     )
     parser.add_argument(
         "--xml-file",

--- a/utils/polarion_testcase_upload.py
+++ b/utils/polarion_testcase_upload.py
@@ -33,8 +33,12 @@ def xml_file_generate():
         f"--automation-script-format {args.automation_script_format} "
         f"{args.test_directory} "
         f"{args.project} "
-        f"{args.xml_file}"
+        f"{args.xml_file} "
     )
+    if args.ignore_path:
+        ignore_path = args.ignore_path.split("|")
+        for path in ignore_path:
+            cmd += f"--collect-ignore-path {path} "
     logger.info(f"\n{cmd}\n")
     ret, output = subprocess.getstatusoutput(cmd)
     logger.info(f"\n{output}\n")
@@ -205,6 +209,12 @@ def arguments_parser():
         help="The directory of the test cases",
     )
     parser.add_argument(
+        "--ignore-path",
+        required=False,
+        default="",
+        help="Ignore path during test collection, separated by | for multi paths, such as: 'tests/others/test_hypervisors_state.py|tests/others/test_hypervisors_sw.py'",
+    )
+    parser.add_argument(
         "--xml-file",
         required=False,
         default="temp/polarion_testcase.xml",
@@ -213,7 +223,7 @@ def arguments_parser():
     parser.add_argument(
         "--automation-script-format",
         required=True,
-        help="Example: https://github.com/.../tree/main/tests/{path}#{line_number}",
+        help="Example: https://github.com/VirtwhoQE/virtwho-test/tree/main/tests/{path}",
     )
     parser.add_argument(
         "--log-file",


### PR DESCRIPTION
There is the requirement to ignore all the test files under tests/others/, which could be supported by option `--collect-ignore-path` of betegeuse.

**Test Result**
```
% python3 utils/polarion_testcase_upload.py --test-directory=tests/ --automation-script-format=https://github.com/VirtwhoQE/virtwho-test/tree/main/tests/{path} --subsystemteam=sst_subscription_virtwho --ignore-path='tests/others'       
[2024-03-06 19:12:17] - [polarion_testcase_upload.py] - INFO: 
betelgeuse test-case --automation-script-format https://github.com/VirtwhoQE/virtwho-test/tree/main/tests/{path} tests/ RHELSS temp/polarion_testcase.xml --collect-ignore-path tests/others 

[2024-03-06 19:12:19] - [polarion_testcase_upload.py] - INFO: 


[2024-03-06 19:12:19] - [polarion_testcase_upload.py] - INFO: Succeeded to generate test case xml file
[2024-03-06 19:12:19] - [polarion_testcase_upload.py] - INFO: Start to add hyperlinks with role testscript in testcases 
[2024-03-06 19:12:19] - [polarion_testcase_upload.py] - INFO: Start to add subsystemteam/sst field in testcases 
[2024-03-06 19:12:19] - [polarion_testcase_upload.py] - INFO: curl -k -u platformqe_machine:polarion -X POST -F file=@temp/polarion_testcase.xml https://polarion.engineering.redhat.com/polarion/import/testcase > temp/polarion_testcase.log
[2024-03-06 19:13:22] - [polarion_testcase_upload.py] - INFO: Finished the upload step
[2024-03-06 19:13:22] - [polarion_testcase_upload.py] - INFO: Succeeded to get the polarion job id: 4002067
[2024-03-06 19:13:25] - [polarion_testcase_upload.py] - INFO: Total uploading case number: 196
Passed uploading case number: 196
Failed uploading case number: 0
```