### PR TITLE
Fix issue for case test_trigger_event_with_different_interval

### DIFF
--- a/tests/hypervisor/test_esx.py
+++ b/tests/hypervisor/test_esx.py
@@ -1258,7 +1258,7 @@ class TestEsxNegative:
             globalconf.update("global", "interval", "60")
             virtwho.run_service()
             esx.guest_suspend(hypervisor_data["guest_name"])
-            rhsm_log = virtwho.rhsm_log_get(80)
+            rhsm_log = virtwho.rhsm_log_get(100)
             result = virtwho.analyzer(rhsm_log)
             assert (
                 result["error"] == 0
@@ -1272,7 +1272,7 @@ class TestEsxNegative:
             globalconf.update("global", "interval", "120")
             virtwho.run_service()
             esx.guest_resume(hypervisor_data["guest_name"])
-            rhsm_log = virtwho.rhsm_log_get(150)
+            rhsm_log = virtwho.rhsm_log_get(180)
             result = virtwho.analyzer(rhsm_log)
             assert (
                 result["error"] == 0


### PR DESCRIPTION
The case failed for esx mode due to didn't get the changed mapping after trigger the guest suspend/resume, which could be fixed after extent the wait time before get rhsm log.