### PR TITLE
Maintain virt-who cases for rhel-10.beta

### DIFF
--- a/docs/virtwho_help_page_rhel_10
+++ b/docs/virtwho_help_page_rhel_10
@@ -1,0 +1,27 @@
+usage: virt-who [-d] [-o] [-i INTERVAL] [-p] [-c CONFIGS] [-s] [-j] [--version]
+
+Agent for reporting virtual guest IDs to subscription manager
+
+options:
+  -h, --help            show this help message and exit
+  -d, --debug           Enable debugging output
+  -o, --one-shot        Send the list of guest IDs and exit immediately
+  -s, --status          Produce a report to show connection health
+  -j, --json            Used with status option to make output in json
+  -i INTERVAL, --interval INTERVAL
+                        Acquire list of virtual guest each N seconds. Send if
+                        changes are detected.
+  -p, --print           Print the host/guest association obtained from
+                        virtualization backend (implies oneshot)
+  -c CONFIGS, --config CONFIGS
+                        Configuration file that will be processed and will
+                        override configuration from other files. 'global' and
+                        'default' sections are not read in files passed in via
+                        this option, and are only read from /etc/virt-
+                        who.conf. Can be used multiple times
+  --version             Display the version information and exit
+
+virt-who also reads environment variables. They have the same name as command
+line arguments but uppercased, with underscore instead of dash and prefixed
+with VIRTWHO_ (e.g. VIRTWHO_ONE_SHOT). Empty variables are considered as
+disabled, non-empty as enabled.

--- a/docs/virtwho_man_page_rhel_10
+++ b/docs/virtwho_man_page_rhel_10
@@ -1,0 +1,174 @@
+VIRT-WHO(8)                 System Manager's Manual                VIRT-WHO(8)
+
+NAME
+       virt-who  -  Agent  for  reporting  virtual guest IDs to an entitlement
+       server.
+
+SYNOPSIS
+       virt-who [-d] [-i INTERVAL] [-o] [-s]
+
+OPTIONS
+       -h, --help
+              show this help message and exit
+
+       -d, --debug
+              Enable debugging output
+
+       -o, --one-shot
+              Send the list of guest IDs and exit immediately
+
+       -i INTERVAL, --interval=INTERVAL
+              Acquire and send guest information each  N  seconds;  note  that
+              this option is recommendation only, requested interval might not
+              been honoured and the actual interval might be longer or shorter
+              depending on backend that is used.
+
+       -p, --print
+              Print  the  host/guests  association  in JSON format to standard
+              output
+
+       -c, --config
+              Use configuration file  directly  (will  override  configuration
+              from  other files. 'global', 'default', and 'system_environment'
+              sections are not read in files passed in via  this  option,  and
+              are  only  read  from  /etc/virt-who.conf). Can be used multiple
+              times. See virt-who-config(5) for  details  about  configuration
+              file format.
+
+       -s, --status
+              Confirm  the correctness of the configurations. Test the connec‐
+              tions and build a report on the result. The default display is a
+              short summary of the configurations.
+
+       -j, --json
+              Used with status to return a more detailed report in  json  for‐
+              mat.
+
+USAGE
+   MODE
+       virt-who has four modes how it can run:
+
+       1. one-shot mode
+              # virt-who -o
+
+              In  this  mode virt-who just sends the host to guest association
+              to the server once and then exits.
+
+       2. interval mode
+              # virt-who -i INTERVAL
+
+              This is the default mode. virt-who will listen to change  events
+              (if  available)  or  do  a polling with given interval, and will
+              send the host to guest association when it changes. The  default
+              polling  interval  is  3600 seconds and can be changed using "-i
+              INTERVAL" (in seconds).
+
+       3. print mode
+              # virt-who -p
+
+              This mode is similar to oneshot mode but the host to guest asso‐
+              ciation is not send to server, but printed  to  standard  output
+              instead.
+
+       3. status mode
+              # virt-who -s
+
+              This  mode is for configuration diagnosis. The host to guest as‐
+              sociation is not compiled and is not sent to  the  server.  When
+              executed,  it  will confirm the ability to log into and retrieve
+              data from the source for each configuration. It will  also  con‐
+              firm  the  credentials  and organization for each destination in
+              the configurations.  It will produce results in  two  ways  that
+              can be used to diagnose problems. The first is a summary:
+
+              Configuration Name: esx_config1
+              Source Status: success
+              Destination Status: success
+
+              Configuration Name: hyperv-55
+              Source Status: failure
+              Destination Status: failure
+
+              The second is a machine-readable json output (which is generated
+              when the -j/--json option is used):
+
+              {
+                  "configurations": [
+                      {
+                          "name":"esx-conf1",
+                          "source":{
+                              "connection":"esx_system.example.com",
+                              "status":"success",
+                              "last_successful_retrieve":"2020-02-28  07:25:25
+              UTC",
+                              "hypervisors":20,
+                              "guests":37
+                          },
+                          "destination":{
+                              "connection":"candlepin.example.com",
+                              "status":"success",
+                              "last_successful_send":"2020-02-28      07:25:27
+              UTC",
+                              "last_successful_send_job_status":"FINISHED"
+                          }
+                      },
+                      {
+                          "name":"hyperv-55",
+                          "source":{
+                              "connection":"windows10-3.company.com",
+                              "status":"failure",
+                              "message":"Unable  to connect to server: invalid
+              credentials",
+                              "last_successful_retrieve":"none"
+                          },
+                          "destination":{
+                              "connection":"candlepin.company.com",
+                              "status":"failure",
+                              "message":"ConnectionRefusedError:  [Errno  111]
+              Connection refused",
+                              "last_successful_send":"none",
+                              "last_successful_send_job_status":"none"
+                          }
+                      }
+                  ] }
+
+LOGGING
+       virt-who  always writes error output to file /var/log/rhsm/rhsm.log. It
+       also writes the same output to standard error output when started  from
+       command line.
+
+       virt-who  can  be  started  with  option "-d" in all modes and with all
+       backends. This option will enable verbose output with more information.
+
+SECURITY
+       Virt-who may present security concerns in  some  scenarios  because  it
+       needs  access to every hypervisor in the environment. To minimize secu‐
+       rity risk, virt-who is a network client, not a  server.  It  only  does
+       outbound  connections to find and register new hypervisors and does not
+       need access to any virtual machines. To  further  reduce  risk,  deploy
+       virt-who  in  a  small  virtual machine with a minimal installation and
+       lock it down from any unsolicited inbound network connections.
+
+       Here is a list of ports that need to be open for different hypervisors:
+
+           VMWare ESX/vCenter: 443/tcp
+           Hyper-V: 5985/tcp
+           RHEV-M: 443/tcp or 8443/tcp (depending on version)
+           libvirt: depending on transport type, default (for  remote  connec‐
+       tions) is qemu over ssh on port 22
+           local libvirt uses a local connection and doesn't need an open port
+           kubevirt: 8443/tcp
+           Nutanix AHV: 9440/tcp
+
+       virt-who  also  needs  to have access to an entitlement server. Default
+       port is 443/tcp. All the ports might be changed by  system  administra‐
+       tors.
+
+       Using  the  same network for machine running virt-who as for hypervisor
+       management software instead of production VM networks is suggested.
+
+AUTHORS
+       Radek Novacek <rnovacek at redhat dot com>
+       William Poteat <wpoteat at redhat dot com>
+
+virt-who                          April 2016                       VIRT-WHO(8)

--- a/tests/function/test_service.py
+++ b/tests/function/test_service.py
@@ -48,8 +48,6 @@ class TestVirtwhoService:
 
         virtwho.operate_service(action="stop")
         _, output = virtwho.operate_service(action="status")
-        if HYPERVISOR == "ahv":
-            logger.info("=== AHV: failed with RHEL-12393 ===")
         assert output is "dead"
 
     @pytest.mark.tier1
@@ -136,24 +134,19 @@ class TestVirtwhoService:
         server = config.virtwho.server
         port = config.virtwho.port
         ssh_access_no_password(ssh_guest, ssh_host, server, port)
+        virtwho.operate_service(action="stop")
         virtwho.kill_pid("virt-who")
-        # stop
-        ssh_guest.runcmd(
-            f"ssh -o StrictHostKeyChecking=no {server} -p {port} 'systemctl stop virt-who'"
-        )
         _, status = virtwho.operate_service(action="status")
-        if HYPERVISOR == "ahv":
-            logger.info("=== AHV: failed with RHEL-12393 ===")
         assert status == "dead"
 
-        # start
+        # start by a remote host
         ssh_guest.runcmd(
-            f"ssh -o StrictHostKeyChecking=no {server} -p {port} 'systemctl restart virt-who'"
+            f"ssh -o StrictHostKeyChecking=no {server} -p {port} 'systemctl start virt-who'"
         )
         _, status = virtwho.operate_service(action="status")
         assert status == "running"
 
-        # stop
+        # stop by a remote host
         ssh_guest.runcmd(
             f"ssh -o StrictHostKeyChecking=no {server} -p {port} 'systemctl stop virt-who'"
         )

--- a/tests/hypervisor/conftest.py
+++ b/tests/hypervisor/conftest.py
@@ -204,9 +204,6 @@ def kubevirt_assertion():
     Collect all the assertion info for kubevirt to this fixture
     :return:
     """
-    disable_error = "Failed to connect socket to '/var/run/libvirt/libvirt-sock-ro'"
-    if "RHEL-9" in RHEL_COMPOSE:
-        disable_error = "Cannot use direct socket mode if no URI is set"
     data = {
         "type": {
             "invalid": {
@@ -215,7 +212,7 @@ def kubevirt_assertion():
                 "": "Unsupported virtual type '' is set",
             },
             "non_rhel9": "virt-who can't be started",
-            "disable": disable_error,
+            "disable": "Cannot use direct socket mode if no URI is set",
             "disable_multi_configs": "Failed to connect socket to '/var/run/libvirt/libvirt-sock-ro'",
         },
     }
@@ -286,11 +283,6 @@ def libvirt_assertion():
     :return:
     """
     login_error = "fails with error: Cannot recv data"
-    server_disable_error = (
-        "Failed to connect socket to '/var/run/libvirt/libvirt-sock-ro'"
-    )
-    if "RHEL-9" in RHEL_COMPOSE:
-        server_disable_error = "Cannot use direct socket mode if no URI is set"
     data = {
         "type": {
             "invalid": {
@@ -308,7 +300,7 @@ def libvirt_assertion():
                 "红帽€467aa": "internal error: Unable to parse URI.*红帽€467aa",
                 "": "Cannot recv data: Host key verification failed.",
             },
-            "disable": server_disable_error,
+            "disable": "Cannot use direct socket mode if no URI is set",
         },
         "username": {
             "invalid": {

--- a/tests/package/test_info.py
+++ b/tests/package/test_info.py
@@ -84,8 +84,8 @@ class TestVirtwhoPackageInfo:
         man_page_remote = "/root/man_page"
         man_page_local = os.path.join(TEMP_DIR, f"virtwho_man_page")
         man_page_compare = os.path.join(DOCS_DIR, f"virtwho_man_page_rhel_9")
-        if "RHEL-8" in RHEL_COMPOSE:
-            man_page_compare = os.path.join(DOCS_DIR, f"virtwho_man_page_rhel_8")
+        if "RHEL-10" in RHEL_COMPOSE:
+            man_page_compare = os.path.join(DOCS_DIR, f"virtwho_man_page_rhel_10")
         ssh_host.runcmd(f"man virt-who > {man_page_remote}")
         ssh_host.get_file(man_page_remote, man_page_local)
         assert base.local_files_compare(man_page_local, man_page_compare)
@@ -110,8 +110,8 @@ class TestVirtwhoPackageInfo:
         help_page_remote = "/root/help_page"
         help_page_local = os.path.join(TEMP_DIR, f"virtwho_help_page")
         help_page_compare = os.path.join(DOCS_DIR, f"virtwho_help_page_rhel_9")
-        if "RHEL-8" in RHEL_COMPOSE:
-            help_page_compare = os.path.join(DOCS_DIR, f"virtwho_help_page_rhel_8")
+        if "RHEL-10" in RHEL_COMPOSE:
+            help_page_compare = os.path.join(DOCS_DIR, f"virtwho_help_page_rhel_10")
         ssh_host.runcmd(f"virt-who --help > {help_page_remote}")
         ssh_host.get_file(help_page_remote, help_page_local)
         assert base.local_files_compare(help_page_local, help_page_compare)

--- a/virtwho/base.py
+++ b/virtwho/base.py
@@ -444,11 +444,11 @@ def wget_download(ssh, url, file_path, file_name=None):
     _, ouput = ssh.runcmd(f"ls {file_path}")
     if "No such file or directory" in ouput:
         ssh.runcmd(f"mkdir -p {file_path}")
-    cmd = f"wget {url} -P {file_path} "
+    cmd = f"wget --no-check-certificate {url} -P {file_path} "
     if file_name:
         cmd += f" -O {file_name}"
-    ret, output = ssh.runcmd(cmd)
-    if ret == 0 and "100%" in output:
+    ret, _ = ssh.runcmd(cmd)
+    if ret == 0:
         return True
     raise FailException(f"Failed to wget download from {url}")
 


### PR DESCRIPTION
- test_man_page, add man page compare file
- test_help_page, add help page compare file
- test_install_uninstall_by_rpm, skip to check cert when wget download
- test_virtwho_service_control_by_ssh_connect, reset the case steps
- test_type and test_server: update the assertion for rhel-10

**Test Result**
```
% pytest -v tests/package/test_info.py -k 'test_man_page or test_help_page' --disable-warnings  
========================================================= test session starts =========================================================
platform darwin -- Python 3.11.9, pytest-7.2.2, pluggy-1.0.0 -- /opt/homebrew/opt/python@3.11/bin/python3.11
cachedir: .pytest_cache
rootdir: /Users/yuefliu/workspace/virtwho-test, configfile: pytest.ini
collected 6 items / 4 deselected / 2 selected                                                                                         

tests/package/test_info.py::TestVirtwhoPackageInfo::test_man_page PASSED                                                        [ 50%]
tests/package/test_info.py::TestVirtwhoPackageInfo::test_help_page PASSED                                                       [100%]

=================================================== 2 passed, 4 deselected in 8.16s ===================================================
```
```
% pytest -v --disable-warnings tests/function/test_service.py -k 'test_virtwho_service_control_by_ssh_connect'
========================================================= test session starts =========================================================
platform darwin -- Python 3.11.9, pytest-7.2.2, pluggy-1.0.0 -- /opt/homebrew/opt/python@3.11/bin/python3.11
cachedir: .pytest_cache
rootdir: /Users/yuefliu/workspace/virtwho-test, configfile: pytest.ini
collected 9 items / 8 deselected / 1 selected                                                                                         

tests/function/test_service.py::TestVirtwhoService::test_virtwho_service_control_by_ssh_connect PASSED                          [100%]

================================================== 1 passed, 8 deselected in 56.41s ===================================================
```