### PR TITLE
test_package_info maintenance due to RHEL-50657

### DIFF
--- a/tests/package/test_info.py
+++ b/tests/package/test_info.py
@@ -11,7 +11,7 @@ import os
 import re
 import pytest
 
-from virtwho import base, RHEL_COMPOSE, VIRTWHO_PKG
+from virtwho import base, RHEL_COMPOSE, VIRTWHO_PKG, VIRTWHO_VERSION
 from virtwho.settings import DOCS_DIR, TEMP_DIR
 
 
@@ -134,15 +134,17 @@ class TestVirtwhoPackageInfo:
         """
         pkg_info = base.package_info_analyzer(ssh_host, "virt-who")
         virtwho_license = "GPLv2+ and LGPLv3+"
-        if "RHEL-8" in RHEL_COMPOSE:
-            virtwho_license = "GPLv2+"
+        group = "System Environment/Base"
+        if VIRTWHO_VERSION >= '1.31.28':
+            virtwho_license = "GPL-2.0-or-later AND LGPL-3.0-or-later"
+            group = "Unspecified"
         assert (
             pkg_info["Name"] == "virt-who"
             and pkg_info["Version"] in VIRTWHO_PKG
             and pkg_info["Release"] in VIRTWHO_PKG
             and pkg_info["Architecture"] == "noarch"
             and pkg_info["Install Date"]
-            and pkg_info["Group"] == "System Environment/Base"
+            and pkg_info["Group"] == group
             and pkg_info["Size"]
             and pkg_info["License"] == virtwho_license
             and "RSA/SHA256" in pkg_info["Signature"]

--- a/tests/package/test_info.py
+++ b/tests/package/test_info.py
@@ -135,7 +135,7 @@ class TestVirtwhoPackageInfo:
         pkg_info = base.package_info_analyzer(ssh_host, "virt-who")
         virtwho_license = "GPLv2+ and LGPLv3+"
         group = "System Environment/Base"
-        if VIRTWHO_VERSION >= '1.31.28':
+        if VIRTWHO_VERSION >= "1.31.28":
             virtwho_license = "GPL-2.0-or-later AND LGPL-3.0-or-later"
             group = "Unspecified"
         assert (

--- a/virtwho/__init__.py
+++ b/virtwho/__init__.py
@@ -27,7 +27,7 @@ REGISTER = config.job.register
 
 VIRTWHO_PKG = config.virtwho.package
 
-VIRTWHO_VERSION = VIRTWHO_PKG.split('-')[2]
+VIRTWHO_VERSION = VIRTWHO_PKG.split("-")[2]
 
 # Backup file for /etc/virt-who.conf
 VIRTWHO_CONF_BACKUP = "virt-who.conf.save"

--- a/virtwho/__init__.py
+++ b/virtwho/__init__.py
@@ -27,6 +27,8 @@ REGISTER = config.job.register
 
 VIRTWHO_PKG = config.virtwho.package
 
+VIRTWHO_VERSION = VIRTWHO_PKG.split('-')[2]
+
 # Backup file for /etc/virt-who.conf
 VIRTWHO_CONF_BACKUP = "virt-who.conf.save"
 


### PR DESCRIPTION
Update test_package_info due to RHEL-50657 was closed as not a bug, so make below changes for the version 1.31.28 and later.

- virtwho_license = "GPL-2.0-or-later AND LGPL-3.0-or-later"
- group = "Unspecified"
- remove if branch for rhel-8, the rhel8 will be run in the specified git branch

**Test Result**
```
% pytest -v tests/package/test_info.py -k 'test_package_info' --disable-warnings
========================================================= test session starts =========================================================
platform darwin -- Python 3.11.9, pytest-7.2.2, pluggy-1.0.0 -- /opt/homebrew/opt/python@3.11/bin/python3.11
cachedir: .pytest_cache
rootdir: /Users/yuefliu/workspace/virtwho-test, configfile: pytest.ini
collected 6 items / 4 deselected / 2 selected                                                                                         

tests/package/test_info.py::TestVirtwhoPackageInfo::test_package_info PASSED                                                    [ 50%]
tests/package/test_info.py::TestVirtwhoPackageInfo::test_package_info_with_User_Agent_header PASSED                             [100%]

================================================== 2 passed, 4 deselected in 33.92s ===================================================
[2024-07-31 15:37:18] - [conftest.py] - INFO: Finished Test: tests/package/test_info.py::TestVirtwhoPackageInfo::test_package_info_with_User_Agent_header
```