### PR TITLE
a code to skip dowgrade/upgrade tests for the first release of rhel version

### DIFF
--- a/tests/package/test_upgrade_downgrade.py
+++ b/tests/package/test_upgrade_downgrade.py
@@ -10,19 +10,28 @@
 """
 
 import pytest
-from virtwho import VIRTWHO_PKG, RHEL_COMPOSE, RHEL_COMPOSE_PATH
+from virtwho import VIRTWHO_PKG, RHEL_COMPOSE, RHEL_COMPOSE_PATH, RHEL_VERSION, RHEL_SUBVERSION
 from virtwho.base import virtwho_package_url
 from virtwho.base import package_check, package_upgrade, package_downgrade
 from virtwho.base import wget_download, rhel_compose_repo, random_string
 from virtwho.base import system_reboot
 
-old_pkg = "virt-who-1.31.22-1.el9_0.noarch"
-old_compose = "latest-RHEL-9.0"
-old_compose_path = "http://download.eng.pek2.redhat.com/rhel-9/rel-eng/RHEL-9"
+old_pkg = "virt-who-unspecified.noarch"
+old_compose = "latest-RHEL-unspecified"
+old_compose_path = "http://download.devel.redhat.com/rhel-unspecified/rel-eng/RHEL-unspecified"
+
+if "RHEL-10" in RHEL_COMPOSE:
+    old_pkg = "virt-who-1.32.1-2.el10.noarch"
+    old_compose = "latest-RHEL-10.0"
+    old_compose_path = "http://download.devel.redhat.com/rhel-10/rel-eng/RHEL-10"
+if "RHEL-9" in RHEL_COMPOSE:
+    old_pkg = "virt-who-1.31.22-1.el9_0.noarch"
+    old_compose = "latest-RHEL-9.0"
+    old_compose_path = "http://download.devel.redhat.com/rhel-9/rel-eng/RHEL-9"
 if "RHEL-8" in RHEL_COMPOSE:
     old_pkg = "virt-who-1.30.8-1.el8.noarch"
     old_compose = "latest-RHEL-8.5"
-    old_compose_path = "http://download.eng.pek2.redhat.com/rhel-8/rel-eng/RHEL-8"
+    old_compose_path = "http://download.devel.redhat.com/rhel-8/rel-eng/RHEL-8"
 
 
 @pytest.mark.usefixtures("function_globalconf_clean")
@@ -53,6 +62,13 @@ class TestUpgradeDowngrade:
             2. all configurations will not be changed after virt-who downgrade,
                 upgrade and host reboot.
         """
+
+        """ If it is the first release of RHEL (aka 9.0, 10.0, ...) there is no reason to try downgrade/upgdare
+            Since no old package is available for downgrading.
+        """
+        if RHEL_SUBVERSION == 0:
+            pytest.skip(f"The first release of a distribution ({RHEL_COMPOSE}) - no downgrade posible ")
+
         old_repo_file = "/etc/yum.repos.d/oldCompose.repo"
         try:
             globalconf.update("global", "debug", "True")

--- a/tests/package/test_upgrade_downgrade.py
+++ b/tests/package/test_upgrade_downgrade.py
@@ -10,7 +10,7 @@
 """
 
 import pytest
-from virtwho import VIRTWHO_PKG, RHEL_COMPOSE, RHEL_COMPOSE_PATH, RHEL_VERSION, RHEL_SUBVERSION
+from virtwho import VIRTWHO_PKG, RHEL_COMPOSE, RHEL_COMPOSE_PATH, RHEL_SUBVERSION
 from virtwho.base import virtwho_package_url
 from virtwho.base import package_check, package_upgrade, package_downgrade
 from virtwho.base import wget_download, rhel_compose_repo, random_string

--- a/tests/package/test_upgrade_downgrade.py
+++ b/tests/package/test_upgrade_downgrade.py
@@ -18,7 +18,9 @@ from virtwho.base import system_reboot
 
 old_pkg = "virt-who-unspecified.noarch"
 old_compose = "latest-RHEL-unspecified"
-old_compose_path = "http://download.devel.redhat.com/rhel-unspecified/rel-eng/RHEL-unspecified"
+old_compose_path = (
+    "http://download.devel.redhat.com/rhel-unspecified/rel-eng/RHEL-unspecified"
+)
 
 if "RHEL-10" in RHEL_COMPOSE:
     old_pkg = "virt-who-1.32.1-2.el10.noarch"
@@ -67,7 +69,9 @@ class TestUpgradeDowngrade:
             Since no old package is available for downgrading.
         """
         if RHEL_SUBVERSION == 0:
-            pytest.skip(f"The first release of a distribution ({RHEL_COMPOSE}) - no downgrade posible ")
+            pytest.skip(
+                f"The first release of a distribution ({RHEL_COMPOSE}) - no downgrade posible "
+            )
 
         old_repo_file = "/etc/yum.repos.d/oldCompose.repo"
         try:

--- a/utils/beaker.py
+++ b/utils/beaker.py
@@ -93,9 +93,14 @@ def beaker_job_submit(
         "--task /distribution/reservesys"
     )
     whiteboard = f'--whiteboard="reserve host for {job_name}"'
-    reserve = "--reserve  --priority Urgent" + \
-        ((reserve_duration and f" --reserve-duration {reserve_duration}") or \
-        (config.beaker.get("reserve_duration") and f" --reserve-duration {config.beaker.get('reserve_duration')}") or "")
+    reserve = "--reserve  --priority Urgent" + (
+        (reserve_duration and f" --reserve-duration {reserve_duration}")
+        or (
+            config.beaker.get("reserve_duration")
+            and f" --reserve-duration {config.beaker.get('reserve_duration')}"
+        )
+        or ""
+    )
     cmd = (
         f"bkr workflow-simple --prettyxml "
         f"{task} {whiteboard} {reserve} "

--- a/virtwho/__init__.py
+++ b/virtwho/__init__.py
@@ -12,7 +12,9 @@ RHEL_COMPOSE_PATH = config.job.rhel_compose_path
 
 def version_subversion(compose):
     rhel_regexp = re.compile(r"^RHEL-([\d]+)\.([\d]+)", re.IGNORECASE)
-    (rhel_version, rhel_subversion) = map(int, rhel_regexp.search(RHEL_COMPOSE).groups())
+    (rhel_version, rhel_subversion) = map(
+        int, rhel_regexp.search(RHEL_COMPOSE).groups()
+    )
     return (rhel_version, rhel_subversion)
 
 

--- a/virtwho/__init__.py
+++ b/virtwho/__init__.py
@@ -9,12 +9,14 @@ RHEL_COMPOSE = config.job.rhel_compose
 
 RHEL_COMPOSE_PATH = config.job.rhel_compose_path
 
-def version_subversion(compose):
-    rhel_regexp = re.compile(r"^RHEL-([\d]+)\.([\d]+)",re.IGNORECASE)
-    (rhel_version,rhel_subversion) = map(int,rhel_regexp.search(RHEL_COMPOSE).groups())
-    return (rhel_version,rhel_subversion)
 
-(RHEL_VERSION,RHEL_SUBVERSION) = version_subversion(RHEL_COMPOSE)
+def version_subversion(compose):
+    rhel_regexp = re.compile(r"^RHEL-([\d]+)\.([\d]+)", re.IGNORECASE)
+    (rhel_version, rhel_subversion) = map(int, rhel_regexp.search(RHEL_COMPOSE).groups())
+    return (rhel_version, rhel_subversion)
+
+
+(RHEL_VERSION, RHEL_SUBVERSION) = version_subversion(RHEL_COMPOSE)
 
 HYPERVISOR = config.job.hypervisor
 

--- a/virtwho/__init__.py
+++ b/virtwho/__init__.py
@@ -1,11 +1,20 @@
 from virtwho.logger import getLogger
 from virtwho.settings import config
+import re
+
 
 logger = getLogger(__name__)
 
 RHEL_COMPOSE = config.job.rhel_compose
 
 RHEL_COMPOSE_PATH = config.job.rhel_compose_path
+
+def version_subversion(compose):
+    rhel_regexp = re.compile(r"^RHEL-([\d]+)\.([\d]+)",re.IGNORECASE)
+    (rhel_version,rhel_subversion) = map(int,rhel_regexp.search(RHEL_COMPOSE).groups())
+    return (rhel_version,rhel_subversion)
+
+(RHEL_VERSION,RHEL_SUBVERSION) = version_subversion(RHEL_COMPOSE)
 
 HYPERVISOR = config.job.hypervisor
 

--- a/virtwho/base.py
+++ b/virtwho/base.py
@@ -642,7 +642,7 @@ def system_reboot(ssh):
 
 def virtwho_package_url(pkg, rhel_compose_id, rhel_compose_path=""):
     """
-    Get the virt-who package url from http://download.eng.pek2.redhat.com/
+    Get the virt-who package url from http://download.devel.redhat.com/
     for downloading.
     :param pkg: virt-who package, such as virt-who-1.31.26-1.el9.noarch
     :param rhel_compose_id: rhel compose id

--- a/virtwho/provision/virtwho_host.py
+++ b/virtwho/provision/virtwho_host.py
@@ -161,6 +161,7 @@ def beaker_args_define(args):
     args.host_require = None
     args.reserve_duration = None
 
+
 def virtwho_install(ssh, url=None):
     """
     Install virt-who package, default is from repository,

--- a/virtwho/provision/virtwho_host.py
+++ b/virtwho/provision/virtwho_host.py
@@ -342,7 +342,7 @@ def virtwho_arguments_parser():
         "--rhel-compose-path",
         required=False,
         default=config.job.rhel_compose_path,
-        help="Such as http://download.eng.pek2.redhat.com/rhel-9/nightly/RHEL-9. "
+        help="Such as http://download.devel.redhat.com/rhel-9/nightly/RHEL-9. "
         "If leave it None, will use the specified path in code.",
     )
     parser.add_argument(


### PR DESCRIPTION
card-id: CCT-1033

There are no packages to downgrade if it is the first release of the rhel distro - aka RHEL10.0, RHEL9.0, ....
