### PR TITLE
Fix case issue test_owner_in_virtwho_conf after rhel9.6 ctc1

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -354,6 +354,7 @@ def owner_data():
         f"Organization with id {bad_owner} could not be found",
         f"Couldn't find Organization '{bad_owner}'",
         f"[Owner] with ID(s) {bad_owner} could not be found",
+        f"Owner with ID(s) {bad_owner} could not be found",
     ]
     # the errors for null are different when virt-who host registered and unreigstered.
     owner["null_error"] = [


### PR DESCRIPTION
The error message changes when configure bad owner, but it doesn't affect the virt-who function, so just add the new error message.

**Test Result**
```
% pytest -v --disable-warnings tests/function/test_config.py -k 'test_owner_in_virtwho_conf' -m 'tier1'
========================================================= test session starts =========================================================
platform darwin -- Python 3.11.10, pytest-7.2.2, pluggy-1.0.0 -- /opt/homebrew/opt/python@3.11/bin/python3.11
cachedir: .pytest_cache
rootdir: /Users/yuefliu/workspace/virtwho-test, configfile: pytest.ini
collected 21 items / 20 deselected / 1 selected                                                                                       

tests/function/test_config.py::TestConfigurationPositive::test_owner_in_virtwho_conf PASSED                                     [100%]

======================================= 1 passed, 20 deselected, 2 warnings in 91.85s (0:01:31) =======================================
```