### PR TITLE
Small fixes

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -12,8 +12,7 @@ markers =
     notSatellite: cases not for satellite
     notRHSM: cases not for candlepin
 
-    notRHEL8: cases not for rhel8
-    notRHEL9: cases not for rhel9
+    release: configure which rhel release this test is for
 
     notLocal: cases not for local libvirt mode
     notRemote: cases not for remote mode

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,6 +26,30 @@ def pytest_runtest_logfinish(nodeid):
     logger.info(f"Finished Test: {nodeid}")
 
 
+def pytest_addoption(parser):
+    parser.addoption(
+        "--rhelver",
+        action="store",
+        metavar="NAME",
+        help="Only run tests for this RHEL version: rhel8, rhel9, rhel10",
+    )
+
+
+def pytest_collection_modifyitems(config, items):
+    rhelver = config.getoption("--rhelver")
+    if not rhelver:
+        return
+    for item in items:
+        release = item.get_closest_marker("release")
+        if not release:
+            return
+        release_conf = release.kwargs
+        if rhelver not in release_conf:
+            return
+        if not release_conf[rhelver]:
+            item.add_marker("skip")
+
+
 @pytest.fixture(scope="class")
 def class_hypervisor():
     """Instantication of class VirtwhoHypervisorConfig()"""

--- a/tests/function/test_cli.py
+++ b/tests/function/test_cli.py
@@ -6,6 +6,7 @@
 :subsystemteam: sst_subscription_virtwho
 :caselevel: Component
 """
+
 import threading
 import time
 import pytest

--- a/tests/function/test_config.py
+++ b/tests/function/test_config.py
@@ -568,7 +568,7 @@ class TestConfigurationPositive:
 @pytest.mark.usefixtures("function_globalconf_clean")
 @pytest.mark.usefixtures("class_hypervisor")
 @pytest.mark.usefixtures("class_virtwho_d_conf_clean")
-@pytest.mark.notRHEL9
+@pytest.mark.release(rhel8=True, rhel9=False, rhel10=False)
 class TestSysConfiguration:
     @pytest.mark.tier1
     def test_debug_in_virtwho_sysconfig(self, virtwho, function_sysconfig):

--- a/tests/function/test_config.py
+++ b/tests/function/test_config.py
@@ -6,6 +6,7 @@
 :subsystemteam: sst_subscription_virtwho
 :caselevel: Component
 """
+
 import pytest
 
 from virtwho import HYPERVISOR, RHEL_COMPOSE

--- a/tests/hypervisor/test_ahv.py
+++ b/tests/hypervisor/test_ahv.py
@@ -6,6 +6,7 @@
 :subsystemteam: sst_subscription_virtwho
 :caselevel: Component
 """
+
 import pytest
 
 from virtwho import REGISTER

--- a/tests/hypervisor/test_default.py
+++ b/tests/hypervisor/test_default.py
@@ -259,7 +259,7 @@ class TestHypervisorPositive:
         assert virt_is_guest == "True"
 
     @pytest.mark.tier1
-    @pytest.mark.notRHEL8
+    @pytest.mark.release(rhel8=False, rhel9=True, rhel10=True)
     @pytest.mark.notLocal
     def test_virtwho_status(
         self,

--- a/tests/hypervisor/test_default.py
+++ b/tests/hypervisor/test_default.py
@@ -6,6 +6,7 @@
 :subsystemteam: sst_subscription_virtwho
 :caselevel: Component
 """
+
 import pytest
 
 from virtwho import REGISTER

--- a/tests/hypervisor/test_esx.py
+++ b/tests/hypervisor/test_esx.py
@@ -6,6 +6,7 @@
 :subsystemteam: sst_subscription_virtwho
 :caselevel: Component
 """
+
 import os
 import random
 import string

--- a/tests/hypervisor/test_hyperv.py
+++ b/tests/hypervisor/test_hyperv.py
@@ -6,6 +6,7 @@
 :subsystemteam: sst_subscription_virtwho
 :caselevel: Component
 """
+
 import time
 import pytest
 

--- a/tests/hypervisor/test_kubevirt.py
+++ b/tests/hypervisor/test_kubevirt.py
@@ -376,7 +376,7 @@ class TestKubevirtNegative:
             )
 
     @pytest.mark.tier2
-    @pytest.mark.notRHEL8
+    @pytest.mark.release(rhel8=False, rhel9=True, rhel10=True)
     def test_insecure(self, virtwho, function_hypervisor, hypervisor_data, ssh_host):
         """Test the insecure option in /etc/virt-who.d/hypervisor.conf
 

--- a/tests/hypervisor/test_kubevirt.py
+++ b/tests/hypervisor/test_kubevirt.py
@@ -6,6 +6,7 @@
 :subsystemteam: sst_subscription_virtwho
 :caselevel: Component
 """
+
 import pytest
 
 from virtwho import REGISTER

--- a/tests/hypervisor/test_libvirt.py
+++ b/tests/hypervisor/test_libvirt.py
@@ -6,6 +6,7 @@
 :subsystemteam: sst_subscription_virtwho
 :caselevel: Component
 """
+
 import pytest
 
 from virtwho import REGISTER

--- a/tests/hypervisor/test_local.py
+++ b/tests/hypervisor/test_local.py
@@ -6,6 +6,7 @@
 :subsystemteam: sst_subscription_virtwho
 :caselevel: Component
 """
+
 import pytest
 import time
 

--- a/tests/hypervisor/test_multi_hypervisors.py
+++ b/tests/hypervisor/test_multi_hypervisors.py
@@ -6,6 +6,7 @@
 :subsystemteam: sst_subscription_virtwho
 :caselevel: Component
 """
+
 import pytest
 
 from virtwho import REGISTER, logger

--- a/tests/hypervisor/test_rhevm.py
+++ b/tests/hypervisor/test_rhevm.py
@@ -6,6 +6,7 @@
 :subsystemteam: sst_subscription_virtwho
 :caselevel: Component
 """
+
 import pytest
 
 from virtwho import REGISTER

--- a/tests/hypervisor/test_xen.py
+++ b/tests/hypervisor/test_xen.py
@@ -6,6 +6,7 @@
 :subsystemteam: sst_subscription_virtwho
 :caselevel: Component
 """
+
 import pytest
 
 from virtwho import REGISTER

--- a/tests/others/test_hypervisors_state.py
+++ b/tests/others/test_hypervisors_state.py
@@ -6,6 +6,7 @@
 :subsystemteam: sst_subscription_virtwho
 :caselevel: Component
 """
+
 # All the test cases have been uploaded to Polarion with Inactive status
 # because the cases are just used to test the test environments.
 

--- a/tests/others/test_hypervisors_sw.py
+++ b/tests/others/test_hypervisors_sw.py
@@ -6,6 +6,7 @@
 :subsystemteam: sst_subscription_virtwho
 :caselevel: Component
 """
+
 # The test case has been uploaded to Polarion with Inactive status because
 # the case is just used to test the environments to support Subscription Watch team.
 

--- a/tests/package/test_info.py
+++ b/tests/package/test_info.py
@@ -7,6 +7,7 @@
 :subsystemteam: sst_subscription_virtwho
 :caselevel: Component
 """
+
 import os
 import re
 import pytest

--- a/tests/package/test_install_uninstall.py
+++ b/tests/package/test_install_uninstall.py
@@ -7,6 +7,7 @@
 :subsystemteam: sst_subscription_virtwho
 :caselevel: Component
 """
+
 import re
 
 import pytest

--- a/tests/package/test_upgrade_downgrade.py
+++ b/tests/package/test_upgrade_downgrade.py
@@ -153,7 +153,7 @@ class TestUpgradeDowngrade:
                 package_upgrade(ssh_host, "virt-who")
 
     @pytest.mark.tier1
-    @pytest.mark.notRHEL8
+    @pytest.mark.release(rhel8=False, rhel9=True, rhel10=True)
     def test_global_options_migration_after_upgrade(self, ssh_host, virtwho):
         """Test the global configurations in /etc/sysconfig/virt-who can be
             migrated to /etc/virt-who.conf after upgrade

--- a/tests/package/test_upgrade_downgrade.py
+++ b/tests/package/test_upgrade_downgrade.py
@@ -8,6 +8,7 @@
 :caselevel: Component
 
 """
+
 import pytest
 from virtwho import VIRTWHO_PKG, RHEL_COMPOSE, RHEL_COMPOSE_PATH
 from virtwho.base import virtwho_package_url

--- a/tests/subscription/test_rhsm.py
+++ b/tests/subscription/test_rhsm.py
@@ -7,6 +7,7 @@
 :subsystemteam: sst_subscription_virtwho
 :caselevel: Component
 """
+
 import pytest
 from virtwho.base import msg_search
 

--- a/tests/subscription/test_rhsm_option.py
+++ b/tests/subscription/test_rhsm_option.py
@@ -6,6 +6,7 @@
 :subsystemteam: sst_subscription_virtwho
 :caselevel: Component
 """
+
 import pytest
 from virtwho.base import msg_search
 from virtwho import REGISTER, HYPERVISOR

--- a/tests/subscription/test_satellite.py
+++ b/tests/subscription/test_satellite.py
@@ -7,6 +7,7 @@
 :subsystemteam: sst_subscription_virtwho
 :caselevel: Component
 """
+
 import pytest
 from virtwho.base import msg_search
 from virtwho import HYPERVISOR

--- a/virtwho/runner.py
+++ b/virtwho/runner.py
@@ -290,7 +290,8 @@ class VirtwhoRunner:
         Clean all log files under /var/log/rhsm/
         Clean the json file created by print function of virt-who
         """
-        self.ssh.runcmd("rm -rf /var/log/rhsm/*")
+        self.ssh.runcmd("truncate -s 0 /var/log/rhsm/*.log")
+        self.ssh.runcmd("rm -f /var/log/rhsm/*.gz")
 
         # comment this line as we need the print json file for fake mode testing
         # self.ssh.runcmd(f"rm -rf {PRINT_JSON_FILE}")

--- a/virtwho/settings.py
+++ b/virtwho/settings.py
@@ -1,4 +1,5 @@
 """Define and instantiate the configuration class for virtwho-test."""
+
 import os
 from configparser import ConfigParser
 


### PR DESCRIPTION
Collecting small fixes here (work in progress):

- pep8
- truncate is safer than rm -rf
- explicit RHEL release skipping, no more not notRHEL9
