### PR TITLE
Fix VIRTWHO_VERSION issue for hypervisor-monitor

### DIFF
--- a/virtwho/__init__.py
+++ b/virtwho/__init__.py
@@ -27,7 +27,7 @@ REGISTER = config.job.register
 
 VIRTWHO_PKG = config.virtwho.package
 
-VIRTWHO_VERSION = ''
+VIRTWHO_VERSION = ""
 if VIRTWHO_PKG:
     VIRTWHO_VERSION = VIRTWHO_PKG.split("-")[2]
 

--- a/virtwho/__init__.py
+++ b/virtwho/__init__.py
@@ -27,7 +27,9 @@ REGISTER = config.job.register
 
 VIRTWHO_PKG = config.virtwho.package
 
-VIRTWHO_VERSION = VIRTWHO_PKG.split("-")[2]
+VIRTWHO_VERSION = ''
+if VIRTWHO_PKG:
+    VIRTWHO_VERSION = VIRTWHO_PKG.split("-")[2]
 
 # Backup file for /etc/virt-who.conf
 VIRTWHO_CONF_BACKUP = "virt-who.conf.save"


### PR DESCRIPTION
The `hypervisor-monitor` jobs were blocked due to a previous pr that added a new `VIRTWHO_VERSION` in __ini__, but in hypervisor-monitor job config.virtwho.package is null, which caused failure.

**Test Result**
```
% pytest -v --disable-warnings tests/others/test_hypervisors_state.py -k 'test_state_esx'
========================================================= test session starts =========================================================
platform darwin -- Python 3.11.9, pytest-7.2.2, pluggy-1.0.0 -- /opt/homebrew/opt/python@3.11/bin/python3.11
cachedir: .pytest_cache
rootdir: /Users/yuefliu/workspace/virtwho-test, configfile: pytest.ini
collected 7 items / 6 deselected / 1 selected                                                                                         

tests/others/test_hypervisors_state.py::TestHypervisorsState::test_state_esx PASSED                                             [100%]

======================================== 1 passed, 6 deselected, 1 warning in 77.63s (0:01:17) ========================================
```