### PR TITLE
Update case test_version due to RHEL-50649/RHEL-50650 won't fix

### DIFF
--- a/tests/package/test_info.py
+++ b/tests/package/test_info.py
@@ -60,7 +60,7 @@ class TestVirtwhoPackageInfo:
             1. the result format should be `virt-who 1.31.23-1`
         """
         version = re.split("virt-who-|.el", VIRTWHO_PKG)[1]
-        # RHEL-50649/RHEL-50650 not fix
+        # RHEL-50649/RHEL-50650 won't fix
         if VIRTWHO_VERSION >= "1.31.28":
             version = re.split("virt-who-|.noarch", VIRTWHO_PKG)[1]
         _, output = ssh_host.runcmd("virt-who --version")

--- a/tests/package/test_info.py
+++ b/tests/package/test_info.py
@@ -60,6 +60,9 @@ class TestVirtwhoPackageInfo:
             1. the result format should be `virt-who 1.31.23-1`
         """
         version = re.split("virt-who-|.el", VIRTWHO_PKG)[1]
+        # RHEL-50649/RHEL-50650 not fix
+        if VIRTWHO_VERSION >= "1.31.28":
+            version = re.split("virt-who-|.noarch", VIRTWHO_PKG)[1]
         _, output = ssh_host.runcmd("virt-who --version")
         output = output.split(" ")
         assert output[0].strip() == "virt-who" and output[1].strip() == version


### PR DESCRIPTION
The output of `#virt-who --verison` changes from 1.31.28
<1.31.28: virt-who 1.31.26-1.el9
>=1.31.28: virt-who 1.32.1-1.el10

**Test Result**
```
% pytest -v --disable-warnings tests/package/test_info.py -k 'test_version'
========================================================= test session starts =========================================================
platform darwin -- Python 3.11.9, pytest-7.2.2, pluggy-1.0.0 -- /opt/homebrew/opt/python@3.11/bin/python3.11
cachedir: .pytest_cache
rootdir: /Users/yuefliu/workspace/virtwho-test, configfile: pytest.ini
collected 6 items / 5 deselected / 1 selected                                                                                         

tests/package/test_info.py::TestVirtwhoPackageInfo::test_version PASSED                                                         [100%]

=================================================== 1 passed, 5 deselected in 5.87s ===================================================
[2024-08-09 09:10:00] - [conftest.py] - INFO: Finished Test: tests/package/test_info.py::TestVirtwhoPackageInfo::test_version
```