### PR TITLE
virtwho_host.py: update for rhel10

### DIFF
--- a/virtwho/provision/virtwho_host.py
+++ b/virtwho/provision/virtwho_host.py
@@ -303,10 +303,9 @@ def libvirt_pkg_install(ssh):
     Install libvirt related packages.
     :param ssh: ssh access of virt-who host.
     """
-    # virt-manager package is not ready in rhel10.0.beta
-    package = "nmap iproute rpcbind libvirt* Xorg* gnome*"
+    package = "nmap iproute rpcbind libvirt* gnome* virt-manager "
     if "RHEL-10" not in args.distro:
-        package += " virt-manager"
+        package += " Xorg*"
     ssh.runcmd(f"yum clean all; yum install -y {package}")
     ret, _ = ssh.runcmd("systemctl restart libvirtd;systemctl enable libvirtd")
     if ret == 0:

--- a/virtwho/provision/virtwho_host.py
+++ b/virtwho/provision/virtwho_host.py
@@ -303,9 +303,7 @@ def libvirt_pkg_install(ssh):
     Install libvirt related packages.
     :param ssh: ssh access of virt-who host.
     """
-    package = "nmap iproute rpcbind libvirt* gnome* virt-manager "
-    if "RHEL-10" not in args.distro:
-        package += " Xorg*"
+    package = "nmap iproute rpcbind libvirt* gnome* virt-manager"
     ssh.runcmd(f"yum clean all; yum install -y {package}")
     ret, _ = ssh.runcmd("systemctl restart libvirtd;systemctl enable libvirtd")
     if ret == 0:


### PR DESCRIPTION
- The virt-manager issue on rhel-10 has been fixed.
- `Xorg` was not found in rhel-10, so skip it by default, we can locally install it when needed.