### PR TITLE
new way to get consumer uuid

### DIFF
--- a/tests/hypervisor/test_default.py
+++ b/tests/hypervisor/test_default.py
@@ -50,20 +50,18 @@ class TestHypervisorPositive:
             1. Succeed to run the virt-who service, no error messages in the rhsm.log file
             2. Succeed to find the guest uuid in from the output of the curl command
         """
-        host_name = hypervisor_data["hypervisor_hostname"]
         guest_uuid = hypervisor_data["guest_uuid"]
         guest_hostname = hypervisor_data["guest_hostname"]
         result = virtwho.run_service()
         assert result["error"] == 0 and result["send"] == 1 and result["thread"] == 1
-        
+
         """
         a note about local libvirt guest being found
         2025-05-14 03:43:26,026 [virtwho.main DEBUG] MainProcess(599130):Thread-2 @libvirtd.py:_listDomains:400 - Libvirt domains found: 538fa355-a1ea-48dd-a1c4-76a0e2ca3698
         2025-05-14 03:43:26,027 [virtwho.main INFO] MainProcess(599130):Thread-2 @virt.py:_send_data:1191 - Report for config "virtwho-local" gathered, placing in datastore
         """
-        
+
         if REGISTER == "rhsm":
-            #registered_id = rhsm.uuid(host_name)
             consumer_info = sm_host.identity()
             registered_id = consumer_info.get('system identity')
             cmd = (

--- a/tests/hypervisor/test_default.py
+++ b/tests/hypervisor/test_default.py
@@ -32,6 +32,7 @@ class TestHypervisorPositive:
         rhsm,
         satellite,
         ssh_host,
+        sm_host,
         function_guest_register,
     ):
         """
@@ -54,9 +55,17 @@ class TestHypervisorPositive:
         guest_hostname = hypervisor_data["guest_hostname"]
         result = virtwho.run_service()
         assert result["error"] == 0 and result["send"] == 1 and result["thread"] == 1
-
+        
+        """
+        a note about local libvirt guest being found
+        2025-05-14 03:43:26,026 [virtwho.main DEBUG] MainProcess(599130):Thread-2 @libvirtd.py:_listDomains:400 - Libvirt domains found: 538fa355-a1ea-48dd-a1c4-76a0e2ca3698
+        2025-05-14 03:43:26,027 [virtwho.main INFO] MainProcess(599130):Thread-2 @virt.py:_send_data:1191 - Report for config "virtwho-local" gathered, placing in datastore
+        """
+        
         if REGISTER == "rhsm":
-            registered_id = rhsm.uuid(host_name)
+            #registered_id = rhsm.uuid(host_name)
+            consumer_info = sm_host.identity()
+            registered_id = consumer_info.get('system identity')
             cmd = (
                 f"curl -s -k -u "
                 f"{register_data['username']}:{register_data['password']} "

--- a/tests/hypervisor/test_default.py
+++ b/tests/hypervisor/test_default.py
@@ -63,7 +63,7 @@ class TestHypervisorPositive:
 
         if REGISTER == "rhsm":
             consumer_info = sm_host.identity()
-            registered_id = consumer_info.get('system identity')
+            registered_id = consumer_info.get("system identity")
             cmd = (
                 f"curl -s -k -u "
                 f"{register_data['username']}:{register_data['password']} "

--- a/virtwho/register.py
+++ b/virtwho/register.py
@@ -163,8 +163,8 @@ class SubscriptionManager:
         cmd = "subscription-manager identity"
         ret, output = self.ssh.runcmd(cmd)
         if ret == 0:
-            lines = [line.strip() for line in output.split('\n')]
-            pairs = [re.split(r'[\ \t]*:[\ \t]*', line) for line in lines if line]
+            lines = [line.strip() for line in output.split("\n")]
+            pairs = [re.split(r"[\ \t]*:[\ \t]*", line) for line in lines if line]
             return dict(pairs)
         return dict()
 

--- a/virtwho/register.py
+++ b/virtwho/register.py
@@ -7,6 +7,7 @@ from virtwho.configure import get_register_handler
 from virtwho.ssh import SSHConnect
 import re
 
+
 class SubscriptionManager:
     def __init__(
         self,
@@ -149,7 +150,6 @@ class SubscriptionManager:
         else:
             raise FailException(f"Failed to {action} repo: {repo}")
 
-
     def identity(self):
         """
         subscription-manager identity
@@ -164,10 +164,11 @@ class SubscriptionManager:
         ret, output = self.ssh.runcmd(cmd)
         if ret == 0:
             lines = [line.strip() for line in output.split('\n')]
-            pairs = [re.split(r'[\ \t]*:[\ \t]*',line) for line in lines if line]
+            pairs = [re.split(r'[\ \t]*:[\ \t]*', line) for line in lines if line]
             return dict(pairs)
         return dict()
-    
+
+
 class RHSM:
     def __init__(self, rhsm="rhsm"):
         """

--- a/virtwho/register.py
+++ b/virtwho/register.py
@@ -5,7 +5,7 @@ from json.decoder import JSONDecodeError
 from virtwho import logger, FailException
 from virtwho.configure import get_register_handler
 from virtwho.ssh import SSHConnect
-
+import re
 
 class SubscriptionManager:
     def __init__(
@@ -150,6 +150,24 @@ class SubscriptionManager:
             raise FailException(f"Failed to {action} repo: {repo}")
 
 
+    def identity(self):
+        """
+        subscription-manager identity
+        ... returns dict
+        aka
+        {'system identity': '29dadce5-0d6b-44ed-bf35-71e1943e4129',
+         'name': 'kvm-06.redhat.com',
+         'org name': '18939614',
+         'org ID': '18939614'}
+        """
+        cmd = "subscription-manager identity"
+        ret, output = self.ssh.runcmd(cmd)
+        if ret == 0:
+            lines = [line.strip() for line in output.split('\n')]
+            pairs = [re.split(r'[\ \t]*:[\ \t]*',line) for line in lines if line]
+            return dict(pairs)
+        return dict()
+    
 class RHSM:
     def __init__(self, rhsm="rhsm"):
         """


### PR DESCRIPTION
Card-ID: CCT-1227
there is a test 'test_guest_attr_by_curl' in hypervisor/test_default.py

It uses  consumer uuid to verify that virt-who service puts guestid into candlepin.

A way to get consumer id is wrong. It is reason of failure of the test.
This PR changes a way to get consumer id.
This PR fixes the test finally.
