### PR TITLE
Support virt-who basic testing in Fedora

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -5,6 +5,7 @@ markers =
     tier3: Tier 2 cases for virt-who extra functions
 
     satelliteSmoke: cases for smoke testing against development satellite
+    fedoraSmoke: cases for smoke testing against development satellite
     fipsEnable: cases to run in fips enabled mode
     gating: cases for gating test
 

--- a/tests/function/test_config.py
+++ b/tests/function/test_config.py
@@ -23,6 +23,7 @@ from virtwho.base import hostname_get
 @pytest.mark.usefixtures("class_virtwho_d_conf_clean")
 class TestConfigurationPositive:
     @pytest.mark.tier1
+    @pytest.mark.fedoraSmoke
     def test_debug_in_virtwho_conf(self, virtwho, globalconf):
         """Test the debug option in /etc/virtwho.conf
 
@@ -51,6 +52,7 @@ class TestConfigurationPositive:
         assert result["send"] == 1 and result["error"] == 0 and result["debug"] is False
 
     @pytest.mark.tier1
+    @pytest.mark.fedoraSmoke
     def test_interval_in_virtwho_conf(self, virtwho, globalconf):
         """Test the interval option in /etc/virtwho.conf
 
@@ -89,6 +91,7 @@ class TestConfigurationPositive:
             assert result["loop"] in [60, 61]
 
     @pytest.mark.tier1
+    @pytest.mark.fedoraSmoke
     def test_oneshot_in_virtwho_conf(self, virtwho, globalconf):
         """Test the oneshot option in /etc/virtwho.conf
 
@@ -489,7 +492,9 @@ class TestConfigurationPositive:
 
     @pytest.mark.tier1
     @pytest.mark.notLocal
-    @pytest.mark.fipsEnable
+    # @pytest.mark.fipsEnable
+    # @pytest.mark.fedoraSmoke
+    # Todo: uncoment the mark for fipsEnable and fedoraSmoke after bugs fixed
     def test_http_proxy_in_virtwho_conf(self, virtwho, globalconf, proxy_data):
         """Test the http_proxy, https_proxy and no_proxy options in /etc/virtwho.conf
 

--- a/tests/function/test_service.py
+++ b/tests/function/test_service.py
@@ -24,6 +24,7 @@ from virtwho.ssh import SSHConnect
 class TestVirtwhoService:
     @pytest.mark.tier1
     @pytest.mark.gating
+    @pytest.mark.fedoraSmoke
     def test_virtwho_service_start_and_stop(self, virtwho):
         """
 

--- a/tests/hypervisor/test_default.py
+++ b/tests/hypervisor/test_default.py
@@ -79,6 +79,7 @@ class TestHypervisorPositive:
 
     @pytest.mark.tier1
     @pytest.mark.satelliteSmoke
+    @pytest.mark.fedoraSmoke
     @pytest.mark.fipsEnable
     @pytest.mark.gating
     def test_associated_info_by_rhsmlog_and_webui(

--- a/tests/hypervisor/test_esx.py
+++ b/tests/hypervisor/test_esx.py
@@ -64,6 +64,7 @@ class TestEsxPositive:
 
     @pytest.mark.tier1
     @pytest.mark.satelliteSmoke
+    @pytest.mark.fedoraSmoke
     def test_hypervisor_id(
         self, virtwho, function_hypervisor, hypervisor_data, globalconf, rhsm, satellite
     ):

--- a/tests/package/test_info.py
+++ b/tests/package/test_info.py
@@ -45,6 +45,7 @@ class TestVirtwhoPackageInfo:
             assert base.url_validation(pkg_url)
 
     @pytest.mark.tier1
+    @pytest.mark.fedoraSmoke
     def test_version(self, ssh_host):
         """Check the virt-who version by command #virt-who --version
 
@@ -117,6 +118,7 @@ class TestVirtwhoPackageInfo:
         assert base.local_files_compare(help_page_local, help_page_compare)
 
     @pytest.mark.tier1
+    @pytest.mark.fedoraSmoke
     def test_package_info(self, ssh_host):
         """Test the virt-who package detail info by #rpm -qi virt-who
 

--- a/tests/subscription/test_rhsm_option.py
+++ b/tests/subscription/test_rhsm_option.py
@@ -91,6 +91,7 @@ class TestSubscriptionPositive:
     @pytest.mark.tier1
     @pytest.mark.satelliteSmoke
     @pytest.mark.fipsEnable
+    @pytest.mark.fedoraSmoke
     def test_rhsm_proxy(self, virtwho, function_hypervisor, rhsmconf, proxy_data):
         """
 

--- a/utils/beaker.py
+++ b/utils/beaker.py
@@ -13,12 +13,12 @@ from virtwho.settings import config
 from virtwho.ssh import SSHConnect
 
 
-def install_rhel_by_beaker(args):
+def install_host_by_beaker(args):
     """
-    Install rhel os by submitting job to beaker with required arguments.
+    Install rhel/fedora os by submitting job to beaker with required arguments.
     Please refer to the utils/README for usage.
     """
-    job_name = f"virtwho-{args.rhel_compose}"
+    job_name = f"virtwho-{args.distro}"
     ssh_client = SSHConnect(
         host=config.beaker.client,
         user=config.beaker.client_username,
@@ -28,7 +28,7 @@ def install_rhel_by_beaker(args):
     job_id = beaker_job_submit(
         ssh_client,
         job_name,
-        args.rhel_compose,
+        args.distro,
         args.arch,
         args.variant,
         args.job_group,
@@ -40,9 +40,9 @@ def install_rhel_by_beaker(args):
         time.sleep(60)
     host = beaker_job_result(ssh_client, job_name, job_id)
     if host:
-        logger.info(f"Succeeded to install {args.rhel_compose} by beaker " f"({host})")
+        logger.info(f"Succeeded to install {args.distro} by beaker ({host})")
         return host
-    raise FailException("Failed to install {args.rhel_compose} by beaker")
+    raise FailException(f"Failed to install {args.distro} by beaker")
 
 
 def beaker_job_submit(
@@ -169,15 +169,9 @@ def beaker_arguments_parser():
     """
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        "--rhel-compose",
+        "--distro",
         required=True,
-        help="Such as: RHEL-7.9-20200917.0, RHEL-8.0-20181005.1",
-    )
-    parser.add_argument(
-        "--arch",
-        required=False,
-        default="x86_64",
-        help="One of [x86_64, s390x, ppc64, ppc64le, aarch64]. " "Default to x86_64.",
+        help="Such as: RHEL-8.0-20181005.1, Fedora-40-20240419.n.0",
     )
     parser.add_argument(
         "--variant",
@@ -185,6 +179,12 @@ def beaker_arguments_parser():
         default=None,
         help="One of [Server, Client, Workstation, BaseOS]. "
         "Unnecessary for RHEL-8 and later, default using BaseOS.",
+    )
+    parser.add_argument(
+        "--arch",
+        required=False,
+        default="x86_64",
+        help="One of [x86_64, s390x, ppc64, ppc64le, aarch64], default is x86_64.",
     )
     parser.add_argument(
         "--job-group",
@@ -217,4 +217,4 @@ def beaker_arguments_parser():
 
 if __name__ == "__main__":
     args = beaker_arguments_parser()
-    install_rhel_by_beaker(args)
+    install_host_by_beaker(args)

--- a/virtwho/provision/virtwho_host.py
+++ b/virtwho/provision/virtwho_host.py
@@ -73,9 +73,7 @@ def provision_virtwho_host(args):
             compose_path=args.rhel_compose_path,
         )
     ssh_host.runcmd("yum install -y subscription-manager expect net-tools wget")
-    ssh_host.runcmd(
-        cmd="subscription-manager unregister; subscription-manager clean"
-    )
+    ssh_host.runcmd(cmd="subscription-manager unregister; subscription-manager clean")
     rhsm_conf_backup(ssh_host)
     system_init(ssh_host, "virtwho")
     virtwho_pkg = virtwho_install(ssh_host, args.virtwho_pkg_url)

--- a/virtwho/provision/virtwho_host.py
+++ b/virtwho/provision/virtwho_host.py
@@ -342,7 +342,7 @@ def virtwho_arguments_parser():
     parser.add_argument(
         "--distro",
         required=False,
-        default=config.job.compose,
+        default=config.job.rhel_compose,
         help="Such as: RHEL-8.5.0-20211013.2, optional for gating test.",
     )
     parser.add_argument(

--- a/virtwho/provision/virtwho_host.py
+++ b/virtwho/provision/virtwho_host.py
@@ -14,7 +14,7 @@ from virtwho.base import ssh_connect, rhel_compose_repo, system_init, rhel_versi
 from virtwho.base import url_validation, url_file_download, hostname_get
 from virtwho.base import ipaddr_get, random_string
 from utils.parse_ci_message import umb_ci_message_parser
-from utils.beaker import install_rhel_by_beaker
+from utils.beaker import install_host_by_beaker
 from utils.properties_update import virtwho_ini_props_update
 from hypervisor.virt.libvirt.libvirtcli import LibvirtCLI
 
@@ -44,8 +44,8 @@ def provision_virtwho_host(args):
         if ssh_connect(ssh_gating_server):
             args.server = gating_stable_server
 
-        if not args.rhel_compose:
-            args.rhel_compose = rhel_latest_compose(msg["rhel_release"])
+        if not args.distro:
+            args.distro = rhel_latest_compose(msg["rhel_release"])
 
         virtwho_ini_props["gating"] = {
             "package_nvr": msg["pkg_nvr"],
@@ -58,22 +58,25 @@ def provision_virtwho_host(args):
     # Deploy a new host by beaker if no server provided
     if not args.server:
         beaker_args_define(args)
-        args.server = install_rhel_by_beaker(args)
+        args.server = install_host_by_beaker(args)
         args.username = config.beaker.default_username
         args.password = config.beaker.default_password
     ssh_host = SSHConnect(host=args.server, user=args.username, pwd=args.password)
 
-    # Initially setup the virt-who host
-    if "RHEL-10" in args.rhel_compose:
-        ssh_host.runcmd("yum install -y subscription-manager")
-    ssh_host.runcmd(cmd="rm -f /etc/yum.repos.d/*.repo")
-    ssh_host.runcmd(cmd="subscription-manager unregister; subscription-manager clean")
-    rhel_compose_repo(
-        ssh=ssh_host,
-        repo_file="/etc/yum.repos.d/compose.repo",
-        compose_id=args.rhel_compose,
-        compose_path=args.rhel_compose_path,
-    )
+    # Initially setup the rhel virt-who host
+    if "RHEL" in args.distro:
+        if "RHEL-10" in args.distro:
+            ssh_host.runcmd("yum install -y subscription-manager")
+        ssh_host.runcmd(cmd="rm -f /etc/yum.repos.d/*.repo")
+        ssh_host.runcmd(
+            cmd="subscription-manager unregister; subscription-manager clean"
+        )
+        rhel_compose_repo(
+            ssh=ssh_host,
+            repo_file="/etc/yum.repos.d/compose.repo",
+            compose_id=args.distro,
+            compose_path=args.rhel_compose_path,
+        )
     rhsm_conf_backup(ssh_host)
     system_init(ssh_host, "virtwho")
     ssh_host.runcmd("yum install -y expect net-tools wget")
@@ -107,7 +110,7 @@ def provision_virtwho_host(args):
 
     # Update the virtwho.ini properties
     virtwho_ini_props["job"] = {
-        "rhel_compose": args.rhel_compose,
+        "rhel_compose": args.distro,
         "rhel_compose_path": args.rhel_compose_path,
     }
     virtwho_ini_props["virtwho"] = {
@@ -122,7 +125,7 @@ def provision_virtwho_host(args):
 
     logger.info(
         f"+++ Suceeded to deploy the virt-who host "
-        f"{args.rhel_compose}/{args.server} +++"
+        f"{args.distro}/{args.server} +++"
     )
 
 
@@ -153,10 +156,10 @@ def beaker_args_define(args):
     Define the necessary args to call the utils/beaker.by
     :param args: arguments to define
     """
-    args.arch = "x86_64"
     args.variant = "BaseOS"
-    if "RHEL-7" in args.rhel_compose:
+    if "RHEL-7" in args.distro or "Fedora" in args.distro:
         args.variant = "Server"
+    args.arch = "x86_64"
     args.job_group = "virt-who-ci-server-group"
     args.host = args.beaker_host
     args.host_type = None
@@ -307,7 +310,7 @@ def libvirt_pkg_install(ssh):
     """
     # virt-manager package is not ready in rhel10.0.beta
     package = "nmap iproute rpcbind libvirt* Xorg* gnome*"
-    if "RHEL-10" not in args.rhel_compose:
+    if "RHEL-10" not in args.distro:
         package += " virt-manager"
     ssh.runcmd(f"yum clean all; yum install -y {package}")
     ret, _ = ssh.runcmd("systemctl restart libvirtd;systemctl enable libvirtd")
@@ -338,9 +341,9 @@ def virtwho_arguments_parser():
     """
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        "--rhel-compose",
+        "--distro",
         required=False,
-        default=config.job.rhel_compose,
+        default=config.job.compose,
         help="Such as: RHEL-8.5.0-20211013.2, optional for gating test.",
     )
     parser.add_argument(

--- a/virtwho/provision/virtwho_host.py
+++ b/virtwho/provision/virtwho_host.py
@@ -124,8 +124,7 @@ def provision_virtwho_host(args):
             virtwho_ini_props_update(args)
 
     logger.info(
-        f"+++ Suceeded to deploy the virt-who host "
-        f"{args.distro}/{args.server} +++"
+        f"+++ Suceeded to deploy the virt-who host " f"{args.distro}/{args.server} +++"
     )
 
 

--- a/virtwho/provision/virtwho_host.py
+++ b/virtwho/provision/virtwho_host.py
@@ -65,21 +65,19 @@ def provision_virtwho_host(args):
 
     # Initially setup the rhel virt-who host
     if "RHEL" in args.distro:
-        if "RHEL-10" in args.distro:
-            ssh_host.runcmd("yum install -y subscription-manager")
         ssh_host.runcmd(cmd="rm -f /etc/yum.repos.d/*.repo")
-        ssh_host.runcmd(
-            cmd="subscription-manager unregister; subscription-manager clean"
-        )
         rhel_compose_repo(
             ssh=ssh_host,
             repo_file="/etc/yum.repos.d/compose.repo",
             compose_id=args.distro,
             compose_path=args.rhel_compose_path,
         )
+    ssh_host.runcmd("yum install -y subscription-manager expect net-tools wget")
+    ssh_host.runcmd(
+        cmd="subscription-manager unregister; subscription-manager clean"
+    )
     rhsm_conf_backup(ssh_host)
     system_init(ssh_host, "virtwho")
-    ssh_host.runcmd("yum install -y expect net-tools wget")
     virtwho_pkg = virtwho_install(ssh_host, args.virtwho_pkg_url)
 
     # Configure the virt-who host for remote libvirt mode

--- a/virtwho/provision/virtwho_satellite.py
+++ b/virtwho/provision/virtwho_satellite.py
@@ -10,7 +10,7 @@ from virtwho import FailException, logger
 from virtwho.register import Satellite
 from virtwho.ssh import SSHConnect
 from virtwho.settings import config
-from utils.beaker import install_rhel_by_beaker
+from utils.beaker import install_host_by_beaker
 from utils.satellite import satellite_deploy
 from utils.properties_update import virtwho_ini_props_update
 
@@ -26,13 +26,13 @@ def satellite_deploy_for_virtwho(args):
     satellite = args.satellite.split("-")
     args.version = satellite[0]
     args.repo = satellite[1]
-    args.rhel_compose = rhel_compose_for_satellite(satellite[2])
+    args.distro = rhel_compose_for_satellite(satellite[2])
     args.manifest = config.satellite.manifest
 
     # Install a new host by beaker to deploy satellite when no server provided.
     if not args.server:
         beaker_args_define(args)
-        args.server = install_rhel_by_beaker(args)
+        args.server = install_host_by_beaker(args)
         args.ssh_username = config.beaker.default_username
         args.ssh_password = config.beaker.default_password
         satellite_deploy(args)
@@ -111,7 +111,7 @@ def beaker_args_define(args):
     """
     args.arch = "x86_64"
     args.variant = "BaseOS"
-    if "RHEL-7" in args.rhel_compose:
+    if "RHEL-7" in args.distro:
         args.variant = "Server"
     args.job_group = "virt-who-ci-server-group"
     args.host = args.beaker_host


### PR DESCRIPTION
**Description**
Got requirement from card CCT-263.
And by confirmation with Devel team, it will be nice to have some basic testing done on virt-who to catch any basic issues like this one ; may be test against a single hypervisor.

This pr helps to

- perfect beaker.py and virtwho_host.py to support install and setup fedora host for virt-who testing
- choose 7 cases as virt-who smoke test in fedora with a mark `fedoraSmoke`

**Test Result: esx+rhsm**
```
% pytest -v tests -m 'fedoraSmoke' --disable-warnings 
========================================================= test session starts =========================================================
platform darwin -- Python 3.11.9, pytest-7.2.2, pluggy-1.0.0 -- /opt/homebrew/opt/python@3.11/bin/python3.11
cachedir: .pytest_cache
rootdir: /Users/yuefliu/workspace/virtwho-test, configfile: pytest.ini
collected 181 items / 174 deselected / 7 selected                                                                                     

tests/function/test_config.py::TestConfigurationPositive::test_debug_in_virtwho_conf PASSED                                     [ 14%]
tests/function/test_config.py::TestConfigurationPositive::test_interval_in_virtwho_conf PASSED                                  [ 28%]
tests/function/test_config.py::TestConfigurationPositive::test_oneshot_in_virtwho_conf PASSED                                   [ 42%]
tests/function/test_service.py::TestVirtwhoService::test_virtwho_service_start_and_stop PASSED                                  [ 57%]
tests/hypervisor/test_default.py::TestHypervisorPositive::test_associated_info_by_rhsmlog_and_webui PASSED                      [ 71%]
tests/hypervisor/test_esx.py::TestEsxPositive::test_hypervisor_id PASSED                                                        [ 85%]
tests/subscription/test_rhsm_option.py::TestSubscriptionPositive::test_rhsm_proxy PASSED                                        [100%]

===================================== 7 passed, 174 deselected, 17 warnings in 2038.03s (0:33:58) =====================================
```