### PR TITLE
fix test_associated_info_by_rhsmlog_and_webui case issue

### DIFF
--- a/tests/hypervisor/test_default.py
+++ b/tests/hypervisor/test_default.py
@@ -90,6 +90,7 @@ class TestHypervisorPositive:
         rhsm,
         satellite,
         register_data,
+        function_guest_register,
     ):
         """
         :title: virt-who: hypervisor: check associated info by rhsm.log and webui


### PR DESCRIPTION
In some smoke jobs, the case `test_associated_info_by_rhsmlog_and_webui `may fail because no guest_register step before it.
Didn't find such issue in the regression test because there were many other cases before this case, so the guest must have been registered before the case.