### PR TITLE
libvirt case test_server non-unicode assertion issue

### DIFF
--- a/tests/hypervisor/conftest.py
+++ b/tests/hypervisor/conftest.py
@@ -305,7 +305,7 @@ def libvirt_assertion():
         "server": {
             "invalid": {
                 "xxx": server_invalid_error,
-                "红帽€467aa": "internal error: Unable to parse URI qemu+ssh",
+                "红帽€467aa": "internal error: Unable to parse URI.*红帽€467aa",
                 "": "Cannot recv data: Host key verification failed.",
             },
             "disable": server_disable_error,


### PR DESCRIPTION
Virt-who failed to assert the `qemu+ssh` any more for rhel-9, so change to use the regular expression `.*` with the keyword `红帽€467aa`, which will not impact the test of rhel-10 no matter there will be the same issue in rhel-10.

Test Result
```
% pytest -v tests/hypervisor/test_libvirt.py -k 'test_server' -m 'tier2' 
========================================================= test session starts =========================================================
platform darwin -- Python 3.11.9, pytest-7.2.2, pluggy-1.0.0 -- /opt/homebrew/opt/python@3.11/bin/python3.11
cachedir: .pytest_cache
rootdir: /Users/yuefliu/workspace/virtwho-test, configfile: pytest.ini
collected 12 items / 11 deselected / 1 selected                                                                                       

tests/hypervisor/test_libvirt.py::TestLibvirtNegative::test_server PASSED                                                       [100%]

====================================== 1 passed, 11 deselected, 4 warnings in 144.56s (0:02:24) =======================================
[2024-07-31 11:46:01] - [conftest.py] - INFO: Finished Test: tests/hypervisor/test_libvirt.py::TestLibvirtNegative::test_server
```