### PR TITLE
fix(runner): handle multi-line pgrep output in thread_number()

### DIFF
--- a/virtwho/runner.py
+++ b/virtwho/runner.py
@@ -565,12 +565,12 @@ class VirtwhoRunner:
         Get the alive virt-who thread number.
         :return: virt-who thread number
         """
-        thread_num = 0
-        cmd = "pgrep -c -x virt-who || echo 0"
+        cmd = "pgrep -c -x virt-who"
         ret, output = self.ssh.runcmd(cmd)
-        if output is not None and output != "":
-            thread_num = int(output.strip())
-        return thread_num
+        if ret == 0 and output is not None:
+            first_line = output.strip().splitlines()[0]
+            return int(first_line)
+        return 0
 
     def operate_service(self, name="virt-who", action="restart", wait=10):
         """


### PR DESCRIPTION
## Summary

- `thread_number()` uses `pgrep -c -x virt-who || echo 0` to count virt-who processes, but when pgrep finds no matches it exits 1 **and** prints `0` to stdout — then the `|| echo 0` fallback also prints `0`, producing `"0\n0"`.
- `int(output.strip())` raises `ValueError: invalid literal for int() with base 10: '0\n0'` because `strip()` only removes leading/trailing whitespace, not internal newlines.
- This caused 9 out of 57 tier1 tests to fail across all recent hyperv compose runs (builds #67-76 on jenkins-csb-rhsm-prod).

## Fix

- Drop the `|| echo 0` shell fallback entirely.
- Check `pgrep` return code: non-zero means no processes → return `0`.
- On success, parse only the first line of output as a safety guard.

## Test plan

- [x] Ruff lint passes
- [ ] Re-run `virt-who/compose` with `HYPERVISORS=hyperv` to confirm the 9 failures are resolved