### PR TITLE
pytest.mark.skip to skip item when different version of rhel is specified

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -47,7 +47,8 @@ def pytest_collection_modifyitems(config, items):
         if rhelver not in release_conf:
             return
         if not release_conf[rhelver]:
-            item.add_marker("skip")
+            item.add_marker(pytest.mark.skip(reason=f"skipped due to required rhel (should be {rhelver})"))
+
 
 
 @pytest.fixture(scope="class")


### PR DESCRIPTION
Card ID: CCT-1310

small update - using pytest.mark.skip instead of "skip" in conftest.py

It should help to skip a test when different version of rhel is specified in a test (pytest.mark.release(rhel8, ...))
