### PR TITLE
fips compliant beaker reservation

### DIFF
--- a/utils/beaker.py
+++ b/utils/beaker.py
@@ -88,12 +88,14 @@ def beaker_job_submit(
     :param host_require: optional, additional <hostRequires/> for job
     :return: beaker job id
     """
-    task = "--task /distribution/check-install " + \
-        "--task /tools/beaker-rhsm/Install/rhsm-qe-keys " + \
-        ("--task /distribution/fips/setup-fips-enabled " if fips else "") + \
-        "--task /distribution/reservesys "
+    task = (
+        "--task /distribution/check-install "
+        + "--task /tools/beaker-rhsm/Install/rhsm-qe-keys "
+        + ("--task /distribution/fips/setup-fips-enabled " if fips else "")
+        + "--task /distribution/reservesys "
+    )
     install_pkg = "beakerlib"
-    ks_meta="method=nfs harness='restraint-rhts beakerlib beakerlib-redhat'"
+    ks_meta = "method=nfs harness='restraint-rhts beakerlib beakerlib-redhat'"
     whiteboard = f'--whiteboard="reserve host for {job_name}"'
     reserve = "--reserve  --priority Urgent" + (
         (reserve_duration and f" --reserve-duration {reserve_duration}")
@@ -109,7 +111,7 @@ def beaker_job_submit(
         f"--distro={distro} "
         f"--arch={arch} "
         f"--install={install_pkg} "
-        f"--ks-meta=\"{ks_meta}\" "
+        f'--ks-meta="{ks_meta}" '
     )
     if variant:
         cmd += f"--variant={variant} "

--- a/virtwho/provision/virtwho_host.py
+++ b/virtwho/provision/virtwho_host.py
@@ -61,8 +61,8 @@ def provision_virtwho_host(args):
         args.server = install_host_by_beaker(args)
         args.username = config.beaker.default_username
         args.password = config.beaker.default_password
-    ssh_host = SSHConnect(host=args.server, user=args.username, pwd=args.password)
 
+    ssh_host = SSHConnect(host=args.server, user=args.username, pwd=args.password)
     # Initially setup the rhel virt-who host
     if "RHEL" in args.distro:
         ssh_host.runcmd(cmd="rm -f /etc/yum.repos.d/*.repo")
@@ -332,6 +332,12 @@ def virtwho_arguments_parser():
     for function using, and generate help and usage messages for
     each arguments.
     """
+    def value_to_boolean(value):
+        return (
+            (value is not None) and \
+            value.lower() in ['yes','y','1','true','t','ok','enabled','enable']
+        ) or False
+
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "--distro",
@@ -346,6 +352,14 @@ def virtwho_arguments_parser():
         help="Such as http://download.devel.redhat.com/rhel-9/nightly/RHEL-9. "
         "If leave it None, will use the specified path in code.",
     )
+    parser.add_argument(
+        "--fips",
+        required=False,
+        action=argparse.BooleanOptionalAction,
+        default=value_to_boolean(config.job.fips),
+        help="--fips/--no-fips: a machine about to create should complain FIPS standard.",
+    )
+
     parser.add_argument(
         "--server",
         required=False,

--- a/virtwho/provision/virtwho_host.py
+++ b/virtwho/provision/virtwho_host.py
@@ -332,10 +332,12 @@ def virtwho_arguments_parser():
     for function using, and generate help and usage messages for
     each arguments.
     """
+
     def value_to_boolean(value):
         return (
-            (value is not None) and \
-            value.lower() in ['yes','y','1','true','t','ok','enabled','enable']
+            (value is not None)
+            and value.lower()
+            in ["yes", "y", "1", "true", "t", "ok", "enabled", "enable"]
         ) or False
 
     parser = argparse.ArgumentParser()

--- a/virtwho/ssh.py
+++ b/virtwho/ssh.py
@@ -6,14 +6,14 @@ from virtwho import logger
 class SSHConnect:
     """Extended SSHClient allowing custom methods"""
 
-    def __init__(self, host, user, pwd=None, rsafile=None, port=22, timeout=1800):
+    def __init__(self, host, user, pwd=None, rsafile=None, port=22, timeout=3000):
         """
         :param str host: The hostname or ip of the server to establish connection.
         :param str user: The username to use when connecting.
         :param str pwd: The password to use when connecting.
         :param str rsafile: The path of the ssh private key to use when connecting to the server
         :param int port: The server port to connect to, the default port is 22.
-        :param int timeout: Time to wait for the ssh command to finish.
+        :param int timeout: Time (seconds) to wait for the ssh command to finish.
         """
         self.host = host
         self.user = user
@@ -44,17 +44,13 @@ class SSHConnect:
     def pwd_connect(self):
         """SSH command execution connection by password"""
         ssh = ""
-        connect = False
         try:
             ssh = paramiko.SSHClient()
             ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
             ssh.connect(self.host, self.port, self.user, self.pwd, timeout=self.timeout)
-            connect = True
-        finally:
-            if connect:
-                return ssh
-            logger.error(f"Failed to ssh connect the {self.host}.")
-            return False
+            return ssh
+        except Exception:
+            raise ConnectionError(f"Failed to ssh connect the {self.host}.")
 
     def rsa_connect(self):
         """SSH command execution connection by key file"""


### PR DESCRIPTION
an utility beaker.py reserves machine fips compliant when new argument '--fips' is used.

ie. there will not be any pipeline task to set machine to be fips compliant - ie. the reservered machine will be already fips compliant.

I have fixed an issue with timeout in ssh.py - a method self._connect returned bool in some cases instead of sshConnection.

I have added '--fips' argument for virtwho_host.py to prepare fips compliant machine.