### PR TITLE
Change to register to product rhsm for satellite deployment

### DIFF
--- a/utils/satellite.py
+++ b/utils/satellite.py
@@ -29,23 +29,16 @@ def satellite_deploy(args):
     # Enable rhsm SCA mode to support the Satellite deployment
     rhsm = RHSM()
     rhsm.sca()
-
+    sm = SubscriptionManager(
+        host=args.server,
+        username=args.ssh_username,
+        password=args.ssh_password,
+        register_type="rhsm_product",
+    )
     # Enable repos of cnd or snap
     if "cdn" in sat_repo:
-        sm = SubscriptionManager(
-            host=args.server,
-            username=args.ssh_username,
-            password=args.ssh_password,
-            register_type="rhsm",
-        )
         satellite_repo_enable_cdn(sm, ssh, rhel_ver, sat_ver)
     if "repo" in sat_repo:
-        sm = SubscriptionManager(
-            host=args.server,
-            username=args.ssh_username,
-            password=args.ssh_password,
-            register_type="rhsm",
-        )
         satellite_repo_enable_snap(sm, ssh, rhel_ver, sat_ver, snap_ver)
 
     # Install satellite

--- a/virtwho/configure.py
+++ b/virtwho/configure.py
@@ -272,6 +272,8 @@ def get_register_handler(register_type):
         register = config.satellite
     if register_type == "rhsm_sw":
         register = config.rhsm_sw
+    if register_type == "rhsm_product":
+        register = config.rhsm_product
     return register
 
 


### PR DESCRIPTION
Always failed with the stage account due to repo issue, so change to the product account.
Another reason is we have created new stage account for testing without so many skus attached due to entitlement mode has been ignored for testing, so the virt-who test no need to test some skus' properties.