### PR TITLE
virtwho_host.py: yum localinstall virt-who package with --allowerasing

### DIFF
--- a/virtwho/provision/virtwho_host.py
+++ b/virtwho/provision/virtwho_host.py
@@ -206,7 +206,7 @@ def virtwho_install_by_url(ssh, url):
     if not output:
         ssh.runcmd("echo 'sslverify=false' >> /etc/yum.conf")
     ssh.runcmd("rm -rf /var/cache/yum/;" "yum clean all;" "yum remove -y virt-who")
-    ssh.runcmd(f"yum localinstall -y {url}")
+    ssh.runcmd(f"yum localinstall -y {url} --allowerasing")
 
 
 def rhsm_conf_backup(ssh):


### PR DESCRIPTION
To fix the conflicting requests, for example
```
Error: 
 Problem: cannot install both python3-3.12.2-7.el10.x86_64 from RHEL-10.0-20240623.1 and python3-3.9.18-3.el9.x86_64 from @System
  - package virt-who-1.32.0-3.noarch from @commandline requires python(abi) = 3.12, but none of the providers can be installed
  - package chrome-gnome-shell-42.1-1.el9.x86_64 from @System requires python(abi) = 3.9, but none of the providers can be installed
  - conflicting requests
  - problem with installed package chrome-gnome-shell-42.1-1.el9.x86_64
```