### PR TITLE
rhel-10 local mode deployment support

### DIFF
--- a/virtwho/provision/virtwho_host.py
+++ b/virtwho/provision/virtwho_host.py
@@ -64,6 +64,8 @@ def provision_virtwho_host(args):
     ssh_host = SSHConnect(host=args.server, user=args.username, pwd=args.password)
 
     # Initially setup the virt-who host
+    if "RHEL-10" in args.rhel_compose:
+        ssh_host.runcmd("yum install -y subscription-manager")
     ssh_host.runcmd(cmd="rm -f /etc/yum.repos.d/*.repo")
     ssh_host.runcmd(cmd="subscription-manager unregister; subscription-manager clean")
     rhel_compose_repo(

--- a/virtwho/provision/virtwho_host.py
+++ b/virtwho/provision/virtwho_host.py
@@ -301,7 +301,7 @@ def libvirt_pkg_install(ssh):
     Install libvirt related packages.
     :param ssh: ssh access of virt-who host.
     """
-    # virt-manager pakcage is not readly in rhel-10
+    # virt-manager package is not ready in rhel10.0.beta
     package = "nmap iproute rpcbind libvirt* Xorg* gnome*"
     if "RHEL-10" not in args.rhel_compose:
         package += " virt-manager"


### PR DESCRIPTION
skip install virt-manager pakcage for rhel-10 because of not found
manually install sub-man for rhel-10 because not as default until now