### PR TITLE
Stop firewall for satellite host

### DIFF
--- a/utils/satellite.py
+++ b/utils/satellite.py
@@ -7,7 +7,7 @@ rootPath = os.path.split(curPath)[0]
 sys.path.append(rootPath)
 
 from virtwho import FailException
-from virtwho.base import system_init
+from virtwho.base import system_init, firewall_set
 from virtwho.ssh import SSHConnect
 from virtwho.register import SubscriptionManager
 from virtwho.settings import config
@@ -24,7 +24,7 @@ def satellite_deploy(args):
     snap_ver = args.snap
     rhel_ver = args.rhel_compose.split("-")[1].split(".")[0]
     ssh = SSHConnect(host=args.server, user=args.ssh_username, pwd=args.ssh_password)
-    system_init(ssh, "satellite")
+    system_init(ssh, "satellite", firewall="stop", selinux="permissive")
 
     # Disable rhsm SCA mode to support the Satellite deployment
     rhsm = RHSM()

--- a/utils/satellite.py
+++ b/utils/satellite.py
@@ -7,7 +7,7 @@ rootPath = os.path.split(curPath)[0]
 sys.path.append(rootPath)
 
 from virtwho import FailException
-from virtwho.base import system_init, firewall_set
+from virtwho.base import system_init
 from virtwho.ssh import SSHConnect
 from virtwho.register import SubscriptionManager
 from virtwho.settings import config

--- a/virtwho/base.py
+++ b/virtwho/base.py
@@ -10,12 +10,14 @@ from virtwho import logger, FailException
 from virtwho.settings import config
 
 
-def system_init(ssh, keyword):
+def system_init(ssh, keyword, firewall="start", selinux="enforcing"):
     """
     Initiate the rhel system before testing, including set hostname,
     stop firewall and disable selinux.
     :param ssh: ssh access of host
     :param keyword: keyword to set the hostname
+    :param firewall: start/stop
+    :param selinux: enforcing/permissive/disabled
     """
     host_ip = ipaddr_get(ssh)
     host_name = hostname_get(ssh)
@@ -29,8 +31,8 @@ def system_init(ssh, keyword):
         host_name = f"{keyword}-{random_str}.redhat.com"
     hostname_set(ssh, host_name)
     etc_hosts_set(ssh, f"{host_ip} {host_name}")
-    firewall_set(ssh, "start")
-    selinux_set(ssh, "enforcing")
+    firewall_set(ssh, firewall)
+    selinux_set(ssh, selinux)
     logger.info(f"Finished to init system {host_name}")
 
 


### PR DESCRIPTION
- Perfect the `system_init` to support set the firewall and selinux.
- Change to stop firewall for Satellite host, otherwise we cannot open the WebUI.