### PR TITLE
fix test_virtwho_service_control_by_ssh_connect case issue for fips test

### DIFF
--- a/tests/function/test_service.py
+++ b/tests/function/test_service.py
@@ -136,6 +136,7 @@ class TestVirtwhoService:
         server = config.virtwho.server
         port = config.virtwho.port
         ssh_access_no_password(ssh_guest, ssh_host, server, port)
+        virtwho.kill_pid('virt-who')
         # stop
         ssh_guest.runcmd(
             f"ssh -o StrictHostKeyChecking=no {server} -p {port} 'systemctl stop virt-who'"

--- a/tests/function/test_service.py
+++ b/tests/function/test_service.py
@@ -136,7 +136,7 @@ class TestVirtwhoService:
         server = config.virtwho.server
         port = config.virtwho.port
         ssh_access_no_password(ssh_guest, ssh_host, server, port)
-        virtwho.kill_pid('virt-who')
+        virtwho.kill_pid("virt-who")
         # stop
         ssh_guest.runcmd(
             f"ssh -o StrictHostKeyChecking=no {server} -p {port} 'systemctl stop virt-who'"


### PR DESCRIPTION
The case `test_virtwho_service_control_by_ssh_connect case` always failed with error `"virt-who seems to be already running. If not, remove /run/virt-who.pid"`

Cause: in the last case 'test_interval' the virt-who cli keeps running, so failed to stop and start the virt-who service again by command, we should kill the pid at the begining.

**Test Result**
```
% pytest -v --disable-warnings tests -k 'test_virtwho_service_control_by_ssh_connect'    
========================================================= test session starts =========================================================
platform darwin -- Python 3.11.9, pytest-7.2.2, pluggy-1.0.0 -- /opt/homebrew/opt/python@3.11/bin/python3.11
cachedir: .pytest_cache
rootdir: /Users/yuefliu/workspace/virtwho-test, configfile: pytest.ini
collected 181 items / 180 deselected / 1 selected                                                                                     

tests/function/test_service.py::TestVirtwhoService::test_virtwho_service_control_by_ssh_connect PASSED                          [100%]

======================================= 1 passed, 180 deselected, 1 warning in 65.12s (0:01:05) ======================================
```