### PR TITLE
beaker util uses ssh-agent now and localhost

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,4 +14,6 @@ unittest2
 urllib3
 PyYAML
 pexpect
+lxml
+funcy
 git+https://github.com/VirtwhoQE/hypervisor-builder.git

--- a/tests/package/test_info.py
+++ b/tests/package/test_info.py
@@ -12,7 +12,7 @@ import os
 import re
 import pytest
 
-from virtwho import base, RHEL_COMPOSE, VIRTWHO_PKG, VIRTWHO_VERSION
+from virtwho import base, RHEL_COMPOSE, RHEL_COMPOSE_PATH, VIRTWHO_PKG, VIRTWHO_VERSION
 from virtwho.settings import DOCS_DIR, TEMP_DIR
 
 
@@ -38,7 +38,7 @@ class TestVirtwhoPackageInfo:
         :expectedresults:
             1. virt-who package are shipped in each supported arch
         """
-        _, repo_extra = base.rhel_compose_url(RHEL_COMPOSE)
+        _, repo_extra = base.rhel_compose_url(RHEL_COMPOSE, RHEL_COMPOSE_PATH)
         base_url = repo_extra.split("/x86_64/")[0]
         archs = ["x86_64", "ppc64le", "aarch64", "s390x"]
         for arch in archs:

--- a/tests/package/test_upgrade_downgrade.py
+++ b/tests/package/test_upgrade_downgrade.py
@@ -139,6 +139,10 @@ class TestUpgradeDowngrade:
             2. all configurations will not be changed after downgrade and
                 upgrade.
         """
+        if RHEL_SUBVERSION == 0:
+            pytest.skip(
+                f"The first release of a distribution ({RHEL_COMPOSE}) - no downgrade posible "
+            )
         try:
             globalconf.update("global", "debug", "True")
             globalconf.update("system_environment", "http_proxy", "xxx")
@@ -194,6 +198,11 @@ class TestUpgradeDowngrade:
             2. all configurations will not be changed after downgrade and
                 upgrade.
         """
+        if RHEL_SUBVERSION == 0:
+            pytest.skip(
+                f"The first release of a distribution ({RHEL_COMPOSE}) - no downgrade posible "
+            )
+
         sysconfig_file = "/etc/sysconfig/virt-who"
         virtwho_conf_file = "/etc/virt-who.conf"
 

--- a/utils/beaker_types.py
+++ b/utils/beaker_types.py
@@ -1,0 +1,72 @@
+from lxml import etree
+from dataclasses import dataclass
+from funcy import first, all
+
+
+@dataclass
+class Job:
+    job_id: str
+    status: str
+    result: str
+    whiteboard: str
+    hostname: str
+
+    @property
+    def is_reserved(self):
+        return self.status == "Reserved" and self.result == "Pass"
+
+    @property
+    def is_running(self):
+        return self.status == "Running" and self.result == "Pass"
+
+
+@dataclass(frozen=True)
+class Task:
+    name: str
+    status: str
+    result: str
+
+    @property
+    def is_completed(self):
+        return self.status == "Completed" and self.result in ("Pass", "New")
+
+
+@dataclass(frozen=True)
+class Report:
+    job: Job
+    tasks: list[Task]
+
+    @classmethod
+    def from_beaker_results(cls, xml: str):
+        root = etree.XML(xml)
+        element = first(root.xpath("/job"))
+        whiteboard = first(root.xpath("/job/whiteboard")).text
+        hostname = first(root.xpath("/job/recipeSet/recipe/@system"))
+        report = cls(
+            Job(
+                element.attrib["id"],
+                element.attrib["status"],
+                element.attrib["result"],
+                whiteboard,
+                hostname,
+            ),
+            list(
+                Task(el.attrib["name"], el.attrib["status"], el.attrib["result"])
+                for el in root.xpath("/job/recipeSet/recipe/task")
+            ),
+        )
+        return report
+
+    @property
+    def is_reserved(self):
+        return self.job.is_reserved and all(task.is_completed for task in self.tasks)
+
+    @property
+    def is_completed_except_reservesysTask(self):
+        runningReservesysTask = Task(
+            name="/distribution/reservesys", status="Running", result="New"
+        )
+        return self.job.is_running and all(
+            task.is_completed
+            for task in (set(self.tasks) - set((runningReservesysTask,)))
+        )

--- a/virtwho/provision/virtwho_host.py
+++ b/virtwho/provision/virtwho_host.py
@@ -72,6 +72,10 @@ def provision_virtwho_host(args):
             compose_id=args.distro,
             compose_path=args.rhel_compose_path,
         )
+    # temporary hack
+    ssh_host.runcmd(
+        "rm -rf /var/lib/rpm/.rpm.lock; rm -rf /usr/lib/sysimage/rpm/.rpm.lock; pkill yum"
+    )
     ssh_host.runcmd("yum install -y subscription-manager expect net-tools wget")
     ssh_host.runcmd(cmd="subscription-manager unregister; subscription-manager clean")
     rhsm_conf_backup(ssh_host)
@@ -155,7 +159,7 @@ def beaker_args_define(args):
     if "RHEL-7" in args.distro or "Fedora" in args.distro:
         args.variant = "Server"
     args.arch = "x86_64"
-    args.job_group = "virt-who-ci-server-group"
+    args.job_group = None  # "virt-who-ci-server-group"
     args.host = args.beaker_host
     args.host_type = "physical"
     args.host_require = None
@@ -175,6 +179,7 @@ def virtwho_install(ssh, url=None):
         "mv /var/lib/rpm /var/lib/rpm.old;"
         "rpm --initdb;"
         "rm -rf /var/lib/rpm;"
+        "rm -rf /usr/lib/sysimage/rpm/.rpm.lock;"
         "mv /var/lib/rpm.old /var/lib/rpm;"
         "rm -rf /var/lib/yum/history/*.sqlite;"
         "rpm -v --rebuilddb"
@@ -378,7 +383,7 @@ def virtwho_arguments_parser():
     parser.add_argument(
         "--password",
         required=False,
-        default=config.virtwho.password,
+        default=None,  # config.virtwho.password,
         help="Password to access the server, "
         "default to the [virtwho]:password in virtwho.ini",
     )

--- a/virtwho/provision/virtwho_satellite.py
+++ b/virtwho/provision/virtwho_satellite.py
@@ -120,10 +120,11 @@ def beaker_args_define(args):
     args.variant = "BaseOS"
     if "RHEL-7" in args.distro:
         args.variant = "Server"
-    args.job_group = "virt-who-ci-server-group"
+    args.job_group = None  # "virt-who-ci-server-group"
     args.host = args.beaker_host
     args.host_type = None
     args.host_require = "cpu>=1,memory>6000"
+    args.reserve_duration = None
 
 
 def satellite_settings(ssh, name, value):
@@ -220,6 +221,13 @@ def virtwho_satellite_arguments_parser():
     )
     parser.add_argument(
         "--snap", required=False, help="Satellite snap version, such as '5.0', '6.0'"
+    )
+    parser.add_argument(
+        "--fips",
+        required=False,
+        action=argparse.BooleanOptionalAction,
+        default=False,
+        help="--fips/--no-fips: a machine about to create should complain FIPS standard.",
     )
     return parser.parse_args()
 

--- a/virtwho/settings.py
+++ b/virtwho/settings.py
@@ -1,5 +1,4 @@
 """Define and instantiate the configuration class for virtwho-test."""
-
 import os
 from configparser import ConfigParser
 
@@ -54,7 +53,7 @@ class Configure:
         """
         if not self.config.has_section(section):
             self.config.add_section(section)
-        self.config.set(section, option, value)
+        self.config.set(section, option, value if value is not None else "")
         self.save()
 
     def delete(self, section, option=None):


### PR DESCRIPTION
Card-ID: CCT-1269

a tool beaker.py now:
 - runs all commands using subprocess (no ssh and remote machine to run commands anymore)
 - can use keys provided by ssh-agent (in case no password is defined in virtwho.ini)
 - uses better way to decide that a machine being reserved by beaker is ready to use
 - use ssh-agent to authorize by a key the agent provides
 
A file  beaker_types.py added ... a few dataclasses to describe beaker report and to encapsulate a statements for beaker report
 