### PR TITLE
CCT-2564: Add image-mode (bootc) testing support for virt-who

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -17,3 +17,5 @@ markers =
 
     notLocal: cases not for local libvirt mode
     notRemote: cases not for remote mode
+
+    notImageMode: test requires mutable package management (dnf install/remove) or local libvirt -- excluded on image-mode

--- a/systemtest/plans/regression.fmf
+++ b/systemtest/plans/regression.fmf
@@ -7,7 +7,6 @@ description: |
 environment:
     HYPERVISOR: libvirt
     REGISTER: rhsm
-    ENV_FOR_DYNACONF: stage
     HTTPS_PROXY: http://squid.corp.redhat.com:3128
     HTTP_PROXY: http://squid.corp.redhat.com:3128
     NO_PROXY: localhost,127.0.0.1,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16
@@ -35,6 +34,9 @@ discover:
       - name: /tests/regression
         test: ./systemtest/scripts/run-tests.sh
         duration: 4h
+      - name: /tests/bootc-lint
+        test: ./systemtest/tests/bootc/test-bootc-lint.sh
+        duration: 15m
 
 execute:
     how: tmt

--- a/systemtest/scripts/install-deps.sh
+++ b/systemtest/scripts/install-deps.sh
@@ -17,4 +17,8 @@ else
     dnf -y install virt-who
 fi
 
-podman pull images.paas.redhat.com/rhsmqe/rhsm-squid:latest 2>/dev/null || true
+# On image-mode container builds, nested podman is unavailable; the pull
+# is deferred to run-tests.sh which executes after the guest boots.
+if systemctl is-system-running &>/dev/null; then
+  podman pull images.paas.redhat.com/rhsmqe/rhsm-squid:latest 2>/dev/null || true
+fi

--- a/systemtest/scripts/run-tests.sh
+++ b/systemtest/scripts/run-tests.sh
@@ -3,7 +3,115 @@
 # to TMT_PLAN_DATA for preservation.
 set -euo pipefail
 
-readonly VIRTWHO_TEST_DIR="/opt/virtwho-test"
+is_bootc() {
+  command -v bootc > /dev/null && \
+  bootc status --format=humanreadable 2>/dev/null | grep -q 'image'
+}
+
+# On bootc guests /opt is immutable at runtime. Copy the test directory
+# to a writable location so we can modify virtwho.ini and write artifacts.
+if is_bootc && [ -d /opt/virtwho-test ]; then
+  WRITABLE_DIR="${TMT_PLAN_DATA:-/var/tmp}/virtwho-test"
+  echo "Image-mode: copying /opt/virtwho-test to writable ${WRITABLE_DIR}"
+  cp -a /opt/virtwho-test "$WRITABLE_DIR"
+  VIRTWHO_TEST_DIR="$WRITABLE_DIR"
+else
+  VIRTWHO_TEST_DIR="/opt/virtwho-test"
+fi
+readonly VIRTWHO_TEST_DIR
+
+# --- Runtime SSH setup (runs in execute phase for both standard and image-mode) ---
+# setup-ssh.sh (prepare) only modifies sshd_config. Everything that needs
+# systemd or /root writability happens here.
+echo "Setting up SSH for localhost testing..."
+mkdir -p /root/.ssh && chmod 700 /root/.ssh
+printf 'Host *\n  StrictHostKeyChecking no\n  UserKnownHostsFile /root/.ssh/known_hosts\n\n' > /root/.ssh/config
+chmod 600 /root/.ssh/config
+
+# Ensure password auth is enabled (RHEL 10+ drop-in configs may override sshd_config)
+mkdir -p /etc/ssh/sshd_config.d
+cat > /etc/ssh/sshd_config.d/99-virtwho-test.conf <<SSHEOF
+PasswordAuthentication yes
+PermitRootLogin yes
+SSHEOF
+for f in /etc/ssh/sshd_config.d/*.conf; do
+  [ -f "$f" ] && [ "$f" != "/etc/ssh/sshd_config.d/99-virtwho-test.conf" ] && {
+    sed -i 's/^PasswordAuthentication no/# &/' "$f" 2>/dev/null
+    sed -i 's/^PermitRootLogin \(no\|prohibit-password\|without-password\)/# &/' "$f" 2>/dev/null
+  } || true
+done
+
+echo "redhat" | passwd --stdin root
+systemctl restart sshd
+
+GUEST_IP=$(hostname -I | awk '{print $1}')
+GUEST_HOSTNAME=$(hostname -f 2>/dev/null || hostname)
+if echo "$GUEST_HOSTNAME" | grep -qE 'localhost|unused|openshift'; then
+    GUEST_HOSTNAME="virtwho-$(head /dev/urandom | tr -dc a-z0-9 | head -c8).redhat.com"
+    hostnamectl set-hostname "$GUEST_HOSTNAME"
+fi
+grep -q "$GUEST_IP" /etc/hosts || echo "$GUEST_IP $GUEST_HOSTNAME" >> /etc/hosts
+
+# --- Runtime virtwho.ini fixups (deferred from setup-virtwho-test.sh) ---
+# Server IP and SSH trust require the guest to be booted with /root writable.
+cd "${VIRTWHO_TEST_DIR}"
+sed -i "/^\[virtwho\]/,/^\[/ s|^server=.*|server=${GUEST_IP}|" virtwho.ini
+
+HYP=${HYPERVISOR:-esx}
+if [ "$HYP" = "libvirt" ]; then
+    HYP_SERVER=$(awk -F= "/^\[${HYP}\]/{f=1;next} /^\[/{f=0} f&&/^server=/{print \$2}" virtwho.ini | tr -d ' ')
+    HYP_USER=$(awk -F= "/^\[${HYP}\]/{f=1;next} /^\[/{f=0} f&&/^username=/{print \$2}" virtwho.ini | tr -d ' ')
+    HYP_PASS=$(awk -F= "/^\[${HYP}\]/{f=1;next} /^\[/{f=0} f&&/^password=/{print \$2}" virtwho.ini | tr -d ' ')
+    if [ -n "$HYP_SERVER" ]; then
+        echo "Setting up SSH trust to $HYP hypervisor at $HYP_SERVER"
+        ssh-keyscan -p 22 "$HYP_SERVER" >> /root/.ssh/known_hosts 2>&1 || true
+
+        if [ -n "${CCT_SSH_KEY_B64:-}" ]; then
+            echo "Using injected SSH key (CCT_SSH_KEY_B64)"
+            echo "$CCT_SSH_KEY_B64" | base64 -d > /root/.ssh/id_rsa
+            chmod 600 /root/.ssh/id_rsa
+            ssh-keygen -y -f /root/.ssh/id_rsa > /root/.ssh/id_rsa.pub
+        else
+            echo "Generating ephemeral SSH keypair"
+            rm -f /root/.ssh/id_rsa /root/.ssh/id_rsa.pub
+            ssh-keygen -t rsa -N "" -f /root/.ssh/id_rsa -C "virtwho-qe" -q
+            if [ -n "$HYP_PASS" ]; then
+                sshpass -p "$HYP_PASS" ssh-copy-id -i /root/.ssh/id_rsa.pub \
+                    -o StrictHostKeyChecking=no "${HYP_USER:-root}@${HYP_SERVER}" || true
+            fi
+        fi
+
+        cp /root/.ssh/id_rsa /root/.ssh/virtwho-qe
+        cp /root/.ssh/id_rsa.pub /root/.ssh/virtwho-qe.pub
+
+        ssh -o StrictHostKeyChecking=no -o BatchMode=yes \
+            "${HYP_USER:-root}@${HYP_SERVER}" hostname \
+            && echo "SSH to $HYP_SERVER: OK" \
+            || echo "WARNING: SSH to $HYP_SERVER failed (tests may fail)"
+    fi
+fi
+
+# --- Image-mode-specific adjustments ---
+if is_bootc; then
+  echo "Image-mode (bootc) detected"
+
+  if command -v podman > /dev/null; then
+    podman pull images.paas.redhat.com/rhsmqe/rhsm-squid:latest 2>/dev/null || true
+  fi
+
+  # Auto-exclude image-mode-incompatible tests. Extract any existing -m
+  # expression from PYTEST_ADDOPTS, combine it with "not notImageMode",
+  # and pass the result as a separate quoted -m argument to pytest.
+  IMAGEMODE_MARKER="not notImageMode"
+  if echo "${PYTEST_ADDOPTS:-}" | grep -qE '\-m[[:space:]]'; then
+    EXISTING_MARKER=$(echo "$PYTEST_ADDOPTS" | sed -E 's/.*-m[[:space:]]+([^[:space:]]+).*/\1/')
+    IMAGEMODE_MARKER="(${EXISTING_MARKER}) and not notImageMode"
+    PYTEST_ADDOPTS=$(echo "${PYTEST_ADDOPTS}" | sed -E 's/[[:space:]]*-m[[:space:]]+[^[:space:]]+//')
+  fi
+  export PYTEST_ADDOPTS
+  export IMAGEMODE_MARKER
+  echo "PYTEST_ADDOPTS adjusted for image-mode: ${PYTEST_ADDOPTS:-} -m '${IMAGEMODE_MARKER}'"
+fi
 
 cd "${VIRTWHO_TEST_DIR}"
 
@@ -13,7 +121,21 @@ echo "=========================================="
 echo "Hypervisor: ${HYPERVISOR:-esx}"
 echo "Register:   ${REGISTER:-rhsm}"
 echo "Compose:    ${RHEL_COMPOSE:-unknown}"
+echo "Image-mode: $(is_bootc && echo yes || echo no)"
 echo "=========================================="
+
+MARKER_ARGS=()
+if [ -n "${IMAGEMODE_MARKER:-}" ]; then
+  MARKER_ARGS=(-m "${IMAGEMODE_MARKER}")
+fi
+
+IGNORE_ARGS=()
+if is_bootc; then
+  # test_hypervisors_state.py imports hypervisor package which writes a log
+  # file at import time — fails on the read-only bootc filesystem during
+  # collection before markers can deselect it.
+  IGNORE_ARGS=(--ignore=tests/others/test_hypervisors_state.py)
+fi
 
 set +e
 pytest tests/ \
@@ -22,7 +144,9 @@ pytest tests/ \
     --html="${TMT_TEST_DATA}/report.html" \
     --self-contained-html \
     -v -s \
-    ${PYTEST_ADDOPTS:-}  # intentionally unquoted: allows multiple flags via word splitting
+    ${PYTEST_ADDOPTS:-} \
+    "${MARKER_ARGS[@]}" \
+    "${IGNORE_ARGS[@]}"
 TEST_EXIT_CODE=$?
 set -e
 

--- a/systemtest/scripts/setup-ssh.sh
+++ b/systemtest/scripts/setup-ssh.sh
@@ -1,21 +1,35 @@
 #!/bin/bash
-# setup-ssh.sh -- Enable password-based SSH to localhost on the TF guest.
-# The TF guest IS the virt-who host; tests SSH to localhost to control virt-who.
+# setup-ssh.sh -- Configure sshd for localhost SSH on the TF guest.
+#
+# This script ONLY modifies /etc/ssh/sshd_config. It does NOT start
+# sshd, write to /root, or call systemctl. Those operations are deferred
+# to run-tests.sh (execute phase) where systemd and /root writability
+# are guaranteed. This separation is required for bootc image-mode
+# composes where the prepare phase runs inside a container build
+# without systemd and with /root restricted.
 set -euo pipefail
 
-echo "redhat" | passwd --stdin root
 sed -i 's/^#*PasswordAuthentication.*/PasswordAuthentication yes/' /etc/ssh/sshd_config
 sed -i 's/^#*PermitRootLogin.*/PermitRootLogin yes/' /etc/ssh/sshd_config
-systemctl restart sshd
 
-GUEST_IP=$(hostname -I | awk '{print $1}')
-GUEST_HOSTNAME=$(hostname -f 2>/dev/null || hostname)
-if echo "$GUEST_HOSTNAME" | grep -qE 'localhost|unused|openshift'; then
-    GUEST_HOSTNAME="virtwho-$(head /dev/urandom | tr -dc a-z0-9 | head -c8).redhat.com"
-    hostnamectl set-hostname "$GUEST_HOSTNAME"
-fi
-grep -q "$GUEST_IP" /etc/hosts || echo "$GUEST_IP $GUEST_HOSTNAME" >> /etc/hosts
+# RHEL 10+ uses /etc/ssh/sshd_config.d/ drop-in files that override the main
+# config. Create a high-priority drop-in to ensure our settings take effect.
+mkdir -p /etc/ssh/sshd_config.d
+cat > /etc/ssh/sshd_config.d/99-virtwho-test.conf <<SSHEOF
+PasswordAuthentication yes
+PermitRootLogin yes
+SSHEOF
 
-mkdir -p ~/.ssh && chmod 700 ~/.ssh
-printf 'Host *\n  StrictHostKeyChecking no\n  UserKnownHostsFile ~/.ssh/known_hosts\n\n' > ~/.ssh/config
-chmod 600 ~/.ssh/config
+# Neutralize any existing drop-ins that conflict with our settings.
+# OpenSSH uses first-match semantics within Include'd files, so earlier
+# drop-ins (e.g. 50-redhat.conf) can override our 99-* file.
+for f in /etc/ssh/sshd_config.d/*.conf; do
+  [ -f "$f" ] && [ "$f" != "/etc/ssh/sshd_config.d/99-virtwho-test.conf" ] && {
+    sed -i 's/^PasswordAuthentication no/# &  # overridden by 99-virtwho-test.conf/' "$f" 2>/dev/null
+    sed -i 's/^PermitRootLogin \(no\|prohibit-password\|without-password\)/# &  # overridden by 99-virtwho-test.conf/' "$f" 2>/dev/null
+  } || true
+done
+
+ssh-keygen -A 2>/dev/null || echo "WARNING: ssh-keygen -A failed -- sshd may need host keys in execute phase"
+
+echo "sshd configured (service start and /root/.ssh setup deferred to execute phase)"

--- a/systemtest/scripts/setup-virtwho-test.sh
+++ b/systemtest/scripts/setup-virtwho-test.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 # setup-virtwho-test.sh -- Clone virtwho-test repo, install deps, fetch INI,
 # and configure dynamic test parameters.
+#
+# This script runs in the TMT prepare phase. On bootc image-mode composes it
+# executes inside a Containerfile RUN layer where /root is restricted (overlay
+# restriction). All /root writes and operations that depend on them (SSH key
+# generation, ssh-copy-id) are deferred to run-tests.sh (execute phase).
 set -euo pipefail
 
 git clone ${VIRTWHO_TEST_REPO:-https://github.com/VirtwhoQE/virtwho-test.git} \
@@ -48,59 +53,19 @@ fi
 
 VIRTWHO_NEVRA=$(rpm -qa virt-who 2>/dev/null | head -1)
 VIRTWHO_NEVRA=${VIRTWHO_NEVRA:-virt-who}
-GUEST_IP=$(hostname -I | awk '{print $1}')
 
 cd /opt/virtwho-test
 sed -i "s|^hypervisor=.*|hypervisor=${HYP}|" virtwho.ini
 sed -i "s|^register=.*|register=${REGISTER:-rhsm}|" virtwho.ini
 sed -i "/^\[job\]/,/^\[/ s|^rhel_compose=.*|rhel_compose=${RESOLVED_COMPOSE}|" virtwho.ini
 sed -i "/^\[virtwho\]/,/^\[/ s|^package=.*|package=${VIRTWHO_NEVRA}|" virtwho.ini
-# Use the guest's actual IP (not localhost) so SSH connections from the test
-# framework resolve correctly regardless of hostname configuration.
-sed -i "/^\[virtwho\]/,/^\[/ s|^server=.*|server=${GUEST_IP}|" virtwho.ini
 sed -i "/^\[virtwho\]/,/^\[/ s|^password=.*|password=redhat|" virtwho.ini
 
-# Set up SSH key trust for remote hypervisors (libvirt, rhevm, etc.)
-if [ "$HYP" = "libvirt" ] || [ "$HYP" = "rhevm" ]; then
-    HYP_SERVER=$(awk -F= "/^\[${HYP}\]/{f=1;next} /^\[/{f=0} f&&/^server=/{print \$2}" virtwho.ini | tr -d ' ')
-    HYP_USER=$(awk -F= "/^\[${HYP}\]/{f=1;next} /^\[/{f=0} f&&/^username=/{print \$2}" virtwho.ini | tr -d ' ')
-    HYP_PASS=$(awk -F= "/^\[${HYP}\]/{f=1;next} /^\[/{f=0} f&&/^password=/{print \$2}" virtwho.ini | tr -d ' ')
-    if [ -n "$HYP_SERVER" ]; then
-        echo "Setting up SSH trust to $HYP hypervisor at $HYP_SERVER"
-        mkdir -p ~/.ssh && chmod 700 ~/.ssh
+# hostname/IP-dependent and SSH-key operations are deferred to run-tests.sh
+# (execute phase) where the guest is fully booted and /root is writable.
+echo "virtwho-test cloned and configured (SSH trust deferred to execute phase)"
 
-        echo "Scanning host keys from $HYP_SERVER..."
-        ssh-keyscan -p 22 "$HYP_SERVER" >> ~/.ssh/known_hosts 2>&1
-        echo "known_hosts entries: $(wc -l < ~/.ssh/known_hosts)"
-
-        if [ -n "${CCT_SSH_KEY_B64:-}" ]; then
-            echo "Using injected SSH key (CCT_SSH_KEY_B64)"
-            echo "$CCT_SSH_KEY_B64" | base64 -d > ~/.ssh/id_rsa
-            chmod 600 ~/.ssh/id_rsa
-            ssh-keygen -y -f ~/.ssh/id_rsa > ~/.ssh/id_rsa.pub
-        else
-            echo "No injected SSH key; generating ephemeral keypair"
-            rm -f ~/.ssh/id_rsa ~/.ssh/id_rsa.pub
-            ssh-keygen -t rsa -N "" -f ~/.ssh/id_rsa -C "virtwho-qe" -q
-            if [ -n "$HYP_PASS" ]; then
-                sshpass -p "$HYP_PASS" ssh-copy-id -i ~/.ssh/id_rsa.pub \
-                    -o StrictHostKeyChecking=no "${HYP_USER:-root}@${HYP_SERVER}"
-            fi
-        fi
-
-        cp ~/.ssh/id_rsa ~/.ssh/virtwho-qe
-        cp ~/.ssh/id_rsa.pub ~/.ssh/virtwho-qe.pub
-
-        echo "Verifying SSH connectivity to $HYP_SERVER..."
-        ssh -o StrictHostKeyChecking=no -o BatchMode=yes \
-            "${HYP_USER:-root}@${HYP_SERVER}" hostname \
-            && echo "SSH to $HYP_SERVER: OK" \
-            || echo "WARNING: SSH to $HYP_SERVER failed"
-        echo "Final known_hosts entries: $(wc -l < ~/.ssh/known_hosts)"
-    fi
-fi
-
-# Hypervisor-specific prepare
+# Hypervisor-specific prepare (kubevirt only — no /root or network needed)
 if [ "$HYP" = "kubevirt" ]; then
     SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
     bash "${SCRIPT_DIR}/prepare-kubevirt.sh"

--- a/systemtest/tests/bootc/main.fmf
+++ b/systemtest/tests/bootc/main.fmf
@@ -1,0 +1,4 @@
+summary: bootc container lint for virt-who
+test: ./test-bootc-lint.sh
+duration: 15m
+tag: [imagemode]

--- a/systemtest/tests/bootc/test-bootc-lint.sh
+++ b/systemtest/tests/bootc/test-bootc-lint.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# test-bootc-lint.sh -- Validate that virt-who installs cleanly into a bootc
+# base image and passes bootc container lint (no writes to /run or /tmp,
+# no duplicate kernels, all boot deps present, etc.).
+set -euo pipefail
+
+RHEL_VERSION="${RHEL_COMPOSE%%.*}"
+RHEL_VERSION="${RHEL_VERSION##*-}"
+
+if [ -z "${RHEL_VERSION}" ] || [ "${RHEL_VERSION}" -lt 9 ] 2>/dev/null; then
+  echo "SKIP: bootc lint requires RHEL >= 9; RHEL_COMPOSE=${RHEL_COMPOSE:-unset}"
+  exit 0
+fi
+
+BOOTC_BASE="registry.redhat.io/rhel${RHEL_VERSION}/rhel-bootc:latest"
+
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+cat > "${TMPDIR}/Containerfile" <<EOF
+FROM ${BOOTC_BASE}
+RUN dnf install -y virt-who && dnf clean all
+RUN bootc container lint
+EOF
+
+echo "=== Containerfile ==="
+cat "${TMPDIR}/Containerfile"
+echo "====================="
+
+echo "Building bootc lint image (base: ${BOOTC_BASE})..."
+BUILD_LOG="${TMPDIR}/build.log"
+if ! podman build --no-cache -t virtwho-bootc-lint -f "${TMPDIR}/Containerfile" "${TMPDIR}" 2>&1 | tee "${BUILD_LOG}"; then
+  if grep -qi 'unauthorized\|login\|auth token' "${BUILD_LOG}"; then
+    echo "SKIP: Cannot pull ${BOOTC_BASE} — registry authentication not available"
+    exit 0
+  fi
+  exit 1
+fi
+
+echo "bootc container lint passed"

--- a/tests/hypervisor/test_local.py
+++ b/tests/hypervisor/test_local.py
@@ -14,6 +14,9 @@ from hypervisor import logger
 from virtwho import RHEL_COMPOSE
 
 
+pytestmark = pytest.mark.notImageMode
+
+
 @pytest.mark.usefixtures("function_host_register_for_local_mode")
 @pytest.mark.usefixtures("function_virtwho_d_conf_clean")
 @pytest.mark.usefixtures("class_debug_true")

--- a/tests/package/test_info.py
+++ b/tests/package/test_info.py
@@ -16,6 +16,9 @@ from virtwho import base, RHEL_COMPOSE, VIRTWHO_PKG, VIRTWHO_VERSION
 from virtwho.settings import DOCS_DIR, TEMP_DIR
 
 
+pytestmark = pytest.mark.notImageMode
+
+
 @pytest.mark.usefixtures("class_globalconf_clean")
 @pytest.mark.usefixtures("class_hypervisor")
 @pytest.mark.usefixtures("class_virtwho_d_conf_clean")

--- a/tests/package/test_install_uninstall.py
+++ b/tests/package/test_install_uninstall.py
@@ -16,6 +16,9 @@ from virtwho.base import package_check, package_install, package_uninstall
 from virtwho.base import dnf_download_pkg, random_string
 
 
+pytestmark = pytest.mark.notImageMode
+
+
 class TestInstallUninstall:
     @pytest.mark.tier1
     def test_install_uninstall_by_dnf(self, ssh_host):

--- a/tests/package/test_upgrade_downgrade.py
+++ b/tests/package/test_upgrade_downgrade.py
@@ -25,6 +25,9 @@ def _skip_if_no_downgrade(ssh_host):
         )
 
 
+pytestmark = pytest.mark.notImageMode
+
+
 @pytest.mark.usefixtures("function_globalconf_clean")
 @pytest.mark.usefixtures("class_hypervisor")
 @pytest.mark.usefixtures("class_virtwho_d_conf_clean")

--- a/tests/upgrade/test_upgrade.py
+++ b/tests/upgrade/test_upgrade.py
@@ -8,9 +8,14 @@
 :caselevel: Component
 """
 
+import pytest
+
 from virtwho import RHEL_COMPOSE, HYPERVISOR
 from virtwho.base import hypervisors_list, local_files_compare
 from virtwho.configure import hypervisor_create, VirtwhoSysConfig
+
+
+pytestmark = pytest.mark.notImageMode
 
 
 class TestUpgrade:

--- a/virtwho/runner.py
+++ b/virtwho/runner.py
@@ -572,7 +572,7 @@ class VirtwhoRunner:
         if action == "status":
             if "Active: active (running)" in output:
                 output = "running"
-            if "Active: inactive (dead)" in output:
+            if "Active: inactive (dead)" in output or "Active: failed" in output:
                 output = "dead"
         return ret, output
 


### PR DESCRIPTION
## Summary

Adds bootc image-mode testing support to virt-who's CI pipelines. Image-mode guests use immutable (ostree) root filesystems, requiring adaptations to test setup, execution, and filtering.

Part of [CCT-2564](https://redhat.atlassian.net/browse/CCT-2564).
Companion MR: [RHSM-QE/rhsm-jobs !467](https://gitlab.cee.redhat.com/RHSM-QE/rhsm-jobs/-/merge_requests/467) (pipeline changes)

## Changes

### Test infrastructure
- Add `notImageMode` pytest marker to exclude package management, upgrade, and local-libvirt tests that require a mutable filesystem
- Auto-detect bootc guests via `bootc status` and inject marker filter at runtime
- Defer SSH setup (`/root` writes, sshd restart) to execute phase since the prepare phase runs inside a container build without systemd
- Create `sshd_config.d` drop-in (`99-virtwho-test.conf`) to ensure `PasswordAuthentication` and `PermitRootLogin` on RHEL 10+ where drop-in files can override the main `sshd_config`
- Neutralize conflicting `PermitRootLogin` and `PasswordAuthentication` directives in other drop-ins
- Copy `/opt/virtwho-test` to writable location on bootc guests (ostree immutability)
- Skip `podman pull` during container builds (no systemd/networking)

### New bootc container lint test
- Validates virt-who installs cleanly in a bootc container image via `bootc container lint`
- Gracefully skips when registry auth is unavailable in the TF environment

### Test harness improvements
- Harden proxy container lifecycle with retry/cleanup logic
- Log virt-who RPM version and compose at session start
- Treat systemd `Active: failed` as 'dead' in `operate_service` helper (handles timeout during service stop on bootc guests)
- Remove stale `ENV_FOR_DYNACONF` from `regression.fmf` (virtwho-test does not use Dynaconf)

## Validation

- **Gate job (imagemode)**: virt-who/gate build #14 — all gating tests pass on RHEL-10 image-mode compose
- **Compose job (imagemode)**: virt-who/compose build #121 — all regression tests pass (1 failure fixed in this PR: `operate_service` helper)
- **Standard mode**: No regressions — standard compose tests continue to work unchanged

## Test plan

- [x] Image-mode gate job passes (DEPLOY_MODE=imagemode)
- [x] Standard gate job passes (DEPLOY_MODE=standard) 
- [x] Combined mode passes (DEPLOY_MODE=both)
- [x] bootc container lint test runs (or gracefully skips)
- [x] `notImageMode` tests correctly excluded on bootc guests
- [x] SSH setup works on RHEL 10+ with sshd_config.d drop-ins
- [ ] Manual review of shell script changes