### PR TITLE
CCT-2564: Harden image-mode testing from review findings

### DIFF
--- a/systemtest/scripts/run-tests.sh
+++ b/systemtest/scripts/run-tests.sh
@@ -13,8 +13,12 @@ is_bootc() {
 if is_bootc && [ -d /opt/virtwho-test ]; then
   WRITABLE_DIR="${TMT_PLAN_DATA:-/var/tmp}/virtwho-test"
   echo "Image-mode: copying /opt/virtwho-test to writable ${WRITABLE_DIR}"
+  rm -rf "$WRITABLE_DIR"
   cp -a /opt/virtwho-test "$WRITABLE_DIR"
   VIRTWHO_TEST_DIR="$WRITABLE_DIR"
+elif is_bootc; then
+  echo "ERROR: bootc detected but /opt/virtwho-test not found (prepare phase may have failed)"
+  exit 1
 else
   VIRTWHO_TEST_DIR="/opt/virtwho-test"
 fi
@@ -29,19 +33,12 @@ printf 'Host *\n  StrictHostKeyChecking no\n  UserKnownHostsFile /root/.ssh/know
 chmod 600 /root/.ssh/config
 
 # Ensure password auth is enabled (RHEL 10+ drop-in configs may override sshd_config)
-mkdir -p /etc/ssh/sshd_config.d
-cat > /etc/ssh/sshd_config.d/99-virtwho-test.conf <<SSHEOF
-PasswordAuthentication yes
-PermitRootLogin yes
-SSHEOF
-for f in /etc/ssh/sshd_config.d/*.conf; do
-  [ -f "$f" ] && [ "$f" != "/etc/ssh/sshd_config.d/99-virtwho-test.conf" ] && {
-    sed -i 's/^PasswordAuthentication no/# &/' "$f" 2>/dev/null
-    sed -i 's/^PermitRootLogin \(no\|prohibit-password\|without-password\)/# &/' "$f" 2>/dev/null
-  } || true
-done
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=sshd-dropin.sh
+source "${SCRIPT_DIR}/sshd-dropin.sh"
 
 echo "redhat" | passwd --stdin root
+ssh-keygen -A 2>/dev/null || true
 systemctl restart sshd
 
 GUEST_IP=$(hostname -I | awk '{print $1}')
@@ -102,6 +99,9 @@ if is_bootc; then
   # Auto-exclude image-mode-incompatible tests. Extract any existing -m
   # expression from PYTEST_ADDOPTS, combine it with "not notImageMode",
   # and pass the result as a separate quoted -m argument to pytest.
+  # NOTE: The -m extraction below only handles a single unquoted token
+  # (e.g. "-m gating"). Compound expressions like '-m "tier1 and gating"'
+  # are not supported — use IMAGEMODE_PYTEST_MARKER env var to override.
   IMAGEMODE_MARKER="not notImageMode"
   if echo "${PYTEST_ADDOPTS:-}" | grep -qE '\-m[[:space:]]'; then
     EXISTING_MARKER=$(echo "$PYTEST_ADDOPTS" | sed -E 's/.*-m[[:space:]]+([^[:space:]]+).*/\1/')

--- a/systemtest/scripts/run-tests.sh
+++ b/systemtest/scripts/run-tests.sh
@@ -101,12 +101,15 @@ if is_bootc; then
   # and pass the result as a separate quoted -m argument to pytest.
   # NOTE: The -m extraction below only handles a single unquoted token
   # (e.g. "-m gating"). Compound expressions like '-m "tier1 and gating"'
-  # are not supported — use IMAGEMODE_PYTEST_MARKER env var to override.
-  IMAGEMODE_MARKER="not notImageMode"
-  if echo "${PYTEST_ADDOPTS:-}" | grep -qE '\-m[[:space:]]'; then
+  # are not supported — set IMAGEMODE_PYTEST_MARKER to override.
+  if [ -n "${IMAGEMODE_PYTEST_MARKER:-}" ]; then
+    IMAGEMODE_MARKER="${IMAGEMODE_PYTEST_MARKER}"
+  elif echo "${PYTEST_ADDOPTS:-}" | grep -qE '\-m[[:space:]]'; then
     EXISTING_MARKER=$(echo "$PYTEST_ADDOPTS" | sed -E 's/.*-m[[:space:]]+([^[:space:]]+).*/\1/')
     IMAGEMODE_MARKER="(${EXISTING_MARKER}) and not notImageMode"
     PYTEST_ADDOPTS=$(echo "${PYTEST_ADDOPTS}" | sed -E 's/[[:space:]]*-m[[:space:]]+[^[:space:]]+//')
+  else
+    IMAGEMODE_MARKER="not notImageMode"
   fi
   export PYTEST_ADDOPTS
   export IMAGEMODE_MARKER

--- a/systemtest/scripts/setup-ssh.sh
+++ b/systemtest/scripts/setup-ssh.sh
@@ -13,22 +13,10 @@ sed -i 's/^#*PasswordAuthentication.*/PasswordAuthentication yes/' /etc/ssh/sshd
 sed -i 's/^#*PermitRootLogin.*/PermitRootLogin yes/' /etc/ssh/sshd_config
 
 # RHEL 10+ uses /etc/ssh/sshd_config.d/ drop-in files that override the main
-# config. Create a high-priority drop-in to ensure our settings take effect.
-mkdir -p /etc/ssh/sshd_config.d
-cat > /etc/ssh/sshd_config.d/99-virtwho-test.conf <<SSHEOF
-PasswordAuthentication yes
-PermitRootLogin yes
-SSHEOF
-
-# Neutralize any existing drop-ins that conflict with our settings.
-# OpenSSH uses first-match semantics within Include'd files, so earlier
-# drop-ins (e.g. 50-redhat.conf) can override our 99-* file.
-for f in /etc/ssh/sshd_config.d/*.conf; do
-  [ -f "$f" ] && [ "$f" != "/etc/ssh/sshd_config.d/99-virtwho-test.conf" ] && {
-    sed -i 's/^PasswordAuthentication no/# &  # overridden by 99-virtwho-test.conf/' "$f" 2>/dev/null
-    sed -i 's/^PermitRootLogin \(no\|prohibit-password\|without-password\)/# &  # overridden by 99-virtwho-test.conf/' "$f" 2>/dev/null
-  } || true
-done
+# config. Create a high-priority drop-in and neutralize conflicting ones.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=sshd-dropin.sh
+source "${SCRIPT_DIR}/sshd-dropin.sh"
 
 ssh-keygen -A 2>/dev/null || echo "WARNING: ssh-keygen -A failed -- sshd may need host keys in execute phase"
 

--- a/systemtest/scripts/sshd-dropin.sh
+++ b/systemtest/scripts/sshd-dropin.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# sshd-dropin.sh -- Ensure PasswordAuthentication and PermitRootLogin are
+# enabled via a high-priority sshd_config.d drop-in and neutralize any
+# conflicting drop-ins. Sourced by setup-ssh.sh (prepare) and run-tests.sh
+# (execute) to keep the logic in one place.
+
+mkdir -p /etc/ssh/sshd_config.d
+cat > /etc/ssh/sshd_config.d/99-virtwho-test.conf <<SSHEOF
+PasswordAuthentication yes
+PermitRootLogin yes
+SSHEOF
+
+for f in /etc/ssh/sshd_config.d/*.conf; do
+  [ -f "$f" ] && [ "$f" != "/etc/ssh/sshd_config.d/99-virtwho-test.conf" ] && {
+    sed -i 's/^PasswordAuthentication no/# &  # overridden by 99-virtwho-test.conf/' "$f" 2>/dev/null
+    sed -i 's/^PermitRootLogin \(no\|prohibit-password\|without-password\)/# &  # overridden by 99-virtwho-test.conf/' "$f" 2>/dev/null
+  } || true
+done

--- a/systemtest/tests/bootc/test-bootc-lint.sh
+++ b/systemtest/tests/bootc/test-bootc-lint.sh
@@ -2,24 +2,40 @@
 # test-bootc-lint.sh -- Validate that virt-who installs cleanly into a bootc
 # base image and passes bootc container lint (no writes to /run or /tmp,
 # no duplicate kernels, all boot deps present, etc.).
+#
+# Gated by RUN_BOOTC_LINT=1 or IMAGE_MODE=1 — skips on standard regression
+# runs to avoid the ~15m podman build overhead.
 set -euo pipefail
 
-RHEL_VERSION="${RHEL_COMPOSE%%.*}"
-RHEL_VERSION="${RHEL_VERSION##*-}"
-
-if [ -z "${RHEL_VERSION}" ] || [ "${RHEL_VERSION}" -lt 9 ] 2>/dev/null; then
-  echo "SKIP: bootc lint requires RHEL >= 9; RHEL_COMPOSE=${RHEL_COMPOSE:-unset}"
+if [ "${RUN_BOOTC_LINT:-}" != "1" ] && [ "${IMAGE_MODE:-}" != "1" ]; then
+  echo "SKIP: bootc-lint only runs when RUN_BOOTC_LINT=1 or IMAGE_MODE=1"
   exit 0
 fi
 
-BOOTC_BASE="registry.redhat.io/rhel${RHEL_VERSION}/rhel-bootc:latest"
+RHEL_COMPOSE="${RHEL_COMPOSE:-}"
+RHEL_VERSION="${RHEL_COMPOSE%%.*}"
+RHEL_VERSION="${RHEL_VERSION##*-}"
+
+if ! [[ "${RHEL_VERSION}" =~ ^[0-9]+$ ]] || [ "${RHEL_VERSION}" -lt 9 ]; then
+  echo "SKIP: bootc lint requires numeric RHEL >= 9; RHEL_COMPOSE=${RHEL_COMPOSE:-unset} (parsed: ${RHEL_VERSION})"
+  exit 0
+fi
+
+BOOTC_BASE="${BOOTC_BASE_IMAGE:-registry.redhat.io/rhel${RHEL_VERSION}/rhel-bootc:latest}"
 
 TMPDIR=$(mktemp -d)
 trap 'rm -rf "$TMPDIR"' EXIT
 
+# When TEST_RPMS is set (gating pipeline), install those instead of repo default.
+if [ -n "${TEST_RPMS:-}" ]; then
+  INSTALL_CMD="dnf install -y ${TEST_RPMS} && dnf clean all"
+else
+  INSTALL_CMD="dnf install -y virt-who && dnf clean all"
+fi
+
 cat > "${TMPDIR}/Containerfile" <<EOF
 FROM ${BOOTC_BASE}
-RUN dnf install -y virt-who && dnf clean all
+RUN ${INSTALL_CMD}
 RUN bootc container lint
 EOF
 

--- a/systemtest/tests/bootc/test-bootc-lint.sh
+++ b/systemtest/tests/bootc/test-bootc-lint.sh
@@ -3,12 +3,16 @@
 # base image and passes bootc container lint (no writes to /run or /tmp,
 # no duplicate kernels, all boot deps present, etc.).
 #
-# Gated by RUN_BOOTC_LINT=1 or IMAGE_MODE=1 — skips on standard regression
-# runs to avoid the ~15m podman build overhead.
+# Gated by RUN_BOOTC_LINT or IMAGE_MODE — skips on standard regression
+# runs to avoid the ~15m podman build overhead. Accepts common truthy
+# values (1, true, yes) to match both Jenkins (IMAGE_MODE=true) and
+# manual invocation (IMAGE_MODE=1).
 set -euo pipefail
 
-if [ "${RUN_BOOTC_LINT:-}" != "1" ] && [ "${IMAGE_MODE:-}" != "1" ]; then
-  echo "SKIP: bootc-lint only runs when RUN_BOOTC_LINT=1 or IMAGE_MODE=1"
+_is_truthy() { case "${1:-}" in 1|true|yes|on|TRUE|True|YES) return 0 ;; *) return 1 ;; esac; }
+
+if ! _is_truthy "${RUN_BOOTC_LINT:-}" && ! _is_truthy "${IMAGE_MODE:-}"; then
+  echo "SKIP: bootc-lint only runs when RUN_BOOTC_LINT or IMAGE_MODE is set"
   exit 0
 fi
 
@@ -28,7 +32,8 @@ trap 'rm -rf "$TMPDIR"' EXIT
 
 # When TEST_RPMS is set (gating pipeline), install those instead of repo default.
 if [ -n "${TEST_RPMS:-}" ]; then
-  INSTALL_CMD="dnf install -y ${TEST_RPMS} && dnf clean all"
+  # shellcheck disable=SC2086
+  INSTALL_CMD="dnf install -y --allowerasing ${TEST_RPMS} && dnf clean all"
 else
   INSTALL_CMD="dnf install -y virt-who && dnf clean all"
 fi


### PR DESCRIPTION
## Summary

Follow-up to PR #286 — addresses findings from a multi-role review (Developer, QA, DevOps) of the image-mode bootc testing support.

- **SSH drop-in deduplication**: Extract shared `sshd-dropin.sh` helper sourced by both `setup-ssh.sh` and `run-tests.sh`
- **Robustness**: Idempotent `/opt` copy, fail-fast on missing prepare output, `ssh-keygen -A` before sshd restart
- **bootc-lint gating**: Skip on standard regression runs (`RUN_BOOTC_LINT=1` or `IMAGE_MODE=1` required), wire `TEST_RPMS` for gating pipeline parity, `BOOTC_BASE_IMAGE` override, robust RHEL version parsing
- **Documentation**: PYTEST_ADDOPTS marker parsing limitation documented

## Test plan

- [ ] Standard (non-bootc) regression run passes unchanged
- [ ] Image-mode gate run with `IMAGE_MODE=1` exercises bootc-lint
- [ ] bootc-lint skips gracefully when env vars are not set
- [ ] `TEST_RPMS` injection into Containerfile verified in gating pipeline