### PR TITLE
rhel10: fix case issues after run ctc1

### DIFF
--- a/tests/hypervisor/conftest.py
+++ b/tests/hypervisor/conftest.py
@@ -1,6 +1,7 @@
 import pytest
 from virtwho import RHEL_COMPOSE
 
+server_xxx_error = ["Name or service not known", "No address associated with hostname"]
 
 @pytest.fixture(scope="session")
 def esx_assertion():
@@ -22,7 +23,7 @@ def esx_assertion():
         },
         "server": {
             "invalid": {
-                "xxx": "Name or service not known",
+                "xxx": server_xxx_error,
                 "红帽€467aa": "Option server needs to be ASCII characters only",
                 "": "Option server needs to be set in config",
             },
@@ -153,7 +154,7 @@ def hyperv_assertion():
         },
         "server": {
             "invalid": {
-                "xxx": "Name or service not known",
+                "xxx": server_xxx_error,
                 "红帽€467aa": "Unable to connect to Hyper-V server",
                 "": "Option server needs to be set in config",
             },
@@ -299,7 +300,7 @@ def libvirt_assertion():
         },
         "server": {
             "invalid": {
-                "xxx": "Name or service not known",
+                "xxx": server_xxx_error,
                 "红帽€467aa": "internal error: Unable to parse URI qemu+ssh",
                 "": "Cannot recv data: Host key verification failed.",
             },

--- a/tests/hypervisor/conftest.py
+++ b/tests/hypervisor/conftest.py
@@ -139,9 +139,9 @@ def hyperv_assertion():
     Collect all the assertion info for rhevm to this fixture
     :return:
     """
-    login_error = "Incorrect domain/username/password"
-    if "RHEL-9" in RHEL_COMPOSE:
-        login_error = "Authentication failed"
+    login_error = "Authentication failed"
+    if "RHEL-8" in RHEL_COMPOSE:
+        login_error = "Incorrect domain/username/password"
     data = {
         "type": {
             "invalid": {

--- a/tests/hypervisor/conftest.py
+++ b/tests/hypervisor/conftest.py
@@ -1,7 +1,7 @@
 import pytest
 from virtwho import RHEL_COMPOSE
 
-server_xxx_error = ["Name or service not known", "No address associated with hostname"]
+server_invalid_error = ["Name or service not known", "No address associated with hostname"]
 
 
 @pytest.fixture(scope="session")
@@ -24,7 +24,7 @@ def esx_assertion():
         },
         "server": {
             "invalid": {
-                "xxx": server_xxx_error,
+                "xxx": server_invalid_error,
                 "红帽€467aa": "Option server needs to be ASCII characters only",
                 "": "Option server needs to be set in config",
             },
@@ -155,7 +155,7 @@ def hyperv_assertion():
         },
         "server": {
             "invalid": {
-                "xxx": server_xxx_error,
+                "xxx": server_invalid_error,
                 "红帽€467aa": "Unable to connect to Hyper-V server",
                 "": "Option server needs to be set in config",
             },
@@ -301,7 +301,7 @@ def libvirt_assertion():
         },
         "server": {
             "invalid": {
-                "xxx": server_xxx_error,
+                "xxx": server_invalid_error,
                 "红帽€467aa": "internal error: Unable to parse URI qemu+ssh",
                 "": "Cannot recv data: Host key verification failed.",
             },

--- a/tests/hypervisor/conftest.py
+++ b/tests/hypervisor/conftest.py
@@ -3,6 +3,7 @@ from virtwho import RHEL_COMPOSE
 
 server_xxx_error = ["Name or service not known", "No address associated with hostname"]
 
+
 @pytest.fixture(scope="session")
 def esx_assertion():
     """

--- a/tests/hypervisor/conftest.py
+++ b/tests/hypervisor/conftest.py
@@ -1,7 +1,10 @@
 import pytest
 from virtwho import RHEL_COMPOSE
 
-server_invalid_error = ["Name or service not known", "No address associated with hostname"]
+server_invalid_error = [
+    "Name or service not known",
+    "No address associated with hostname",
+]
 
 
 @pytest.fixture(scope="session")

--- a/tests/hypervisor/test_ahv.py
+++ b/tests/hypervisor/test_ahv.py
@@ -286,10 +286,10 @@ class TestAHVNegative:
         function_hypervisor.update("type", "")
         result = virtwho.run_service()
         assert result["send"] == 1 and result["thread"] == 1
-        if "RHEL-9" in RHEL_COMPOSE:
-            assert result["error"] == 1
-        else:
+        if "RHEL-8" in RHEL_COMPOSE:
             assert result["error"] == 0
+        else:
+            assert result["error"] == 1
 
     @pytest.mark.tier2
     def test_server(self, virtwho, function_hypervisor, ahv_assertion):

--- a/tests/hypervisor/test_esx.py
+++ b/tests/hypervisor/test_esx.py
@@ -22,7 +22,7 @@ from virtwho import PRINT_JSON_FILE
 from virtwho import SECOND_HYPERVISOR_FILE
 from virtwho import SECOND_HYPERVISOR_SECTION
 
-from virtwho.base import encrypt_password
+from virtwho.base import encrypt_password, msg_search
 from virtwho.base import get_host_domain_id
 from virtwho.configure import hypervisor_create
 from virtwho.settings import TEMP_DIR
@@ -458,7 +458,7 @@ class TestEsxNegative:
             assert (
                 result["error"] is not 0
                 and result["send"] == 0
-                and assertion["invalid"][f"{value}"] in result["error_msg"]
+                and msg_search(result["error_msg"], assertion["invalid"][f"{value}"])
             )
 
         # server option is disable

--- a/tests/hypervisor/test_esx.py
+++ b/tests/hypervisor/test_esx.py
@@ -421,10 +421,10 @@ class TestEsxNegative:
         function_hypervisor.update("type", "")
         result = virtwho.run_service()
         assert result["send"] == 1 and result["thread"] == 1
-        if "RHEL-9" in RHEL_COMPOSE:
-            assert result["error"] == 1
-        else:
+        if "RHEL-8" in RHEL_COMPOSE:
             assert result["error"] == 0
+        else:
+            assert result["error"] == 1
 
     @pytest.mark.tier2
     def test_server(self, virtwho, function_hypervisor, esx_assertion):

--- a/tests/hypervisor/test_hyperv.py
+++ b/tests/hypervisor/test_hyperv.py
@@ -17,7 +17,7 @@ from virtwho import SECOND_HYPERVISOR_FILE
 from virtwho import SECOND_HYPERVISOR_SECTION
 
 
-from virtwho.base import encrypt_password, is_host_responsive
+from virtwho.base import encrypt_password, is_host_responsive, msg_search
 from virtwho.configure import hypervisor_create
 
 from hypervisor.virt.hyperv.hypervcli import HypervCLI
@@ -302,7 +302,7 @@ class TestHypervNegative:
             assert (
                 result["error"] is not 0
                 and result["send"] == 0
-                and assertion["invalid"][f"{value}"] in result["error_msg"]
+                and msg_search(result["error_msg"], assertion["invalid"][f"{value}"])
             )
 
         # server option is disable

--- a/tests/hypervisor/test_hyperv.py
+++ b/tests/hypervisor/test_hyperv.py
@@ -265,10 +265,10 @@ class TestHypervNegative:
         function_hypervisor.update("type", "")
         result = virtwho.run_service()
         assert result["send"] == 1 and result["thread"] == 1
-        if "RHEL-9" in RHEL_COMPOSE:
-            assert result["error"] == 1
-        else:
+        if "RHEL-8" in RHEL_COMPOSE:
             assert result["error"] == 0
+        else:
+            assert result["error"] == 1
 
     @pytest.mark.tier2
     def test_server(self, virtwho, function_hypervisor, hyperv_assertion):

--- a/tests/hypervisor/test_kubevirt.py
+++ b/tests/hypervisor/test_kubevirt.py
@@ -231,10 +231,10 @@ class TestKubevirtNegative:
         function_hypervisor.update("type", "")
         result = virtwho.run_service()
         assert result["send"] == 1 and result["thread"] == 1
-        if "RHEL-9" in RHEL_COMPOSE:
-            assert result["error"] == 1
-        else:
+        if "RHEL-8" in RHEL_COMPOSE:
             assert result["error"] == 0
+        else:
+            assert result["error"] == 1
 
     @pytest.mark.tier2
     def test_filter_hosts(self, virtwho, function_hypervisor, hypervisor_data):

--- a/tests/hypervisor/test_libvirt.py
+++ b/tests/hypervisor/test_libvirt.py
@@ -16,7 +16,7 @@ from virtwho import SECOND_HYPERVISOR_FILE
 from virtwho import SECOND_HYPERVISOR_SECTION
 
 
-from virtwho.base import encrypt_password
+from virtwho.base import encrypt_password, msg_search
 from virtwho.configure import hypervisor_create
 
 
@@ -298,7 +298,7 @@ class TestLibvirtNegative:
                 result["error"] is not 0
                 and result["send"] == 0
                 and result["thread"] == 1
-                and assertion["invalid"][f"{value}"] in result["error_msg"]
+                and msg_search(result["error_msg"], assertion["invalid"][f"{value}"])
             )
 
         # server option is disable

--- a/tests/hypervisor/test_libvirt.py
+++ b/tests/hypervisor/test_libvirt.py
@@ -260,10 +260,10 @@ class TestLibvirtNegative:
         function_hypervisor.update("type", "")
         result = virtwho.run_service()
         assert result["send"] == 1 and result["thread"] == 1
-        if "RHEL-9" in RHEL_COMPOSE:
-            assert result["error"] == 1
-        else:
+        if "RHEL-8" in RHEL_COMPOSE:
             assert result["error"] == 0
+        else:
+            assert result["error"] == 1
 
     @pytest.mark.tier2
     def test_server(self, virtwho, function_hypervisor, libvirt_assertion):

--- a/tests/subscription/conftest.py
+++ b/tests/subscription/conftest.py
@@ -18,7 +18,11 @@ def register_assertion():
         "virt-who can't be started|"
         "Communication with subscription manager failed"
     ]
-    rhsm_hostname_error = [
+    rhsm_hostname_error1 = [
+        "Name or service not known",
+        "No address associated with hostname"
+    ]
+    rhsm_hostname_error2 = [
         "Server error attempting a GET to /rhsm/status/",
         "Communication with subscription manager failed",
     ]
@@ -46,8 +50,8 @@ def register_assertion():
             "null_with_another_good": owner_error_null,
         },
         "rhsm_hostname": {
-            "invalid": {"xxx": "Name or service not known", "": rhsm_hostname_error},
-            "disable": rhsm_hostname_error,
+            "invalid": {"xxx": rhsm_hostname_error1, "": rhsm_hostname_error2},
+            "disable": rhsm_hostname_error2,
         },
         "rhsm_port": {
             "invalid": {

--- a/tests/subscription/conftest.py
+++ b/tests/subscription/conftest.py
@@ -20,7 +20,7 @@ def register_assertion():
     ]
     rhsm_hostname_error1 = [
         "Name or service not known",
-        "No address associated with hostname"
+        "No address associated with hostname",
     ]
     rhsm_hostname_error2 = [
         "Server error attempting a GET to /rhsm/status/",

--- a/virtwho/base.py
+++ b/virtwho/base.py
@@ -589,7 +589,9 @@ def ssh_access_no_password(ssh_local, ssh_remote, remote_host, remote_port=22):
     ssh_remote.runcmd(f"mkdir ~/.ssh/;echo '{output}' >> ~/.ssh/authorized_keys")
 
     # creat ~/.ssh/known_hosts for local host
-    ssh_local.runcmd(f"ssh-keyscan -p {remote_port} {remote_host} > ~/.ssh/known_hosts")
+    ssh_local.runcmd(
+        f"ssh-keyscan -p {remote_port} {remote_host} >> ~/.ssh/known_hosts"
+    )
 
 
 def expect_run(ssh, cmd, attrs):

--- a/virtwho/base.py
+++ b/virtwho/base.py
@@ -589,9 +589,7 @@ def ssh_access_no_password(ssh_local, ssh_remote, remote_host, remote_port=22):
     ssh_remote.runcmd(f"mkdir ~/.ssh/;echo '{output}' >> ~/.ssh/authorized_keys")
 
     # creat ~/.ssh/known_hosts for local host
-    ssh_local.runcmd(
-        f"ssh-keyscan -p {remote_port} {remote_host} > ~/.ssh/known_hosts"
-    )
+    ssh_local.runcmd(f"ssh-keyscan -p {remote_port} {remote_host} > ~/.ssh/known_hosts")
 
 
 def expect_run(ssh, cmd, attrs):

--- a/virtwho/base.py
+++ b/virtwho/base.py
@@ -581,7 +581,7 @@ def ssh_access_no_password(ssh_local, ssh_remote, remote_host, remote_port=22):
     """
     # create ssh key for local host
     ssh_local.runcmd('echo -e "\n" | ssh-keygen -N "" &> /dev/null')
-    ret, output = ssh_local.runcmd("cat ~/.ssh/id_rsa.pub")
+    ret, output = ssh_local.runcmd("cat ~/.ssh/id_*.pub")
     if ret != 0 or output is None:
         raise FailException("Failed to create ssh key ")
 
@@ -590,7 +590,7 @@ def ssh_access_no_password(ssh_local, ssh_remote, remote_host, remote_port=22):
 
     # creat ~/.ssh/known_hosts for local host
     ssh_local.runcmd(
-        f"ssh-keyscan -p {remote_port} {remote_host} >> ~/.ssh/known_hosts"
+        f"ssh-keyscan -p {remote_port} {remote_host} > ~/.ssh/known_hosts"
     )
 
 


### PR DESCRIPTION
- test_virtwho_service_control_by_ssh_connect: fix issue to ssh connect no password
- test_rhsm_hostname： fix error message change issue with invalid value
- test_type: fix error number issue for rhel10
- test_server: fix error message change issue with invalid value
- test_username/password for hyperv: fix error message issue

**Test Result**
```
% pytest -v --disable-warnings tests/function/test_service.py -k 'test_virtwho_service_control_by_ssh_connect'
========================================================= test session starts =========================================================
platform darwin -- Python 3.11.9, pytest-7.2.2, pluggy-1.0.0 -- /opt/homebrew/opt/python@3.11/bin/python3.11
cachedir: .pytest_cache
rootdir: /Users/yuefliu/workspace/virtwho-test, configfile: pytest.ini
collected 9 items / 8 deselected / 1 selected                                                                                         

tests/function/test_service.py::TestVirtwhoService::test_virtwho_service_control_by_ssh_connect PASSED                          [100%]

================================================== 1 passed, 8 deselected in 46.89s ===================================================
```

```
% pytest -v --disable-warnings tests/subscription/test_rhsm_option.py -k 'test_rhsm_hostname' -m 'tier2'
========================================================= test session starts =========================================================
platform darwin -- Python 3.11.9, pytest-7.2.2, pluggy-1.0.0 -- /opt/homebrew/opt/python@3.11/bin/python3.11
cachedir: .pytest_cache
rootdir: /Users/yuefliu/workspace/virtwho-test, configfile: pytest.ini
collected 12 items / 11 deselected / 1 selected                                                                                       

tests/subscription/test_rhsm_option.py::TestSubscriptionNegative::test_rhsm_hostname PASSED                                     [100%]

====================================== 1 passed, 11 deselected, 3 warnings in 112.52s (0:01:52) =======================================
[2024-06-12 09:25:35] - [conftest.py] - INFO: Finished Test: tests/subscription/test_rhsm_option.py::TestSubscriptionNegative::test_rhsm_hostname
```
```
% pytest -v --disable-warnings tests/hypervisor/test_esx.py -k 'test_type' -m 'tier2' 
========================================================= test session starts =========================================================
platform darwin -- Python 3.11.9, pytest-7.2.2, pluggy-1.0.0 -- /opt/homebrew/opt/python@3.11/bin/python3.11
cachedir: .pytest_cache
rootdir: /Users/yuefliu/workspace/virtwho-test, configfile: pytest.ini
collected 29 items / 28 deselected / 1 selected                                                                                       

tests/hypervisor/test_esx.py::TestEsxNegative::test_type PASSED                                                                 [100%]

====================================== 1 passed, 28 deselected, 6 warnings in 173.86s (0:02:53) =======================================
```
```
% pytest -v --disable-warnings tests/hypervisor/test_hyperv.py -k 'test_server' -m 'tier2'
========================================================= test session starts =========================================================
platform darwin -- Python 3.11.9, pytest-7.2.2, pluggy-1.0.0 -- /opt/homebrew/opt/python@3.11/bin/python3.11
cachedir: .pytest_cache
rootdir: /Users/yuefliu/workspace/virtwho-test, configfile: pytest.ini
collected 13 items / 12 deselected / 1 selected                                                                                       

tests/hypervisor/test_hyperv.py::TestHypervNegative::test_server PASSED                                                         [100%]

====================================== 1 passed, 12 deselected, 6 warnings in 206.80s (0:03:26) =======================================
```
```
% pytest -v --disable-warnings tests/hypervisor/test_hyperv.py -k 'test_username or test_password' -m 'tier2'
========================================================= test session starts =========================================================
platform darwin -- Python 3.11.9, pytest-7.2.2, pluggy-1.0.0 -- /opt/homebrew/opt/python@3.11/bin/python3.11
cachedir: .pytest_cache
rootdir: /Users/yuefliu/workspace/virtwho-test, configfile: pytest.ini
collected 13 items / 11 deselected / 2 selected                                                                                       

tests/hypervisor/test_hyperv.py::TestHypervNegative::test_username PASSED                                                       [ 50%]
tests/hypervisor/test_hyperv.py::TestHypervNegative::test_password PASSED                                                       [100%]

====================================== 2 passed, 11 deselected, 10 warnings in 356.69s (0:05:56) ======================================
```